### PR TITLE
[WIP] Signals: Fixing signal system bugs

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -145,22 +145,22 @@ void MultiplayerAPI::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_pee
 			"Supplied NetworkedMultiplayerPeer must be connecting or connected.");
 
 	if (network_peer.is_valid()) {
-		network_peer->disconnect_compat("peer_connected", this, "_add_peer");
-		network_peer->disconnect_compat("peer_disconnected", this, "_del_peer");
-		network_peer->disconnect_compat("connection_succeeded", this, "_connected_to_server");
-		network_peer->disconnect_compat("connection_failed", this, "_connection_failed");
-		network_peer->disconnect_compat("server_disconnected", this, "_server_disconnected");
+		network_peer->disconnect("peer_connected", callable_mp(this, &MultiplayerAPI::_add_peer));
+		network_peer->disconnect("peer_disconnected", callable_mp(this, &MultiplayerAPI::_del_peer));
+		network_peer->disconnect("connection_succeeded", callable_mp(this, &MultiplayerAPI::_connected_to_server));
+		network_peer->disconnect("connection_failed", callable_mp(this, &MultiplayerAPI::_connection_failed));
+		network_peer->disconnect("server_disconnected", callable_mp(this, &MultiplayerAPI::_server_disconnected));
 		clear();
 	}
 
 	network_peer = p_peer;
 
 	if (network_peer.is_valid()) {
-		network_peer->connect_compat("peer_connected", this, "_add_peer");
-		network_peer->connect_compat("peer_disconnected", this, "_del_peer");
-		network_peer->connect_compat("connection_succeeded", this, "_connected_to_server");
-		network_peer->connect_compat("connection_failed", this, "_connection_failed");
-		network_peer->connect_compat("server_disconnected", this, "_server_disconnected");
+		network_peer->connect("peer_connected", callable_mp(this, &MultiplayerAPI::_add_peer));
+		network_peer->connect("peer_disconnected", callable_mp(this, &MultiplayerAPI::_del_peer));
+		network_peer->connect("connection_succeeded", callable_mp(this, &MultiplayerAPI::_connected_to_server));
+		network_peer->connect("connection_failed", callable_mp(this, &MultiplayerAPI::_connection_failed));
+		network_peer->connect("server_disconnected", callable_mp(this, &MultiplayerAPI::_server_disconnected));
 	}
 }
 
@@ -1262,15 +1262,10 @@ void MultiplayerAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_network_unique_id"), &MultiplayerAPI::get_network_unique_id);
 	ClassDB::bind_method(D_METHOD("is_network_server"), &MultiplayerAPI::is_network_server);
 	ClassDB::bind_method(D_METHOD("get_rpc_sender_id"), &MultiplayerAPI::get_rpc_sender_id);
-	ClassDB::bind_method(D_METHOD("_add_peer", "id"), &MultiplayerAPI::_add_peer);
-	ClassDB::bind_method(D_METHOD("_del_peer", "id"), &MultiplayerAPI::_del_peer);
 	ClassDB::bind_method(D_METHOD("set_network_peer", "peer"), &MultiplayerAPI::set_network_peer);
 	ClassDB::bind_method(D_METHOD("poll"), &MultiplayerAPI::poll);
 	ClassDB::bind_method(D_METHOD("clear"), &MultiplayerAPI::clear);
 
-	ClassDB::bind_method(D_METHOD("_connected_to_server"), &MultiplayerAPI::_connected_to_server);
-	ClassDB::bind_method(D_METHOD("_connection_failed"), &MultiplayerAPI::_connection_failed);
-	ClassDB::bind_method(D_METHOD("_server_disconnected"), &MultiplayerAPI::_server_disconnected);
 	ClassDB::bind_method(D_METHOD("get_network_connected_peers"), &MultiplayerAPI::get_network_connected_peers);
 	ClassDB::bind_method(D_METHOD("set_refuse_new_network_connections", "refuse"), &MultiplayerAPI::set_refuse_new_network_connections);
 	ClassDB::bind_method(D_METHOD("is_refusing_new_network_connections"), &MultiplayerAPI::is_refusing_new_network_connections);

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -522,7 +522,7 @@ void AnimationBezierTrackEdit::set_undo_redo(UndoRedo *p_undo_redo) {
 
 void AnimationBezierTrackEdit::set_timeline(AnimationTimelineEdit *p_timeline) {
 	timeline = p_timeline;
-	timeline->connect_compat("zoom_changed", this, "_zoom_changed");
+	timeline->connect("zoom_changed", callable_mp(this, &AnimationBezierTrackEdit::_zoom_changed));
 }
 void AnimationBezierTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 	editor = p_editor;
@@ -1141,10 +1141,7 @@ void AnimationBezierTrackEdit::set_block_animation_update_ptr(bool *p_block_ptr)
 
 void AnimationBezierTrackEdit::_bind_methods() {
 
-	ClassDB::bind_method("_zoom_changed", &AnimationBezierTrackEdit::_zoom_changed);
-	ClassDB::bind_method("_menu_selected", &AnimationBezierTrackEdit::_menu_selected);
 	ClassDB::bind_method("_gui_input", &AnimationBezierTrackEdit::_gui_input);
-	ClassDB::bind_method("_play_position_draw", &AnimationBezierTrackEdit::_play_position_draw);
 
 	ClassDB::bind_method("_clear_selection", &AnimationBezierTrackEdit::_clear_selection);
 	ClassDB::bind_method("_clear_selection_for_anim", &AnimationBezierTrackEdit::_clear_selection_for_anim);
@@ -1184,7 +1181,7 @@ AnimationBezierTrackEdit::AnimationBezierTrackEdit() {
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);
 	play_position->set_anchors_and_margins_preset(PRESET_WIDE);
-	play_position->connect_compat("draw", this, "_play_position_draw");
+	play_position->connect("draw", callable_mp(this, &AnimationBezierTrackEdit::_play_position_draw));
 	set_focus_mode(FOCUS_CLICK);
 
 	v_scroll = 0;
@@ -1198,7 +1195,7 @@ AnimationBezierTrackEdit::AnimationBezierTrackEdit() {
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_menu_selected");
+	menu->connect("id_pressed", callable_mp(this, &AnimationBezierTrackEdit::_menu_selected));
 
 	//set_mouse_filter(MOUSE_FILTER_PASS); //scroll has to work too for selection
 }

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5731,9 +5731,12 @@ void AnimationTrackEditor::_bind_methods() {
 	ClassDB::bind_method("_track_grab_focus", &AnimationTrackEditor::_track_grab_focus);
 	ClassDB::bind_method("_update_tracks", &AnimationTrackEditor::_update_tracks);
 	ClassDB::bind_method("_insert_delay", &AnimationTrackEditor::_insert_delay);
-	ClassDB::bind_method("_clear_selection", &AnimationTrackEditor::_clear_selection);
 	ClassDB::bind_method("_clear_selection_for_anim", &AnimationTrackEditor::_clear_selection_for_anim);
 	ClassDB::bind_method("_select_at_anim", &AnimationTrackEditor::_select_at_anim);
+
+	ClassDB::bind_method("_key_selected", &AnimationTrackEditor::_key_selected); // Still used by some connect_compat.
+	ClassDB::bind_method("_key_deselected", &AnimationTrackEditor::_key_deselected); // Still used by some connect_compat.
+	ClassDB::bind_method("_clear_selection", &AnimationTrackEditor::_clear_selection); // Still used by some connect_compat.
 
 	ADD_SIGNAL(MethodInfo("timeline_changed", PropertyInfo(Variant::REAL, "position"), PropertyInfo(Variant::BOOL, "drag")));
 	ADD_SIGNAL(MethodInfo("keying_changed"));

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1697,7 +1697,7 @@ void AnimationTimelineEdit::set_undo_redo(UndoRedo *p_undo_redo) {
 
 void AnimationTimelineEdit::set_zoom(Range *p_zoom) {
 	zoom = p_zoom;
-	zoom->connect_compat("value_changed", this, "_zoom_changed");
+	zoom->connect("value_changed", callable_mp(this, &AnimationTimelineEdit::_zoom_changed));
 }
 
 void AnimationTimelineEdit::set_play_position(float p_pos) {
@@ -1845,12 +1845,7 @@ void AnimationTimelineEdit::_track_added(int p_track) {
 }
 
 void AnimationTimelineEdit::_bind_methods() {
-	ClassDB::bind_method("_zoom_changed", &AnimationTimelineEdit::_zoom_changed);
-	ClassDB::bind_method("_anim_length_changed", &AnimationTimelineEdit::_anim_length_changed);
-	ClassDB::bind_method("_anim_loop_pressed", &AnimationTimelineEdit::_anim_loop_pressed);
-	ClassDB::bind_method("_play_position_draw", &AnimationTimelineEdit::_play_position_draw);
 	ClassDB::bind_method("_gui_input", &AnimationTimelineEdit::_gui_input);
-	ClassDB::bind_method("_track_added", &AnimationTimelineEdit::_track_added);
 
 	ADD_SIGNAL(MethodInfo("zoom_changed"));
 	ADD_SIGNAL(MethodInfo("name_limit_changed"));
@@ -1871,7 +1866,7 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);
 	play_position->set_anchors_and_margins_preset(PRESET_WIDE);
-	play_position->connect_compat("draw", this, "_play_position_draw");
+	play_position->connect("draw", callable_mp(this, &AnimationTimelineEdit::_play_position_draw));
 
 	add_track = memnew(MenuButton);
 	add_track->set_position(Vector2(0, 0));
@@ -1895,17 +1890,17 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
 	length->set_hide_slider(true);
 	length->set_tooltip(TTR("Animation length (seconds)"));
-	length->connect_compat("value_changed", this, "_anim_length_changed");
+	length->connect("value_changed", callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
 	len_hb->add_child(length);
 	loop = memnew(ToolButton);
 	loop->set_tooltip(TTR("Animation Looping"));
-	loop->connect_compat("pressed", this, "_anim_loop_pressed");
+	loop->connect("pressed", callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
 	loop->set_toggle_mode(true);
 	len_hb->add_child(loop);
 	add_child(len_hb);
 
 	add_track->hide();
-	add_track->get_popup()->connect_compat("index_pressed", this, "_track_added");
+	add_track->get_popup()->connect("index_pressed", callable_mp(this, &AnimationTimelineEdit::_track_added));
 	len_hb->hide();
 
 	panning_timeline = false;
@@ -2429,8 +2424,8 @@ void AnimationTrackEdit::set_undo_redo(UndoRedo *p_undo_redo) {
 
 void AnimationTrackEdit::set_timeline(AnimationTimelineEdit *p_timeline) {
 	timeline = p_timeline;
-	timeline->connect_compat("zoom_changed", this, "_zoom_changed");
-	timeline->connect_compat("name_limit_changed", this, "_zoom_changed");
+	timeline->connect("zoom_changed", callable_mp(this, &AnimationTrackEdit::_zoom_changed));
+	timeline->connect("name_limit_changed", callable_mp(this, &AnimationTrackEdit::_zoom_changed));
 }
 void AnimationTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 	editor = p_editor;
@@ -2688,7 +2683,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!menu) {
 				menu = memnew(PopupMenu);
 				add_child(menu);
-				menu->connect_compat("id_pressed", this, "_menu_selected");
+				menu->connect("id_pressed", callable_mp(this, &AnimationTrackEdit::_menu_selected));
 			}
 			menu->clear();
 			menu->add_icon_item(get_icon("TrackContinuous", "EditorIcons"), TTR("Continuous"), MENU_CALL_MODE_CONTINUOUS);
@@ -2707,7 +2702,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!menu) {
 				menu = memnew(PopupMenu);
 				add_child(menu);
-				menu->connect_compat("id_pressed", this, "_menu_selected");
+				menu->connect("id_pressed", callable_mp(this, &AnimationTrackEdit::_menu_selected));
 			}
 			menu->clear();
 			menu->add_icon_item(get_icon("InterpRaw", "EditorIcons"), TTR("Nearest"), MENU_INTERPOLATION_NEAREST);
@@ -2725,7 +2720,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!menu) {
 				menu = memnew(PopupMenu);
 				add_child(menu);
-				menu->connect_compat("id_pressed", this, "_menu_selected");
+				menu->connect("id_pressed", callable_mp(this, &AnimationTrackEdit::_menu_selected));
 			}
 			menu->clear();
 			menu->add_icon_item(get_icon("InterpWrapClamp", "EditorIcons"), TTR("Clamp Loop Interp"), MENU_LOOP_CLAMP);
@@ -2820,7 +2815,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!menu) {
 				menu = memnew(PopupMenu);
 				add_child(menu);
-				menu->connect_compat("id_pressed", this, "_menu_selected");
+				menu->connect("id_pressed", callable_mp(this, &AnimationTrackEdit::_menu_selected));
 			}
 
 			menu->clear();
@@ -2848,7 +2843,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			path = memnew(LineEdit);
 			add_child(path);
 			path->set_as_toplevel(true);
-			path->connect_compat("text_entered", this, "_path_entered");
+			path->connect("text_entered", callable_mp(this, &AnimationTrackEdit::_path_entered));
 		}
 
 		path->set_text(animation->track_get_path(track));
@@ -3067,11 +3062,7 @@ void AnimationTrackEdit::append_to_selection(const Rect2 &p_box, bool p_deselect
 
 void AnimationTrackEdit::_bind_methods() {
 
-	ClassDB::bind_method("_zoom_changed", &AnimationTrackEdit::_zoom_changed);
-	ClassDB::bind_method("_menu_selected", &AnimationTrackEdit::_menu_selected);
 	ClassDB::bind_method("_gui_input", &AnimationTrackEdit::_gui_input);
-	ClassDB::bind_method("_path_entered", &AnimationTrackEdit::_path_entered);
-	ClassDB::bind_method("_play_position_draw", &AnimationTrackEdit::_play_position_draw);
 
 	ADD_SIGNAL(MethodInfo("timeline_changed", PropertyInfo(Variant::REAL, "position"), PropertyInfo(Variant::BOOL, "drag")));
 	ADD_SIGNAL(MethodInfo("remove_request", PropertyInfo(Variant::INT, "track")));
@@ -3111,7 +3102,7 @@ AnimationTrackEdit::AnimationTrackEdit() {
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);
 	play_position->set_anchors_and_margins_preset(PRESET_WIDE);
-	play_position->connect_compat("draw", this, "_play_position_draw");
+	play_position->connect("draw", callable_mp(this, &AnimationTrackEdit::_play_position_draw));
 	set_focus_mode(FOCUS_CLICK);
 	set_mouse_filter(MOUSE_FILTER_PASS); //scroll has to work too for selection
 }
@@ -3217,8 +3208,8 @@ Size2 AnimationTrackEditGroup::get_minimum_size() const {
 
 void AnimationTrackEditGroup::set_timeline(AnimationTimelineEdit *p_timeline) {
 	timeline = p_timeline;
-	timeline->connect_compat("zoom_changed", this, "_zoom_changed");
-	timeline->connect_compat("name_limit_changed", this, "_zoom_changed");
+	timeline->connect("zoom_changed", callable_mp(this, &AnimationTrackEditGroup::_zoom_changed));
+	timeline->connect("name_limit_changed", callable_mp(this, &AnimationTrackEditGroup::_zoom_changed));
 }
 
 void AnimationTrackEditGroup::set_root(Node *p_root) {
@@ -3231,7 +3222,6 @@ void AnimationTrackEditGroup::_zoom_changed() {
 }
 
 void AnimationTrackEditGroup::_bind_methods() {
-	ClassDB::bind_method("_zoom_changed", &AnimationTrackEditGroup::_zoom_changed);
 }
 
 AnimationTrackEditGroup::AnimationTrackEditGroup() {
@@ -3258,7 +3248,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim) {
 		track_edits[_get_track_selected()]->release_focus();
 	}
 	if (animation.is_valid()) {
-		animation->disconnect_compat("changed", this, "_animation_changed");
+		animation->disconnect("changed", callable_mp(this, &AnimationTrackEditor::_animation_changed));
 		_clear_selection();
 	}
 	animation = p_anim;
@@ -3268,7 +3258,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim) {
 	_update_tracks();
 
 	if (animation.is_valid()) {
-		animation->connect_compat("changed", this, "_animation_changed");
+		animation->connect("changed", callable_mp(this, &AnimationTrackEditor::_animation_changed));
 
 		hscroll->show();
 		edit->set_disabled(false);
@@ -3311,13 +3301,13 @@ void AnimationTrackEditor::_root_removed(Node *p_root) {
 
 void AnimationTrackEditor::set_root(Node *p_root) {
 	if (root) {
-		root->disconnect_compat("tree_exiting", this, "_root_removed");
+		root->disconnect("tree_exiting", callable_mp(this, &AnimationTrackEditor::_root_removed));
 	}
 
 	root = p_root;
 
 	if (root) {
-		root->connect_compat("tree_exiting", this, "_root_removed", make_binds(), CONNECT_ONESHOT);
+		root->connect("tree_exiting", callable_mp(this, &AnimationTrackEditor::_root_removed), make_binds(), CONNECT_ONESHOT);
 	}
 
 	_update_tracks();
@@ -4257,21 +4247,21 @@ void AnimationTrackEditor::_update_tracks() {
 			track_edit->grab_focus();
 		}
 
-		track_edit->connect_compat("timeline_changed", this, "_timeline_changed");
-		track_edit->connect_compat("remove_request", this, "_track_remove_request", varray(), CONNECT_DEFERRED);
-		track_edit->connect_compat("dropped", this, "_dropped_track", varray(), CONNECT_DEFERRED);
-		track_edit->connect_compat("insert_key", this, "_insert_key_from_track", varray(i), CONNECT_DEFERRED);
-		track_edit->connect_compat("select_key", this, "_key_selected", varray(i), CONNECT_DEFERRED);
-		track_edit->connect_compat("deselect_key", this, "_key_deselected", varray(i), CONNECT_DEFERRED);
-		track_edit->connect_compat("bezier_edit", this, "_bezier_edit", varray(i), CONNECT_DEFERRED);
-		track_edit->connect_compat("move_selection_begin", this, "_move_selection_begin");
-		track_edit->connect_compat("move_selection", this, "_move_selection");
-		track_edit->connect_compat("move_selection_commit", this, "_move_selection_commit");
-		track_edit->connect_compat("move_selection_cancel", this, "_move_selection_cancel");
+		track_edit->connect("timeline_changed", callable_mp(this, &AnimationTrackEditor::_timeline_changed));
+		track_edit->connect("remove_request", callable_mp(this, &AnimationTrackEditor::_track_remove_request), varray(), CONNECT_DEFERRED);
+		track_edit->connect("dropped", callable_mp(this, &AnimationTrackEditor::_dropped_track), varray(), CONNECT_DEFERRED);
+		track_edit->connect("insert_key", callable_mp(this, &AnimationTrackEditor::_insert_key_from_track), varray(i), CONNECT_DEFERRED);
+		track_edit->connect("select_key", callable_mp(this, &AnimationTrackEditor::_key_selected), varray(i), CONNECT_DEFERRED);
+		track_edit->connect("deselect_key", callable_mp(this, &AnimationTrackEditor::_key_deselected), varray(i), CONNECT_DEFERRED);
+		track_edit->connect("bezier_edit", callable_mp(this, &AnimationTrackEditor::_bezier_edit), varray(i), CONNECT_DEFERRED);
+		track_edit->connect("move_selection_begin", callable_mp(this, &AnimationTrackEditor::_move_selection_begin));
+		track_edit->connect("move_selection", callable_mp(this, &AnimationTrackEditor::_move_selection));
+		track_edit->connect("move_selection_commit", callable_mp(this, &AnimationTrackEditor::_move_selection_commit));
+		track_edit->connect("move_selection_cancel", callable_mp(this, &AnimationTrackEditor::_move_selection_cancel));
 
-		track_edit->connect_compat("duplicate_request", this, "_edit_menu_pressed", varray(EDIT_DUPLICATE_SELECTION), CONNECT_DEFERRED);
-		track_edit->connect_compat("duplicate_transpose_request", this, "_edit_menu_pressed", varray(EDIT_DUPLICATE_TRANSPOSED), CONNECT_DEFERRED);
-		track_edit->connect_compat("delete_request", this, "_edit_menu_pressed", varray(EDIT_DELETE_SELECTION), CONNECT_DEFERRED);
+		track_edit->connect("duplicate_request", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed), varray(EDIT_DUPLICATE_SELECTION), CONNECT_DEFERRED);
+		track_edit->connect("duplicate_transpose_request", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed), varray(EDIT_DUPLICATE_TRANSPOSED), CONNECT_DEFERRED);
+		track_edit->connect("delete_request", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed), varray(EDIT_DELETE_SELECTION), CONNECT_DEFERRED);
 	}
 }
 
@@ -4384,7 +4374,7 @@ void AnimationTrackEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_READY) {
-		EditorNode::get_singleton()->get_editor_selection()->connect_compat("selection_changed", this, "_selection_changed");
+		EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", callable_mp(this, &AnimationTrackEditor::_selection_changed));
 	}
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
@@ -5737,45 +5727,13 @@ void AnimationTrackEditor::_select_all_tracks_for_copy() {
 
 void AnimationTrackEditor::_bind_methods() {
 
-	ClassDB::bind_method("_animation_changed", &AnimationTrackEditor::_animation_changed);
 	ClassDB::bind_method("_animation_update", &AnimationTrackEditor::_animation_update);
-	ClassDB::bind_method("_timeline_changed", &AnimationTrackEditor::_timeline_changed);
-	ClassDB::bind_method("_track_remove_request", &AnimationTrackEditor::_track_remove_request);
 	ClassDB::bind_method("_track_grab_focus", &AnimationTrackEditor::_track_grab_focus);
-	ClassDB::bind_method("_name_limit_changed", &AnimationTrackEditor::_name_limit_changed);
-	ClassDB::bind_method("_update_scroll", &AnimationTrackEditor::_update_scroll);
 	ClassDB::bind_method("_update_tracks", &AnimationTrackEditor::_update_tracks);
-	ClassDB::bind_method("_update_step", &AnimationTrackEditor::_update_step);
-	ClassDB::bind_method("_update_length", &AnimationTrackEditor::_update_length);
-	ClassDB::bind_method("_dropped_track", &AnimationTrackEditor::_dropped_track);
-	ClassDB::bind_method("_add_track", &AnimationTrackEditor::_add_track);
-	ClassDB::bind_method("_new_track_node_selected", &AnimationTrackEditor::_new_track_node_selected);
-	ClassDB::bind_method("_new_track_property_selected", &AnimationTrackEditor::_new_track_property_selected);
-	ClassDB::bind_method("_root_removed", &AnimationTrackEditor::_root_removed);
-	ClassDB::bind_method("_confirm_insert_list", &AnimationTrackEditor::_confirm_insert_list);
 	ClassDB::bind_method("_insert_delay", &AnimationTrackEditor::_insert_delay);
-	ClassDB::bind_method("_timeline_value_changed", &AnimationTrackEditor::_timeline_value_changed);
-	ClassDB::bind_method("_insert_key_from_track", &AnimationTrackEditor::_insert_key_from_track);
-	ClassDB::bind_method("_add_method_key", &AnimationTrackEditor::_add_method_key);
-	ClassDB::bind_method("_key_selected", &AnimationTrackEditor::_key_selected);
-	ClassDB::bind_method("_key_deselected", &AnimationTrackEditor::_key_deselected);
 	ClassDB::bind_method("_clear_selection", &AnimationTrackEditor::_clear_selection);
-	ClassDB::bind_method("_move_selection_begin", &AnimationTrackEditor::_move_selection_begin);
-	ClassDB::bind_method("_move_selection", &AnimationTrackEditor::_move_selection);
-	ClassDB::bind_method("_move_selection_commit", &AnimationTrackEditor::_move_selection_commit);
-	ClassDB::bind_method("_move_selection_cancel", &AnimationTrackEditor::_move_selection_cancel);
 	ClassDB::bind_method("_clear_selection_for_anim", &AnimationTrackEditor::_clear_selection_for_anim);
 	ClassDB::bind_method("_select_at_anim", &AnimationTrackEditor::_select_at_anim);
-	ClassDB::bind_method("_scroll_input", &AnimationTrackEditor::_scroll_input);
-	ClassDB::bind_method("_box_selection_draw", &AnimationTrackEditor::_box_selection_draw);
-	ClassDB::bind_method("_bezier_edit", &AnimationTrackEditor::_bezier_edit);
-	ClassDB::bind_method("_cancel_bezier_edit", &AnimationTrackEditor::_cancel_bezier_edit);
-	ClassDB::bind_method("_edit_menu_pressed", &AnimationTrackEditor::_edit_menu_pressed);
-	ClassDB::bind_method("_view_group_toggle", &AnimationTrackEditor::_view_group_toggle);
-	ClassDB::bind_method("_selection_changed", &AnimationTrackEditor::_selection_changed);
-	ClassDB::bind_method("_snap_mode_changed", &AnimationTrackEditor::_snap_mode_changed);
-	ClassDB::bind_method("_show_imported_anim_warning", &AnimationTrackEditor::_show_imported_anim_warning);
-	ClassDB::bind_method("_select_all_tracks_for_copy", &AnimationTrackEditor::_select_all_tracks_for_copy);
 
 	ADD_SIGNAL(MethodInfo("timeline_changed", PropertyInfo(Variant::REAL, "position"), PropertyInfo(Variant::BOOL, "drag")));
 	ADD_SIGNAL(MethodInfo("keying_changed"));
@@ -5813,11 +5771,11 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline = memnew(AnimationTimelineEdit);
 	timeline->set_undo_redo(undo_redo);
 	timeline_vbox->add_child(timeline);
-	timeline->connect_compat("timeline_changed", this, "_timeline_changed");
-	timeline->connect_compat("name_limit_changed", this, "_name_limit_changed");
-	timeline->connect_compat("track_added", this, "_add_track");
-	timeline->connect_compat("value_changed", this, "_timeline_value_changed");
-	timeline->connect_compat("length_changed", this, "_update_length");
+	timeline->connect("timeline_changed", callable_mp(this, &AnimationTrackEditor::_timeline_changed));
+	timeline->connect("name_limit_changed", callable_mp(this, &AnimationTrackEditor::_name_limit_changed));
+	timeline->connect("track_added", callable_mp(this, &AnimationTrackEditor::_add_track));
+	timeline->connect("value_changed", callable_mp(this, &AnimationTrackEditor::_timeline_value_changed));
+	timeline->connect("length_changed", callable_mp(this, &AnimationTrackEditor::_update_length));
 
 	scroll = memnew(ScrollContainer);
 	timeline_vbox->add_child(scroll);
@@ -5825,7 +5783,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	VScrollBar *sb = scroll->get_v_scrollbar();
 	scroll->remove_child(sb);
 	timeline_scroll->add_child(sb); //move here so timeline and tracks are always aligned
-	scroll->connect_compat("gui_input", this, "_scroll_input");
+	scroll->connect("gui_input", callable_mp(this, &AnimationTrackEditor::_scroll_input));
 
 	bezier_edit = memnew(AnimationBezierTrackEdit);
 	timeline_vbox->add_child(bezier_edit);
@@ -5834,14 +5792,14 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bezier_edit->set_timeline(timeline);
 	bezier_edit->hide();
 	bezier_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	bezier_edit->connect_compat("close_request", this, "_cancel_bezier_edit");
+	bezier_edit->connect("close_request", callable_mp(this, &AnimationTrackEditor::_cancel_bezier_edit));
 
 	timeline_vbox->set_custom_minimum_size(Size2(0, 150) * EDSCALE);
 
 	hscroll = memnew(HScrollBar);
 	hscroll->share(timeline);
 	hscroll->hide();
-	hscroll->connect_compat("value_changed", this, "_update_scroll");
+	hscroll->connect("value_changed", callable_mp(this, &AnimationTrackEditor::_update_scroll));
 	timeline_vbox->add_child(hscroll);
 	timeline->set_hscroll(hscroll);
 
@@ -5858,20 +5816,20 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	imported_anim_warning = memnew(Button);
 	imported_anim_warning->hide();
 	imported_anim_warning->set_tooltip(TTR("Warning: Editing imported animation"));
-	imported_anim_warning->connect_compat("pressed", this, "_show_imported_anim_warning");
+	imported_anim_warning->connect("pressed", callable_mp(this, &AnimationTrackEditor::_show_imported_anim_warning));
 	bottom_hb->add_child(imported_anim_warning);
 
 	bottom_hb->add_spacer();
 
 	selected_filter = memnew(ToolButton);
-	selected_filter->connect_compat("pressed", this, "_view_group_toggle"); //same function works the same
+	selected_filter->connect("pressed", callable_mp(this, &AnimationTrackEditor::_view_group_toggle)); //same function works the same
 	selected_filter->set_toggle_mode(true);
 	selected_filter->set_tooltip(TTR("Only show tracks from nodes selected in tree."));
 
 	bottom_hb->add_child(selected_filter);
 
 	view_group = memnew(ToolButton);
-	view_group->connect_compat("pressed", this, "_view_group_toggle");
+	view_group->connect("pressed", callable_mp(this, &AnimationTrackEditor::_view_group_toggle));
 	view_group->set_toggle_mode(true);
 	view_group->set_tooltip(TTR("Group tracks by node or display them as plain list."));
 
@@ -5893,14 +5851,14 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	step->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 	step->set_tooltip(TTR("Animation step value."));
 	bottom_hb->add_child(step);
-	step->connect_compat("value_changed", this, "_update_step");
+	step->connect("value_changed", callable_mp(this, &AnimationTrackEditor::_update_step));
 	step->set_read_only(true);
 
 	snap_mode = memnew(OptionButton);
 	snap_mode->add_item(TTR("Seconds"));
 	snap_mode->add_item(TTR("FPS"));
 	bottom_hb->add_child(snap_mode);
-	snap_mode->connect_compat("item_selected", this, "_snap_mode_changed");
+	snap_mode->connect("item_selected", callable_mp(this, &AnimationTrackEditor::_snap_mode_changed));
 	snap_mode->set_disabled(true);
 
 	bottom_hb->add_child(memnew(VSeparator));
@@ -5945,19 +5903,19 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	edit->get_popup()->add_item(TTR("Optimize Animation"), EDIT_OPTIMIZE_ANIMATION);
 	edit->get_popup()->add_item(TTR("Clean-Up Animation"), EDIT_CLEAN_UP_ANIMATION);
 
-	edit->get_popup()->connect_compat("id_pressed", this, "_edit_menu_pressed");
+	edit->get_popup()->connect("id_pressed", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed));
 
 	pick_track = memnew(SceneTreeDialog);
 	add_child(pick_track);
 	pick_track->set_title(TTR("Pick the node that will be animated:"));
-	pick_track->connect_compat("selected", this, "_new_track_node_selected");
+	pick_track->connect("selected", callable_mp(this, &AnimationTrackEditor::_new_track_node_selected));
 	prop_selector = memnew(PropertySelector);
 	add_child(prop_selector);
-	prop_selector->connect_compat("selected", this, "_new_track_property_selected");
+	prop_selector->connect("selected", callable_mp(this, &AnimationTrackEditor::_new_track_property_selected));
 
 	method_selector = memnew(PropertySelector);
 	add_child(method_selector);
-	method_selector->connect_compat("selected", this, "_add_method_key");
+	method_selector->connect("selected", callable_mp(this, &AnimationTrackEditor::_add_method_key));
 
 	inserting = false;
 	insert_query = false;
@@ -5966,7 +5924,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	insert_confirm = memnew(ConfirmationDialog);
 	add_child(insert_confirm);
-	insert_confirm->connect_compat("confirmed", this, "_confirm_insert_list");
+	insert_confirm->connect("confirmed", callable_mp(this, &AnimationTrackEditor::_confirm_insert_list));
 	VBoxContainer *icvb = memnew(VBoxContainer);
 	insert_confirm->add_child(icvb);
 	insert_confirm_text = memnew(Label);
@@ -5984,7 +5942,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	box_selection->set_as_toplevel(true);
 	box_selection->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	box_selection->hide();
-	box_selection->connect_compat("draw", this, "_box_selection_draw");
+	box_selection->connect("draw", callable_mp(this, &AnimationTrackEditor::_box_selection_draw));
 	box_selecting = false;
 
 	//default plugins
@@ -6022,7 +5980,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	optimize_max_angle->set_value(22);
 
 	optimize_dialog->get_ok()->set_text(TTR("Optimize"));
-	optimize_dialog->connect_compat("confirmed", this, "_edit_menu_pressed", varray(EDIT_CLEAN_UP_ANIMATION_CONFIRM));
+	optimize_dialog->connect("confirmed", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed), varray(EDIT_CLEAN_UP_ANIMATION_CONFIRM));
 
 	//
 
@@ -6048,7 +6006,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	cleanup_dialog->set_title(TTR("Clean-Up Animation(s) (NO UNDO!)"));
 	cleanup_dialog->get_ok()->set_text(TTR("Clean-Up"));
 
-	cleanup_dialog->connect_compat("confirmed", this, "_edit_menu_pressed", varray(EDIT_CLEAN_UP_ANIMATION_CONFIRM));
+	cleanup_dialog->connect("confirmed", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed), varray(EDIT_CLEAN_UP_ANIMATION_CONFIRM));
 
 	//
 	scale_dialog = memnew(ConfirmationDialog);
@@ -6060,7 +6018,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	scale->set_max(99999);
 	scale->set_step(0.001);
 	vbc->add_margin_child(TTR("Scale Ratio:"), scale);
-	scale_dialog->connect_compat("confirmed", this, "_edit_menu_pressed", varray(EDIT_SCALE_CONFIRM));
+	scale_dialog->connect("confirmed", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed), varray(EDIT_SCALE_CONFIRM));
 	add_child(scale_dialog);
 
 	track_copy_dialog = memnew(ConfirmationDialog);
@@ -6073,7 +6031,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	Button *select_all_button = memnew(Button);
 	select_all_button->set_text(TTR("Select All/None"));
-	select_all_button->connect_compat("pressed", this, "_select_all_tracks_for_copy");
+	select_all_button->connect("pressed", callable_mp(this, &AnimationTrackEditor::_select_all_tracks_for_copy));
 	track_vbox->add_child(select_all_button);
 
 	track_copy_select = memnew(Tree);
@@ -6081,7 +6039,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	track_copy_select->set_v_size_flags(SIZE_EXPAND_FILL);
 	track_copy_select->set_hide_root(true);
 	track_vbox->add_child(track_copy_select);
-	track_copy_dialog->connect_compat("confirmed", this, "_edit_menu_pressed", varray(EDIT_COPY_TRACKS_CONFIRM));
+	track_copy_dialog->connect("confirmed", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed), varray(EDIT_COPY_TRACKS_CONFIRM));
 	animation_changing_awaiting_update = false;
 }
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -330,11 +330,10 @@ void AnimationTrackEditAudio::set_node(Object *p_object) {
 }
 
 void AnimationTrackEditAudio::_bind_methods() {
-	ClassDB::bind_method("_preview_changed", &AnimationTrackEditAudio::_preview_changed);
 }
 
 AnimationTrackEditAudio::AnimationTrackEditAudio() {
-	AudioStreamPreviewGenerator::get_singleton()->connect_compat("preview_updated", this, "_preview_changed");
+	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
 }
 
 /// SPRITE FRAME / FRAME_COORDS ///
@@ -945,11 +944,10 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 }
 
 void AnimationTrackEditTypeAudio::_bind_methods() {
-	ClassDB::bind_method("_preview_changed", &AnimationTrackEditTypeAudio::_preview_changed);
 }
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
-	AudioStreamPreviewGenerator::get_singleton()->connect_compat("preview_updated", this, "_preview_changed");
+	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
 	len_resizing = false;
 }
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1711,7 +1711,7 @@ CodeTextEditor::CodeTextEditor() {
 	error->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	error->set_mouse_filter(MOUSE_FILTER_STOP);
 	error->connect("gui_input", callable_mp(this, &CodeTextEditor::_error_pressed));
-	find_replace_bar->connect_compat("error", error, "set_text");
+	find_replace_bar->connect("error", callable_mp(error, &Label::set_text));
 
 	// Warnings
 	warning_button = memnew(ToolButton);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -200,7 +200,7 @@ void FindReplaceBar::_replace() {
 
 void FindReplaceBar::_replace_all() {
 
-	text_edit->disconnect_compat("text_changed", this, "_editor_text_changed");
+	text_edit->disconnect("text_changed", callable_mp(this, &FindReplaceBar::_editor_text_changed));
 	// Line as x so it gets priority in comparison, column as y.
 	Point2i orig_cursor(text_edit->cursor_get_line(), text_edit->cursor_get_column());
 	Point2i prev_match = Point2(-1, -1);
@@ -559,24 +559,14 @@ void FindReplaceBar::set_text_edit(TextEdit *p_text_edit) {
 
 	results_count = -1;
 	text_edit = p_text_edit;
-	text_edit->connect_compat("text_changed", this, "_editor_text_changed");
+	text_edit->connect("text_changed", callable_mp(this, &FindReplaceBar::_editor_text_changed));
 }
 
 void FindReplaceBar::_bind_methods() {
 
 	ClassDB::bind_method("_unhandled_input", &FindReplaceBar::_unhandled_input);
 
-	ClassDB::bind_method("_editor_text_changed", &FindReplaceBar::_editor_text_changed);
-	ClassDB::bind_method("_search_text_changed", &FindReplaceBar::_search_text_changed);
-	ClassDB::bind_method("_search_text_entered", &FindReplaceBar::_search_text_entered);
-	ClassDB::bind_method("_replace_text_entered", &FindReplaceBar::_replace_text_entered);
 	ClassDB::bind_method("_search_current", &FindReplaceBar::search_current);
-	ClassDB::bind_method("_search_next", &FindReplaceBar::search_next);
-	ClassDB::bind_method("_search_prev", &FindReplaceBar::search_prev);
-	ClassDB::bind_method("_replace_pressed", &FindReplaceBar::_replace);
-	ClassDB::bind_method("_replace_all_pressed", &FindReplaceBar::_replace_all);
-	ClassDB::bind_method("_search_options_changed", &FindReplaceBar::_search_options_changed);
-	ClassDB::bind_method("_hide_pressed", &FindReplaceBar::_hide_bar);
 
 	ADD_SIGNAL(MethodInfo("search"));
 	ADD_SIGNAL(MethodInfo("error"));
@@ -613,8 +603,8 @@ FindReplaceBar::FindReplaceBar() {
 	search_text = memnew(LineEdit);
 	vbc_lineedit->add_child(search_text);
 	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-	search_text->connect_compat("text_changed", this, "_search_text_changed");
-	search_text->connect_compat("text_entered", this, "_search_text_entered");
+	search_text->connect("text_changed", callable_mp(this, &FindReplaceBar::_search_text_changed));
+	search_text->connect("text_entered", callable_mp(this, &FindReplaceBar::_search_text_entered));
 
 	matches_label = memnew(Label);
 	hbc_button_search->add_child(matches_label);
@@ -623,51 +613,51 @@ FindReplaceBar::FindReplaceBar() {
 	find_prev = memnew(ToolButton);
 	hbc_button_search->add_child(find_prev);
 	find_prev->set_focus_mode(FOCUS_NONE);
-	find_prev->connect_compat("pressed", this, "_search_prev");
+	find_prev->connect("pressed", callable_mp(this, &FindReplaceBar::search_prev));
 
 	find_next = memnew(ToolButton);
 	hbc_button_search->add_child(find_next);
 	find_next->set_focus_mode(FOCUS_NONE);
-	find_next->connect_compat("pressed", this, "_search_next");
+	find_next->connect("pressed", callable_mp(this, &FindReplaceBar::search_next));
 
 	case_sensitive = memnew(CheckBox);
 	hbc_option_search->add_child(case_sensitive);
 	case_sensitive->set_text(TTR("Match Case"));
 	case_sensitive->set_focus_mode(FOCUS_NONE);
-	case_sensitive->connect_compat("toggled", this, "_search_options_changed");
+	case_sensitive->connect("toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
 
 	whole_words = memnew(CheckBox);
 	hbc_option_search->add_child(whole_words);
 	whole_words->set_text(TTR("Whole Words"));
 	whole_words->set_focus_mode(FOCUS_NONE);
-	whole_words->connect_compat("toggled", this, "_search_options_changed");
+	whole_words->connect("toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
 
 	// replace toolbar
 	replace_text = memnew(LineEdit);
 	vbc_lineedit->add_child(replace_text);
 	replace_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-	replace_text->connect_compat("text_entered", this, "_replace_text_entered");
+	replace_text->connect("text_entered", callable_mp(this, &FindReplaceBar::_replace_text_entered));
 
 	replace = memnew(Button);
 	hbc_button_replace->add_child(replace);
 	replace->set_text(TTR("Replace"));
-	replace->connect_compat("pressed", this, "_replace_pressed");
+	replace->connect("pressed", callable_mp(this, &FindReplaceBar::_replace));
 
 	replace_all = memnew(Button);
 	hbc_button_replace->add_child(replace_all);
 	replace_all->set_text(TTR("Replace All"));
-	replace_all->connect_compat("pressed", this, "_replace_all_pressed");
+	replace_all->connect("pressed", callable_mp(this, &FindReplaceBar::_replace_all));
 
 	selection_only = memnew(CheckBox);
 	hbc_option_replace->add_child(selection_only);
 	selection_only->set_text(TTR("Selection Only"));
 	selection_only->set_focus_mode(FOCUS_NONE);
-	selection_only->connect_compat("toggled", this, "_search_options_changed");
+	selection_only->connect("toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
 
 	hide_button = memnew(TextureButton);
 	add_child(hide_button);
 	hide_button->set_focus_mode(FOCUS_NONE);
-	hide_button->connect_compat("pressed", this, "_hide_pressed");
+	hide_button->connect("pressed", callable_mp(this, &FindReplaceBar::_hide_bar));
 	hide_button->set_v_size_flags(SIZE_SHRINK_CENTER);
 }
 
@@ -1642,18 +1632,6 @@ void CodeTextEditor::remove_all_bookmarks() {
 void CodeTextEditor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_input"), &CodeTextEditor::_input);
-	ClassDB::bind_method("_text_editor_gui_input", &CodeTextEditor::_text_editor_gui_input);
-	ClassDB::bind_method("_line_col_changed", &CodeTextEditor::_line_col_changed);
-	ClassDB::bind_method("_text_changed", &CodeTextEditor::_text_changed);
-	ClassDB::bind_method("_on_settings_change", &CodeTextEditor::_on_settings_change);
-	ClassDB::bind_method("_text_changed_idle_timeout", &CodeTextEditor::_text_changed_idle_timeout);
-	ClassDB::bind_method("_code_complete_timer_timeout", &CodeTextEditor::_code_complete_timer_timeout);
-	ClassDB::bind_method("_complete_request", &CodeTextEditor::_complete_request);
-	ClassDB::bind_method("_font_resize_timeout", &CodeTextEditor::_font_resize_timeout);
-	ClassDB::bind_method("_error_pressed", &CodeTextEditor::_error_pressed);
-	ClassDB::bind_method("_toggle_scripts_pressed", &CodeTextEditor::_toggle_scripts_pressed);
-	ClassDB::bind_method("_warning_button_pressed", &CodeTextEditor::_warning_button_pressed);
-	ClassDB::bind_method("_warning_label_gui_input", &CodeTextEditor::_warning_label_gui_input);
 
 	ADD_SIGNAL(MethodInfo("validate_script"));
 	ADD_SIGNAL(MethodInfo("load_theme_settings"));
@@ -1717,7 +1695,7 @@ CodeTextEditor::CodeTextEditor() {
 	error_column = 0;
 
 	toggle_scripts_button = memnew(ToolButton);
-	toggle_scripts_button->connect_compat("pressed", this, "_toggle_scripts_pressed");
+	toggle_scripts_button->connect("pressed", callable_mp(this, &CodeTextEditor::_toggle_scripts_pressed));
 	status_bar->add_child(toggle_scripts_button);
 	toggle_scripts_button->hide();
 
@@ -1732,7 +1710,7 @@ CodeTextEditor::CodeTextEditor() {
 	scroll->add_child(error);
 	error->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	error->set_mouse_filter(MOUSE_FILTER_STOP);
-	error->connect_compat("gui_input", this, "_error_pressed");
+	error->connect("gui_input", callable_mp(this, &CodeTextEditor::_error_pressed));
 	find_replace_bar->connect_compat("error", error, "set_text");
 
 	// Warnings
@@ -1740,7 +1718,7 @@ CodeTextEditor::CodeTextEditor() {
 	status_bar->add_child(warning_button);
 	warning_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	warning_button->set_default_cursor_shape(CURSOR_POINTING_HAND);
-	warning_button->connect_compat("pressed", this, "_warning_button_pressed");
+	warning_button->connect("pressed", callable_mp(this, &CodeTextEditor::_warning_button_pressed));
 	warning_button->set_tooltip(TTR("Warnings"));
 
 	warning_count_label = memnew(Label);
@@ -1752,7 +1730,7 @@ CodeTextEditor::CodeTextEditor() {
 	warning_count_label->set_tooltip(TTR("Warnings"));
 	warning_count_label->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("warning_color", "Editor"));
 	warning_count_label->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
-	warning_count_label->connect_compat("gui_input", this, "_warning_label_gui_input");
+	warning_count_label->connect("gui_input", callable_mp(this, &CodeTextEditor::_warning_label_gui_input));
 
 	is_warnings_panel_opened = false;
 	set_warning_nb(0);
@@ -1765,10 +1743,10 @@ CodeTextEditor::CodeTextEditor() {
 	line_and_col_txt->set_tooltip(TTR("Line and column numbers."));
 	line_and_col_txt->set_mouse_filter(MOUSE_FILTER_STOP);
 
-	text_editor->connect_compat("gui_input", this, "_text_editor_gui_input");
-	text_editor->connect_compat("cursor_changed", this, "_line_col_changed");
-	text_editor->connect_compat("text_changed", this, "_text_changed");
-	text_editor->connect_compat("request_completion", this, "_complete_request");
+	text_editor->connect("gui_input", callable_mp(this, &CodeTextEditor::_text_editor_gui_input));
+	text_editor->connect("cursor_changed", callable_mp(this, &CodeTextEditor::_line_col_changed));
+	text_editor->connect("text_changed", callable_mp(this, &CodeTextEditor::_text_changed));
+	text_editor->connect("request_completion", callable_mp(this, &CodeTextEditor::_complete_request));
 	Vector<String> cs;
 	cs.push_back(".");
 	cs.push_back(",");
@@ -1776,9 +1754,9 @@ CodeTextEditor::CodeTextEditor() {
 	cs.push_back("=");
 	cs.push_back("$");
 	text_editor->set_completion(true, cs);
-	idle->connect_compat("timeout", this, "_text_changed_idle_timeout");
+	idle->connect("timeout", callable_mp(this, &CodeTextEditor::_text_changed_idle_timeout));
 
-	code_complete_timer->connect_compat("timeout", this, "_code_complete_timer_timeout");
+	code_complete_timer->connect("timeout", callable_mp(this, &CodeTextEditor::_code_complete_timer_timeout));
 
 	font_resize_val = 0;
 	font_size = EditorSettings::get_singleton()->get("interface/editor/code_font_size");
@@ -1786,7 +1764,7 @@ CodeTextEditor::CodeTextEditor() {
 	add_child(font_resize_timer);
 	font_resize_timer->set_one_shot(true);
 	font_resize_timer->set_wait_time(0.07);
-	font_resize_timer->connect_compat("timeout", this, "_font_resize_timeout");
+	font_resize_timer->connect("timeout", callable_mp(this, &CodeTextEditor::_font_resize_timeout));
 
-	EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_on_settings_change");
+	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &CodeTextEditor::_on_settings_change));
 }

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -234,11 +234,7 @@ void ConnectDialog::_notification(int p_what) {
 
 void ConnectDialog::_bind_methods() {
 
-	ClassDB::bind_method("_advanced_pressed", &ConnectDialog::_advanced_pressed);
 	ClassDB::bind_method("_cancel", &ConnectDialog::_cancel_pressed);
-	ClassDB::bind_method("_tree_node_selected", &ConnectDialog::_tree_node_selected);
-	ClassDB::bind_method("_add_bind", &ConnectDialog::_add_bind);
-	ClassDB::bind_method("_remove_bind", &ConnectDialog::_remove_bind);
 	ClassDB::bind_method("_update_ok_enabled", &ConnectDialog::_update_ok_enabled);
 
 	ADD_SIGNAL(MethodInfo("connected"));
@@ -391,7 +387,7 @@ ConnectDialog::ConnectDialog() {
 	tree = memnew(SceneTreeEditor(false));
 	tree->set_connecting_signal(true);
 	tree->get_scene_tree()->connect_compat("item_activated", this, "_ok");
-	tree->connect_compat("node_selected", this, "_tree_node_selected");
+	tree->connect("node_selected", callable_mp(this, &ConnectDialog::_tree_node_selected));
 	tree->set_connect_to_script_mode(true);
 
 	Node *mc = vbc_left->add_margin_child(TTR("Connect to Script:"), tree, true);
@@ -431,12 +427,12 @@ ConnectDialog::ConnectDialog() {
 	Button *add_bind = memnew(Button);
 	add_bind->set_text(TTR("Add"));
 	add_bind_hb->add_child(add_bind);
-	add_bind->connect_compat("pressed", this, "_add_bind");
+	add_bind->connect("pressed", callable_mp(this, &ConnectDialog::_add_bind));
 
 	Button *del_bind = memnew(Button);
 	del_bind->set_text(TTR("Remove"));
 	add_bind_hb->add_child(del_bind);
-	del_bind->connect_compat("pressed", this, "_remove_bind");
+	del_bind->connect("pressed", callable_mp(this, &ConnectDialog::_remove_bind));
 
 	vbc_right->add_margin_child(TTR("Add Extra Call Argument:"), add_bind_hb);
 
@@ -455,7 +451,7 @@ ConnectDialog::ConnectDialog() {
 	advanced = memnew(CheckButton);
 	dstm_hb->add_child(advanced);
 	advanced->set_text(TTR("Advanced"));
-	advanced->connect_compat("pressed", this, "_advanced_pressed");
+	advanced->connect("pressed", callable_mp(this, &ConnectDialog::_advanced_pressed));
 
 	// Add spacing so the tree and inspector are the same size.
 	Control *spacing = memnew(Control);
@@ -866,15 +862,7 @@ void ConnectionsDock::_notification(int p_what) {
 
 void ConnectionsDock::_bind_methods() {
 
-	ClassDB::bind_method("_make_or_edit_connection", &ConnectionsDock::_make_or_edit_connection);
-	ClassDB::bind_method("_disconnect_all", &ConnectionsDock::_disconnect_all);
-	ClassDB::bind_method("_tree_item_selected", &ConnectionsDock::_tree_item_selected);
-	ClassDB::bind_method("_tree_item_activated", &ConnectionsDock::_tree_item_activated);
-	ClassDB::bind_method("_handle_signal_menu_option", &ConnectionsDock::_handle_signal_menu_option);
-	ClassDB::bind_method("_handle_slot_menu_option", &ConnectionsDock::_handle_slot_menu_option);
-	ClassDB::bind_method("_rmb_pressed", &ConnectionsDock::_rmb_pressed);
 	ClassDB::bind_method("_close", &ConnectionsDock::_close);
-	ClassDB::bind_method("_connect_pressed", &ConnectionsDock::_connect_pressed);
 	ClassDB::bind_method("update_tree", &ConnectionsDock::update_tree);
 }
 
@@ -1086,7 +1074,7 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	vbc->add_child(hb);
 	hb->add_spacer();
 	hb->add_child(connect_button);
-	connect_button->connect_compat("pressed", this, "_connect_pressed");
+	connect_button->connect("pressed", callable_mp(this, &ConnectionsDock::_connect_pressed));
 
 	connect_dialog = memnew(ConnectDialog);
 	connect_dialog->set_as_toplevel(true);
@@ -1095,26 +1083,26 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	disconnect_all_dialog = memnew(ConfirmationDialog);
 	disconnect_all_dialog->set_as_toplevel(true);
 	add_child(disconnect_all_dialog);
-	disconnect_all_dialog->connect_compat("confirmed", this, "_disconnect_all");
+	disconnect_all_dialog->connect("confirmed", callable_mp(this, &ConnectionsDock::_disconnect_all));
 	disconnect_all_dialog->set_text(TTR("Are you sure you want to remove all connections from this signal?"));
 
 	signal_menu = memnew(PopupMenu);
 	add_child(signal_menu);
-	signal_menu->connect_compat("id_pressed", this, "_handle_signal_menu_option");
+	signal_menu->connect("id_pressed", callable_mp(this, &ConnectionsDock::_handle_signal_menu_option));
 	signal_menu->add_item(TTR("Connect..."), CONNECT);
 	signal_menu->add_item(TTR("Disconnect All"), DISCONNECT_ALL);
 
 	slot_menu = memnew(PopupMenu);
 	add_child(slot_menu);
-	slot_menu->connect_compat("id_pressed", this, "_handle_slot_menu_option");
+	slot_menu->connect("id_pressed", callable_mp(this, &ConnectionsDock::_handle_slot_menu_option));
 	slot_menu->add_item(TTR("Edit..."), EDIT);
 	slot_menu->add_item(TTR("Go To Method"), GO_TO_SCRIPT);
 	slot_menu->add_item(TTR("Disconnect"), DISCONNECT);
 
-	connect_dialog->connect_compat("connected", this, "_make_or_edit_connection");
-	tree->connect_compat("item_selected", this, "_tree_item_selected");
-	tree->connect_compat("item_activated", this, "_tree_item_activated");
-	tree->connect_compat("item_rmb_selected", this, "_rmb_pressed");
+	connect_dialog->connect("connected", callable_mp(this, &ConnectionsDock::_make_or_edit_connection));
+	tree->connect("item_selected", callable_mp(this, &ConnectionsDock::_tree_item_selected));
+	tree->connect("item_activated", callable_mp(this, &ConnectionsDock::_tree_item_activated));
+	tree->connect("item_rmb_selected", callable_mp(this, &ConnectionsDock::_rmb_pressed));
 
 	add_constant_override("separation", 3 * EDSCALE);
 }

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -459,13 +459,13 @@ void CreateDialog::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("confirmed", this, "_confirmed");
+			connect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
 			search_box->set_clear_button_enabled(true);
 			favorite->set_icon(get_icon("Favorites", "EditorIcons"));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("confirmed", this, "_confirmed");
+			disconnect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible_in_tree()) {
@@ -725,15 +725,6 @@ void CreateDialog::_save_and_update_favorite_list() {
 
 void CreateDialog::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_text_changed"), &CreateDialog::_text_changed);
-	ClassDB::bind_method(D_METHOD("_confirmed"), &CreateDialog::_confirmed);
-	ClassDB::bind_method(D_METHOD("_sbox_input"), &CreateDialog::_sbox_input);
-	ClassDB::bind_method(D_METHOD("_item_selected"), &CreateDialog::_item_selected);
-	ClassDB::bind_method(D_METHOD("_favorite_toggled"), &CreateDialog::_favorite_toggled);
-	ClassDB::bind_method(D_METHOD("_history_selected"), &CreateDialog::_history_selected);
-	ClassDB::bind_method(D_METHOD("_favorite_selected"), &CreateDialog::_favorite_selected);
-	ClassDB::bind_method(D_METHOD("_history_activated"), &CreateDialog::_history_activated);
-	ClassDB::bind_method(D_METHOD("_favorite_activated"), &CreateDialog::_favorite_activated);
 	ClassDB::bind_method(D_METHOD("_save_and_update_favorite_list"), &CreateDialog::_save_and_update_favorite_list);
 
 	ClassDB::bind_method("get_drag_data_fw", &CreateDialog::get_drag_data_fw);
@@ -766,8 +757,8 @@ CreateDialog::CreateDialog() {
 	favorites->set_hide_root(true);
 	favorites->set_hide_folding(true);
 	favorites->set_allow_reselect(true);
-	favorites->connect_compat("cell_selected", this, "_favorite_selected");
-	favorites->connect_compat("item_activated", this, "_favorite_activated");
+	favorites->connect("cell_selected", callable_mp(this, &CreateDialog::_favorite_selected));
+	favorites->connect("item_activated", callable_mp(this, &CreateDialog::_favorite_activated));
 	favorites->set_drag_forwarding(this);
 	favorites->add_constant_override("draw_guides", 1);
 
@@ -781,8 +772,8 @@ CreateDialog::CreateDialog() {
 	recent->set_hide_root(true);
 	recent->set_hide_folding(true);
 	recent->set_allow_reselect(true);
-	recent->connect_compat("cell_selected", this, "_history_selected");
-	recent->connect_compat("item_activated", this, "_history_activated");
+	recent->connect("cell_selected", callable_mp(this, &CreateDialog::_history_selected));
+	recent->connect("item_activated", callable_mp(this, &CreateDialog::_history_activated));
 	recent->add_constant_override("draw_guides", 1);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
@@ -797,17 +788,17 @@ CreateDialog::CreateDialog() {
 	favorite->set_flat(true);
 	favorite->set_toggle_mode(true);
 	search_hb->add_child(favorite);
-	favorite->connect_compat("pressed", this, "_favorite_toggled");
+	favorite->connect("pressed", callable_mp(this, &CreateDialog::_favorite_toggled));
 	vbc->add_margin_child(TTR("Search:"), search_hb);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", callable_mp(this, &CreateDialog::_text_changed));
+	search_box->connect("gui_input", callable_mp(this, &CreateDialog::_sbox_input));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
-	search_options->connect_compat("cell_selected", this, "_item_selected");
+	search_options->connect("item_activated", callable_mp(this, &CreateDialog::_confirmed));
+	search_options->connect("cell_selected", callable_mp(this, &CreateDialog::_item_selected));
 	base_type = "Object";
 	preferred_search_result_type = "";
 

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -95,8 +95,6 @@ EditorDebuggerInspector::~EditorDebuggerInspector() {
 }
 
 void EditorDebuggerInspector::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_object_edited", "name", "value"), &EditorDebuggerInspector::_object_edited);
-	ClassDB::bind_method(D_METHOD("_object_selected", "id"), &EditorDebuggerInspector::_object_selected);
 	ADD_SIGNAL(MethodInfo("object_selected", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("object_edited", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "property"), PropertyInfo("value")));
 	ADD_SIGNAL(MethodInfo("object_property_updated", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "property")));
@@ -105,7 +103,7 @@ void EditorDebuggerInspector::_bind_methods() {
 void EditorDebuggerInspector::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE:
-			connect_compat("object_id_selected", this, "_object_selected");
+			connect("object_id_selected", callable_mp(this, &EditorDebuggerInspector::_object_selected));
 			break;
 		case NOTIFICATION_ENTER_TREE:
 			edit(variables);
@@ -139,7 +137,7 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 		debugObj->remote_object_id = obj.id;
 		debugObj->type_name = obj.class_name;
 		remote_objects[obj.id] = debugObj;
-		debugObj->connect_compat("value_edited", this, "_object_edited");
+		debugObj->connect("value_edited", callable_mp(this, &EditorDebuggerInspector::_object_edited));
 	}
 
 	int old_prop_size = debugObj->prop_list.size();

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -57,7 +57,7 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	tabs = memnew(TabContainer);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
 	tabs->set_tabs_visible(false);
-	tabs->connect_compat("tab_changed", this, "_debugger_changed");
+	tabs->connect("tab_changed", callable_mp(this, &EditorDebuggerNode::_debugger_changed));
 	add_child(tabs);
 
 	Ref<StyleBoxEmpty> empty;
@@ -69,10 +69,10 @@ EditorDebuggerNode::EditorDebuggerNode() {
 
 	// Remote scene tree
 	remote_scene_tree = memnew(EditorDebuggerTree);
-	remote_scene_tree->connect_compat("object_selected", this, "_remote_object_requested");
-	remote_scene_tree->connect_compat("save_node", this, "_save_node_requested");
+	remote_scene_tree->connect("object_selected", callable_mp(this, &EditorDebuggerNode::_remote_object_requested));
+	remote_scene_tree->connect("save_node", callable_mp(this, &EditorDebuggerNode::_save_node_requested));
 	EditorNode::get_singleton()->get_scene_tree_dock()->add_remote_tree_editor(remote_scene_tree);
-	EditorNode::get_singleton()->get_scene_tree_dock()->connect_compat("remote_tree_selected", this, "request_remote_tree");
+	EditorNode::get_singleton()->get_scene_tree_dock()->connect("remote_tree_selected", callable_mp(this, &EditorDebuggerNode::request_remote_tree));
 
 	remote_scene_tree_timeout = EDITOR_DEF("debugger/remote_scene_tree_refresh_interval", 1.0);
 	inspect_edited_object_timeout = EDITOR_DEF("debugger/remote_inspect_refresh_interval", 0.2);
@@ -80,23 +80,23 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	EditorNode *editor = EditorNode::get_singleton();
 	editor->get_undo_redo()->set_method_notify_callback(_method_changeds, this);
 	editor->get_undo_redo()->set_property_notify_callback(_property_changeds, this);
-	editor->get_pause_button()->connect_compat("pressed", this, "_paused");
+	editor->get_pause_button()->connect("pressed", callable_mp(this, &EditorDebuggerNode::_paused));
 }
 
 ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	ScriptEditorDebugger *node = memnew(ScriptEditorDebugger(EditorNode::get_singleton()));
 
 	int id = tabs->get_tab_count();
-	node->connect_compat("stop_requested", this, "_debugger_wants_stop", varray(id));
-	node->connect_compat("stopped", this, "_debugger_stopped", varray(id));
-	node->connect_compat("stack_frame_selected", this, "_stack_frame_selected", varray(id));
-	node->connect_compat("error_selected", this, "_error_selected", varray(id));
-	node->connect_compat("clear_execution", this, "_clear_execution");
-	node->connect_compat("breaked", this, "_breaked", varray(id));
-	node->connect_compat("remote_tree_updated", this, "_remote_tree_updated", varray(id));
-	node->connect_compat("remote_object_updated", this, "_remote_object_updated", varray(id));
-	node->connect_compat("remote_object_property_updated", this, "_remote_object_property_updated", varray(id));
-	node->connect_compat("remote_object_requested", this, "_remote_object_requested", varray(id));
+	node->connect("stop_requested", callable_mp(this, &EditorDebuggerNode::_debugger_wants_stop), varray(id));
+	node->connect("stopped", callable_mp(this, &EditorDebuggerNode::_debugger_stopped), varray(id));
+	node->connect("stack_frame_selected", callable_mp(this, &EditorDebuggerNode::_stack_frame_selected), varray(id));
+	node->connect("error_selected", callable_mp(this, &EditorDebuggerNode::_error_selected), varray(id));
+	node->connect("clear_execution", callable_mp(this, &EditorDebuggerNode::_clear_execution));
+	node->connect("breaked", callable_mp(this, &EditorDebuggerNode::_breaked), varray(id));
+	node->connect("remote_tree_updated", callable_mp(this, &EditorDebuggerNode::_remote_tree_updated), varray(id));
+	node->connect("remote_object_updated", callable_mp(this, &EditorDebuggerNode::_remote_object_updated), varray(id));
+	node->connect("remote_object_property_updated", callable_mp(this, &EditorDebuggerNode::_remote_object_property_updated), varray(id));
+	node->connect("remote_object_requested", callable_mp(this, &EditorDebuggerNode::_remote_object_requested), varray(id));
 
 	if (tabs->get_tab_count() > 0) {
 		get_debugger(0)->clear_style();
@@ -139,23 +139,6 @@ void EditorDebuggerNode::_text_editor_stack_goto(const ScriptEditorDebugger *p_d
 }
 
 void EditorDebuggerNode::_bind_methods() {
-	ClassDB::bind_method("_menu_option", &EditorDebuggerNode::_menu_option);
-	ClassDB::bind_method("_debugger_stopped", &EditorDebuggerNode::_debugger_stopped);
-	ClassDB::bind_method("_debugger_wants_stop", &EditorDebuggerNode::_debugger_wants_stop);
-	ClassDB::bind_method("_debugger_changed", &EditorDebuggerNode::_debugger_changed);
-	ClassDB::bind_method("_stack_frame_selected", &EditorDebuggerNode::_stack_frame_selected);
-	ClassDB::bind_method("_error_selected", &EditorDebuggerNode::_error_selected);
-	ClassDB::bind_method("_clear_execution", &EditorDebuggerNode::_clear_execution);
-	ClassDB::bind_method("_breaked", &EditorDebuggerNode::_breaked);
-	ClassDB::bind_method("start", &EditorDebuggerNode::start);
-	ClassDB::bind_method("stop", &EditorDebuggerNode::stop);
-	ClassDB::bind_method("_paused", &EditorDebuggerNode::_paused);
-	ClassDB::bind_method("request_remote_tree", &EditorDebuggerNode::request_remote_tree);
-	ClassDB::bind_method("_remote_tree_updated", &EditorDebuggerNode::_remote_tree_updated);
-	ClassDB::bind_method("_remote_object_updated", &EditorDebuggerNode::_remote_object_updated);
-	ClassDB::bind_method("_remote_object_property_updated", &EditorDebuggerNode::_remote_object_property_updated);
-	ClassDB::bind_method("_remote_object_requested", &EditorDebuggerNode::_remote_object_requested);
-	ClassDB::bind_method("_save_node_requested", &EditorDebuggerNode::_save_node_requested);
 
 	// LiveDebug.
 	ClassDB::bind_method("live_debug_create_node", &EditorDebuggerNode::live_debug_create_node);
@@ -229,12 +212,12 @@ void EditorDebuggerNode::stop() {
 void EditorDebuggerNode::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			EditorNode::get_singleton()->connect_compat("play_pressed", this, "start");
-			EditorNode::get_singleton()->connect_compat("stop_pressed", this, "stop");
+			EditorNode::get_singleton()->connect("play_pressed", callable_mp(this, &EditorDebuggerNode::start));
+			EditorNode::get_singleton()->connect("stop_pressed", callable_mp(this, &EditorDebuggerNode::stop));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			EditorNode::get_singleton()->disconnect_compat("play_pressed", this, "start");
-			EditorNode::get_singleton()->disconnect_compat("stop_pressed", this, "stop");
+			EditorNode::get_singleton()->disconnect("play_pressed", callable_mp(this, &EditorDebuggerNode::start));
+			EditorNode::get_singleton()->disconnect("stop_pressed", callable_mp(this, &EditorDebuggerNode::stop));
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (tabs->get_tab_count() > 1) {
@@ -390,7 +373,7 @@ void EditorDebuggerNode::set_script_debug_button(MenuButton *p_button) {
 	p->add_separator();
 	p->add_check_shortcut(ED_GET_SHORTCUT("debugger/keep_debugger_open"), DEBUG_SHOW_KEEP_OPEN);
 	p->add_check_shortcut(ED_GET_SHORTCUT("debugger/debug_with_external_editor"), DEBUG_WITH_EXTERNAL_EDITOR);
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", callable_mp(this, &EditorDebuggerNode::_menu_option));
 
 	_break_state_changed();
 	script_menu->show();

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -40,29 +40,24 @@ EditorDebuggerTree::EditorDebuggerTree() {
 
 	// Popup
 	item_menu = memnew(PopupMenu);
-	item_menu->connect_compat("id_pressed", this, "_item_menu_id_pressed");
+	item_menu->connect("id_pressed", callable_mp(this, &EditorDebuggerTree::_item_menu_id_pressed));
 	add_child(item_menu);
 
 	// File Dialog
 	file_dialog = memnew(EditorFileDialog);
-	file_dialog->connect_compat("file_selected", this, "_file_selected");
+	file_dialog->connect("file_selected", callable_mp(this, &EditorDebuggerTree::_file_selected));
 	add_child(file_dialog);
 }
 
 void EditorDebuggerTree::_notification(int p_what) {
 	if (p_what == NOTIFICATION_POSTINITIALIZE) {
-		connect_compat("cell_selected", this, "_scene_tree_selected");
-		connect_compat("item_collapsed", this, "_scene_tree_folded");
-		connect_compat("item_rmb_selected", this, "_scene_tree_rmb_selected");
+		connect("cell_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_selected));
+		connect("item_collapsed", callable_mp(this, &EditorDebuggerTree::_scene_tree_folded));
+		connect("item_rmb_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_rmb_selected));
 	}
 }
 
 void EditorDebuggerTree::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_scene_tree_selected"), &EditorDebuggerTree::_scene_tree_selected);
-	ClassDB::bind_method(D_METHOD("_scene_tree_folded"), &EditorDebuggerTree::_scene_tree_folded);
-	ClassDB::bind_method(D_METHOD("_scene_tree_rmb_selected"), &EditorDebuggerTree::_scene_tree_rmb_selected);
-	ClassDB::bind_method(D_METHOD("_item_menu_id_pressed"), &EditorDebuggerTree::_item_menu_id_pressed);
-	ClassDB::bind_method(D_METHOD("_file_selected"), &EditorDebuggerTree::_file_selected);
 	ADD_SIGNAL(MethodInfo("object_selected", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::INT, "debugger")));
 	ADD_SIGNAL(MethodInfo("save_node", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "filename"), PropertyInfo(Variant::INT, "debugger")));
 }

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -763,10 +763,10 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			next->set_icon(get_icon("DebugNext", "EditorIcons"));
 			dobreak->set_icon(get_icon("Pause", "EditorIcons"));
 			docontinue->set_icon(get_icon("DebugContinue", "EditorIcons"));
-			le_set->connect_compat("pressed", this, "_live_edit_set");
-			le_clear->connect_compat("pressed", this, "_live_edit_clear");
-			error_tree->connect_compat("item_selected", this, "_error_selected");
-			error_tree->connect_compat("item_activated", this, "_error_activated");
+			le_set->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_live_edit_set));
+			le_clear->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_live_edit_clear));
+			error_tree->connect("item_selected", callable_mp(this, &ScriptEditorDebugger::_error_selected));
+			error_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_error_activated));
 			vmem_refresh->set_icon(get_icon("Reload", "EditorIcons"));
 
 			reason->add_color_override("font_color", get_color("error_color", "Editor"));
@@ -1477,40 +1477,6 @@ void ScriptEditorDebugger::_tab_changed(int p_tab) {
 
 void ScriptEditorDebugger::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_stack_dump_frame_selected"), &ScriptEditorDebugger::_stack_dump_frame_selected);
-
-	ClassDB::bind_method(D_METHOD("debug_skip_breakpoints"), &ScriptEditorDebugger::debug_skip_breakpoints);
-	ClassDB::bind_method(D_METHOD("debug_copy"), &ScriptEditorDebugger::debug_copy);
-
-	ClassDB::bind_method(D_METHOD("debug_next"), &ScriptEditorDebugger::debug_next);
-	ClassDB::bind_method(D_METHOD("debug_step"), &ScriptEditorDebugger::debug_step);
-	ClassDB::bind_method(D_METHOD("debug_break"), &ScriptEditorDebugger::debug_break);
-	ClassDB::bind_method(D_METHOD("debug_continue"), &ScriptEditorDebugger::debug_continue);
-	ClassDB::bind_method(D_METHOD("_export_csv"), &ScriptEditorDebugger::_export_csv);
-	ClassDB::bind_method(D_METHOD("_performance_draw"), &ScriptEditorDebugger::_performance_draw);
-	ClassDB::bind_method(D_METHOD("_performance_select"), &ScriptEditorDebugger::_performance_select);
-	ClassDB::bind_method(D_METHOD("_video_mem_request"), &ScriptEditorDebugger::_video_mem_request);
-	ClassDB::bind_method(D_METHOD("_live_edit_set"), &ScriptEditorDebugger::_live_edit_set);
-	ClassDB::bind_method(D_METHOD("_live_edit_clear"), &ScriptEditorDebugger::_live_edit_clear);
-
-	ClassDB::bind_method(D_METHOD("_error_selected"), &ScriptEditorDebugger::_error_selected);
-	ClassDB::bind_method(D_METHOD("_error_activated"), &ScriptEditorDebugger::_error_activated);
-	ClassDB::bind_method(D_METHOD("_expand_errors_list"), &ScriptEditorDebugger::_expand_errors_list);
-	ClassDB::bind_method(D_METHOD("_collapse_errors_list"), &ScriptEditorDebugger::_collapse_errors_list);
-	ClassDB::bind_method(D_METHOD("_profiler_activate"), &ScriptEditorDebugger::_profiler_activate);
-	ClassDB::bind_method(D_METHOD("_visual_profiler_activate"), &ScriptEditorDebugger::_visual_profiler_activate);
-	ClassDB::bind_method(D_METHOD("_network_profiler_activate"), &ScriptEditorDebugger::_network_profiler_activate);
-	ClassDB::bind_method(D_METHOD("_profiler_seeked"), &ScriptEditorDebugger::_profiler_seeked);
-	ClassDB::bind_method(D_METHOD("_clear_errors_list"), &ScriptEditorDebugger::_clear_errors_list);
-
-	ClassDB::bind_method(D_METHOD("_error_tree_item_rmb_selected"), &ScriptEditorDebugger::_error_tree_item_rmb_selected);
-	ClassDB::bind_method(D_METHOD("_item_menu_id_pressed"), &ScriptEditorDebugger::_item_menu_id_pressed);
-	ClassDB::bind_method(D_METHOD("_tab_changed"), &ScriptEditorDebugger::_tab_changed);
-	ClassDB::bind_method(D_METHOD("_file_selected"), &ScriptEditorDebugger::_file_selected);
-	ClassDB::bind_method(D_METHOD("_remote_object_selected", "id"), &ScriptEditorDebugger::_remote_object_selected);
-	ClassDB::bind_method(D_METHOD("_remote_object_edited", "id", "property", "value"), &ScriptEditorDebugger::_remote_object_edited);
-	ClassDB::bind_method(D_METHOD("_remote_object_property_updated", "id", "property"), &ScriptEditorDebugger::_remote_object_property_updated);
-
 	ClassDB::bind_method(D_METHOD("live_debug_create_node"), &ScriptEditorDebugger::live_debug_create_node);
 	ClassDB::bind_method(D_METHOD("live_debug_instance_node"), &ScriptEditorDebugger::live_debug_instance_node);
 	ClassDB::bind_method(D_METHOD("live_debug_remove_node"), &ScriptEditorDebugger::live_debug_remove_node);
@@ -1543,7 +1509,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	tabs = memnew(TabContainer);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
 	tabs->add_style_override("panel", editor->get_gui_base()->get_stylebox("DebuggerPanel", "EditorStyles"));
-	tabs->connect_compat("tab_changed", this, "_tab_changed");
+	tabs->connect("tab_changed", callable_mp(this, &ScriptEditorDebugger::_tab_changed));
 
 	add_child(tabs);
 
@@ -1568,14 +1534,14 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		skip_breakpoints = memnew(ToolButton);
 		hbc->add_child(skip_breakpoints);
 		skip_breakpoints->set_tooltip(TTR("Skip Breakpoints"));
-		skip_breakpoints->connect_compat("pressed", this, "debug_skip_breakpoints");
+		skip_breakpoints->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_skip_breakpoints));
 
 		hbc->add_child(memnew(VSeparator));
 
 		copy = memnew(ToolButton);
 		hbc->add_child(copy);
 		copy->set_tooltip(TTR("Copy Error"));
-		copy->connect_compat("pressed", this, "debug_copy");
+		copy->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_copy));
 
 		hbc->add_child(memnew(VSeparator));
 
@@ -1583,13 +1549,13 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		hbc->add_child(step);
 		step->set_tooltip(TTR("Step Into"));
 		step->set_shortcut(ED_GET_SHORTCUT("debugger/step_into"));
-		step->connect_compat("pressed", this, "debug_step");
+		step->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_step));
 
 		next = memnew(ToolButton);
 		hbc->add_child(next);
 		next->set_tooltip(TTR("Step Over"));
 		next->set_shortcut(ED_GET_SHORTCUT("debugger/step_over"));
-		next->connect_compat("pressed", this, "debug_next");
+		next->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_next));
 
 		hbc->add_child(memnew(VSeparator));
 
@@ -1597,13 +1563,13 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		hbc->add_child(dobreak);
 		dobreak->set_tooltip(TTR("Break"));
 		dobreak->set_shortcut(ED_GET_SHORTCUT("debugger/break"));
-		dobreak->connect_compat("pressed", this, "debug_break");
+		dobreak->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_break));
 
 		docontinue = memnew(ToolButton);
 		hbc->add_child(docontinue);
 		docontinue->set_tooltip(TTR("Continue"));
 		docontinue->set_shortcut(ED_GET_SHORTCUT("debugger/continue"));
-		docontinue->connect_compat("pressed", this, "debug_continue");
+		docontinue->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_continue));
 
 		HSplitContainer *sc = memnew(HSplitContainer);
 		vbc->add_child(sc);
@@ -1616,16 +1582,16 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		stack_dump->set_column_title(0, TTR("Stack Frames"));
 		stack_dump->set_h_size_flags(SIZE_EXPAND_FILL);
 		stack_dump->set_hide_root(true);
-		stack_dump->connect_compat("cell_selected", this, "_stack_dump_frame_selected");
+		stack_dump->connect("cell_selected", callable_mp(this, &ScriptEditorDebugger::_stack_dump_frame_selected));
 		sc->add_child(stack_dump);
 
 		inspector = memnew(EditorDebuggerInspector);
 		inspector->set_h_size_flags(SIZE_EXPAND_FILL);
 		inspector->set_enable_capitalize_paths(false);
 		inspector->set_read_only(true);
-		inspector->connect_compat("object_selected", this, "_remote_object_selected");
-		inspector->connect_compat("object_edited", this, "_remote_object_edited");
-		inspector->connect_compat("object_property_updated", this, "_remote_object_property_updated");
+		inspector->connect("object_selected", callable_mp(this, &ScriptEditorDebugger::_remote_object_selected));
+		inspector->connect("object_edited", callable_mp(this, &ScriptEditorDebugger::_remote_object_edited));
+		inspector->connect("object_property_updated", callable_mp(this, &ScriptEditorDebugger::_remote_object_property_updated));
 		sc->add_child(inspector);
 		tabs->add_child(dbg);
 	}
@@ -1639,12 +1605,12 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 		Button *expand_all = memnew(Button);
 		expand_all->set_text(TTR("Expand All"));
-		expand_all->connect_compat("pressed", this, "_expand_errors_list");
+		expand_all->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_expand_errors_list));
 		errhb->add_child(expand_all);
 
 		Button *collapse_all = memnew(Button);
 		collapse_all->set_text(TTR("Collapse All"));
-		collapse_all->connect_compat("pressed", this, "_collapse_errors_list");
+		collapse_all->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_collapse_errors_list));
 		errhb->add_child(collapse_all);
 
 		Control *space = memnew(Control);
@@ -1654,7 +1620,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		clearbutton = memnew(Button);
 		clearbutton->set_text(TTR("Clear"));
 		clearbutton->set_h_size_flags(0);
-		clearbutton->connect_compat("pressed", this, "_clear_errors_list");
+		clearbutton->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_clear_errors_list));
 		errhb->add_child(clearbutton);
 
 		error_tree = memnew(Tree);
@@ -1669,11 +1635,11 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		error_tree->set_hide_root(true);
 		error_tree->set_v_size_flags(SIZE_EXPAND_FILL);
 		error_tree->set_allow_rmb_select(true);
-		error_tree->connect_compat("item_rmb_selected", this, "_error_tree_item_rmb_selected");
+		error_tree->connect("item_rmb_selected", callable_mp(this, &ScriptEditorDebugger::_error_tree_item_rmb_selected));
 		errors_tab->add_child(error_tree);
 
 		item_menu = memnew(PopupMenu);
-		item_menu->connect_compat("id_pressed", this, "_item_menu_id_pressed");
+		item_menu->connect("id_pressed", callable_mp(this, &ScriptEditorDebugger::_item_menu_id_pressed));
 		error_tree->add_child(item_menu);
 
 		tabs->add_child(errors_tab);
@@ -1681,7 +1647,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 	{ // File dialog
 		file_dialog = memnew(EditorFileDialog);
-		file_dialog->connect_compat("file_selected", this, "_file_selected");
+		file_dialog->connect("file_selected", callable_mp(this, &ScriptEditorDebugger::_file_selected));
 		add_child(file_dialog);
 	}
 
@@ -1689,23 +1655,23 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		profiler = memnew(EditorProfiler);
 		profiler->set_name(TTR("Profiler"));
 		tabs->add_child(profiler);
-		profiler->connect_compat("enable_profiling", this, "_profiler_activate");
-		profiler->connect_compat("break_request", this, "_profiler_seeked");
+		profiler->connect("enable_profiling", callable_mp(this, &ScriptEditorDebugger::_profiler_activate));
+		profiler->connect("break_request", callable_mp(this, &ScriptEditorDebugger::_profiler_seeked));
 	}
 
 	{ //frame profiler
 		visual_profiler = memnew(EditorVisualProfiler);
 		visual_profiler->set_name(TTR("Visual Profiler"));
 		tabs->add_child(visual_profiler);
-		visual_profiler->connect_compat("enable_profiling", this, "_visual_profiler_activate");
-		visual_profiler->connect_compat("break_request", this, "_profiler_seeked");
+		visual_profiler->connect("enable_profiling", callable_mp(this, &ScriptEditorDebugger::_visual_profiler_activate));
+		visual_profiler->connect("break_request", callable_mp(this, &ScriptEditorDebugger::_profiler_seeked));
 	}
 
 	{ //network profiler
 		network_profiler = memnew(EditorNetworkProfiler);
 		network_profiler->set_name(TTR("Network Profiler"));
 		tabs->add_child(network_profiler);
-		network_profiler->connect_compat("enable_profiling", this, "_network_profiler_activate");
+		network_profiler->connect("enable_profiling", callable_mp(this, &ScriptEditorDebugger::_network_profiler_activate));
 	}
 
 	{ //monitors
@@ -1717,12 +1683,12 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		perf_monitors->set_column_title(0, TTR("Monitor"));
 		perf_monitors->set_column_title(1, TTR("Value"));
 		perf_monitors->set_column_titles_visible(true);
-		perf_monitors->connect_compat("item_edited", this, "_performance_select");
+		perf_monitors->connect("item_edited", callable_mp(this, &ScriptEditorDebugger::_performance_select));
 		hsp->add_child(perf_monitors);
 
 		perf_draw = memnew(Control);
 		perf_draw->set_clip_contents(true);
-		perf_draw->connect_compat("draw", this, "_performance_draw");
+		perf_draw->connect("draw", callable_mp(this, &ScriptEditorDebugger::_performance_draw));
 		hsp->add_child(perf_draw);
 
 		hsp->set_name(TTR("Monitors"));
@@ -1783,7 +1749,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		vmem_refresh = memnew(ToolButton);
 		vmem_hb->add_child(vmem_refresh);
 		vmem_vb->add_child(vmem_hb);
-		vmem_refresh->connect_compat("pressed", this, "_video_mem_request");
+		vmem_refresh->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_video_mem_request));
 
 		VBoxContainer *vmmc = memnew(VBoxContainer);
 		vmem_tree = memnew(Tree);
@@ -1849,7 +1815,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		HBoxContainer *buttons = memnew(HBoxContainer);
 
 		export_csv = memnew(Button(TTR("Export measures as CSV")));
-		export_csv->connect_compat("pressed", this, "_export_csv");
+		export_csv->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_export_csv));
 		buttons->add_child(export_csv);
 
 		misc->add_child(buttons);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -229,10 +229,6 @@ void DependencyEditor::edit(const String &p_path) {
 }
 
 void DependencyEditor::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_searched"), &DependencyEditor::_searched);
-	ClassDB::bind_method(D_METHOD("_load_pressed"), &DependencyEditor::_load_pressed);
-	ClassDB::bind_method(D_METHOD("_fix_all"), &DependencyEditor::_fix_all);
 }
 
 DependencyEditor::DependencyEditor() {
@@ -247,7 +243,7 @@ DependencyEditor::DependencyEditor() {
 	tree->set_column_title(0, TTR("Resource"));
 	tree->set_column_title(1, TTR("Path"));
 	tree->set_hide_root(true);
-	tree->connect_compat("button_pressed", this, "_load_pressed");
+	tree->connect("button_pressed", callable_mp(this, &DependencyEditor::_load_pressed));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	Label *label = memnew(Label(TTR("Dependencies:")));
@@ -255,7 +251,7 @@ DependencyEditor::DependencyEditor() {
 	hbc->add_spacer();
 	fixdeps = memnew(Button(TTR("Fix Broken")));
 	hbc->add_child(fixdeps);
-	fixdeps->connect_compat("pressed", this, "_fix_all");
+	fixdeps->connect("pressed", callable_mp(this, &DependencyEditor::_fix_all));
 
 	vb->add_child(hbc);
 
@@ -267,7 +263,7 @@ DependencyEditor::DependencyEditor() {
 
 	set_title(TTR("Dependency Editor"));
 	search = memnew(EditorFileDialog);
-	search->connect_compat("file_selected", this, "_searched");
+	search->connect("file_selected", callable_mp(this, &DependencyEditor::_searched));
 	search->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	search->set_title(TTR("Search Replacement Resource:"));
 	add_child(search);
@@ -310,10 +306,6 @@ void DependencyEditorOwners::_file_option(int p_option) {
 }
 
 void DependencyEditorOwners::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_list_rmb_select"), &DependencyEditorOwners::_list_rmb_select);
-	ClassDB::bind_method(D_METHOD("_file_option"), &DependencyEditorOwners::_file_option);
-	ClassDB::bind_method(D_METHOD("_select_file"), &DependencyEditorOwners::_select_file);
 }
 
 void DependencyEditorOwners::_fill_owners(EditorFileSystemDirectory *efsd) {
@@ -360,12 +352,12 @@ DependencyEditorOwners::DependencyEditorOwners(EditorNode *p_editor) {
 
 	file_options = memnew(PopupMenu);
 	add_child(file_options);
-	file_options->connect_compat("id_pressed", this, "_file_option");
+	file_options->connect("id_pressed", callable_mp(this, &DependencyEditorOwners::_file_option));
 
 	owners = memnew(ItemList);
 	owners->set_select_mode(ItemList::SELECT_SINGLE);
-	owners->connect_compat("item_rmb_selected", this, "_list_rmb_select");
-	owners->connect_compat("item_activated", this, "_select_file");
+	owners->connect("item_rmb_selected", callable_mp(this, &DependencyEditorOwners::_list_rmb_select));
+	owners->connect("item_activated", callable_mp(this, &DependencyEditorOwners::_select_file));
 	owners->set_allow_rmb_select(true);
 	add_child(owners);
 }
@@ -787,9 +779,6 @@ void OrphanResourcesDialog::_button_pressed(Object *p_item, int p_column, int p_
 }
 
 void OrphanResourcesDialog::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_delete_confirm"), &OrphanResourcesDialog::_delete_confirm);
-	ClassDB::bind_method(D_METHOD("_button_pressed"), &OrphanResourcesDialog::_button_pressed);
 }
 
 OrphanResourcesDialog::OrphanResourcesDialog() {
@@ -800,7 +789,7 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 	add_child(delete_confirm);
 	dep_edit = memnew(DependencyEditor);
 	add_child(dep_edit);
-	delete_confirm->connect_compat("confirmed", this, "_delete_confirm");
+	delete_confirm->connect("confirmed", callable_mp(this, &OrphanResourcesDialog::_delete_confirm));
 	set_hide_on_ok(false);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
@@ -816,5 +805,5 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 	files->set_column_title(1, TTR("Owns"));
 	files->set_hide_root(true);
 	vbc->add_margin_child(TTR("Resources Without Explicit Ownership:"), files, true);
-	files->connect_compat("button_pressed", this, "_button_pressed");
+	files->connect("button_pressed", callable_mp(this, &OrphanResourcesDialog::_button_pressed));
 }

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -63,8 +63,6 @@ void EditorAbout::_license_tree_selected() {
 }
 
 void EditorAbout::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_license_tree_selected"), &EditorAbout::_license_tree_selected);
 }
 
 TextureRect *EditorAbout::get_logo() const {
@@ -255,7 +253,7 @@ EditorAbout::EditorAbout() {
 	_tpl_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tpl_hbc->add_child(_tpl_text);
 
-	_tpl_tree->connect_compat("item_selected", this, "_license_tree_selected");
+	_tpl_tree->connect("item_selected", callable_mp(this, &EditorAbout::_license_tree_selected));
 	tpl_ti_all->select(0);
 	_tpl_text->set_text(tpl_ti_all->get_metadata(0));
 }

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -307,8 +307,6 @@ void EditorAssetInstaller::ok_pressed() {
 }
 
 void EditorAssetInstaller::_bind_methods() {
-
-	ClassDB::bind_method("_item_edited", &EditorAssetInstaller::_item_edited);
 }
 
 EditorAssetInstaller::EditorAssetInstaller() {
@@ -318,7 +316,7 @@ EditorAssetInstaller::EditorAssetInstaller() {
 
 	tree = memnew(Tree);
 	vb->add_margin_child(TTR("Package Contents:"), tree, true);
-	tree->connect_compat("item_edited", this, "_item_edited");
+	tree->connect("item_edited", callable_mp(this, &EditorAssetInstaller::_item_edited));
 
 	error = memnew(AcceptDialog);
 	add_child(error);

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -757,25 +757,10 @@ void EditorAudioBus::_bind_methods() {
 
 	ClassDB::bind_method("update_bus", &EditorAudioBus::update_bus);
 	ClassDB::bind_method("update_send", &EditorAudioBus::update_send);
-	ClassDB::bind_method("_name_changed", &EditorAudioBus::_name_changed);
-	ClassDB::bind_method("_volume_changed", &EditorAudioBus::_volume_changed);
-	ClassDB::bind_method("_show_value", &EditorAudioBus::_show_value);
-	ClassDB::bind_method("_hide_value_preview", &EditorAudioBus::_hide_value_preview);
-	ClassDB::bind_method("_solo_toggled", &EditorAudioBus::_solo_toggled);
-	ClassDB::bind_method("_mute_toggled", &EditorAudioBus::_mute_toggled);
-	ClassDB::bind_method("_bypass_toggled", &EditorAudioBus::_bypass_toggled);
-	ClassDB::bind_method("_name_focus_exit", &EditorAudioBus::_name_focus_exit);
-	ClassDB::bind_method("_send_selected", &EditorAudioBus::_send_selected);
-	ClassDB::bind_method("_effect_edited", &EditorAudioBus::_effect_edited);
-	ClassDB::bind_method("_effect_selected", &EditorAudioBus::_effect_selected);
-	ClassDB::bind_method("_effect_add", &EditorAudioBus::_effect_add);
 	ClassDB::bind_method("_gui_input", &EditorAudioBus::_gui_input);
-	ClassDB::bind_method("_bus_popup_pressed", &EditorAudioBus::_bus_popup_pressed);
 	ClassDB::bind_method("get_drag_data_fw", &EditorAudioBus::get_drag_data_fw);
 	ClassDB::bind_method("can_drop_data_fw", &EditorAudioBus::can_drop_data_fw);
 	ClassDB::bind_method("drop_data_fw", &EditorAudioBus::drop_data_fw);
-	ClassDB::bind_method("_delete_effect_pressed", &EditorAudioBus::_delete_effect_pressed);
-	ClassDB::bind_method("_effect_rmb", &EditorAudioBus::_effect_rmb);
 
 	ADD_SIGNAL(MethodInfo("duplicate_request"));
 	ADD_SIGNAL(MethodInfo("delete_request"));
@@ -799,8 +784,8 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	set_v_size_flags(SIZE_EXPAND_FILL);
 
 	track_name = memnew(LineEdit);
-	track_name->connect_compat("text_entered", this, "_name_changed");
-	track_name->connect_compat("focus_exited", this, "_name_focus_exit");
+	track_name->connect("text_entered", callable_mp(this, &EditorAudioBus::_name_changed));
+	track_name->connect("focus_exited", callable_mp(this, &EditorAudioBus::_name_focus_exit));
 	vb->add_child(track_name);
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
@@ -809,19 +794,19 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	solo->set_toggle_mode(true);
 	solo->set_tooltip(TTR("Solo"));
 	solo->set_focus_mode(FOCUS_NONE);
-	solo->connect_compat("pressed", this, "_solo_toggled");
+	solo->connect("pressed", callable_mp(this, &EditorAudioBus::_solo_toggled));
 	hbc->add_child(solo);
 	mute = memnew(ToolButton);
 	mute->set_toggle_mode(true);
 	mute->set_tooltip(TTR("Mute"));
 	mute->set_focus_mode(FOCUS_NONE);
-	mute->connect_compat("pressed", this, "_mute_toggled");
+	mute->connect("pressed", callable_mp(this, &EditorAudioBus::_mute_toggled));
 	hbc->add_child(mute);
 	bypass = memnew(ToolButton);
 	bypass->set_toggle_mode(true);
 	bypass->set_tooltip(TTR("Bypass"));
 	bypass->set_focus_mode(FOCUS_NONE);
-	bypass->connect_compat("pressed", this, "_bypass_toggled");
+	bypass->connect("pressed", callable_mp(this, &EditorAudioBus::_bypass_toggled));
 	hbc->add_child(bypass);
 	hbc->add_spacer();
 
@@ -878,9 +863,9 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	preview_timer->set_one_shot(true);
 	add_child(preview_timer);
 
-	slider->connect_compat("value_changed", this, "_volume_changed");
-	slider->connect_compat("value_changed", this, "_show_value");
-	preview_timer->connect_compat("timeout", this, "_hide_value_preview");
+	slider->connect("value_changed", callable_mp(this, &EditorAudioBus::_volume_changed));
+	slider->connect("value_changed", callable_mp(this, &EditorAudioBus::_show_value));
+	preview_timer->connect("timeout", callable_mp(this, &EditorAudioBus::_hide_value_preview));
 	hb->add_child(slider);
 
 	cc = 0;
@@ -918,24 +903,24 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	effects->set_hide_folding(true);
 	effects->set_v_size_flags(SIZE_EXPAND_FILL);
 	vb->add_child(effects);
-	effects->connect_compat("item_edited", this, "_effect_edited");
-	effects->connect_compat("cell_selected", this, "_effect_selected");
+	effects->connect("item_edited", callable_mp(this, &EditorAudioBus::_effect_edited));
+	effects->connect("cell_selected", callable_mp(this, &EditorAudioBus::_effect_selected));
 	effects->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
 	effects->set_drag_forwarding(this);
-	effects->connect_compat("item_rmb_selected", this, "_effect_rmb");
+	effects->connect("item_rmb_selected", callable_mp(this, &EditorAudioBus::_effect_rmb));
 	effects->set_allow_rmb_select(true);
 	effects->set_focus_mode(FOCUS_CLICK);
 	effects->set_allow_reselect(true);
 
 	send = memnew(OptionButton);
 	send->set_clip_text(true);
-	send->connect_compat("item_selected", this, "_send_selected");
+	send->connect("item_selected", callable_mp(this, &EditorAudioBus::_send_selected));
 	vb->add_child(send);
 
 	set_focus_mode(FOCUS_CLICK);
 
 	effect_options = memnew(PopupMenu);
-	effect_options->connect_compat("index_pressed", this, "_effect_add");
+	effect_options->connect("index_pressed", callable_mp(this, &EditorAudioBus::_effect_add));
 	add_child(effect_options);
 	List<StringName> effects;
 	ClassDB::get_inheriters_from_class("AudioEffect", &effects);
@@ -956,12 +941,12 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	bus_popup->add_item(TTR("Delete"));
 	bus_popup->set_item_disabled(1, is_master);
 	bus_popup->add_item(TTR("Reset Volume"));
-	bus_popup->connect_compat("index_pressed", this, "_bus_popup_pressed");
+	bus_popup->connect("index_pressed", callable_mp(this, &EditorAudioBus::_bus_popup_pressed));
 
 	delete_effect_popup = memnew(PopupMenu);
 	delete_effect_popup->add_item(TTR("Delete Effect"));
 	add_child(delete_effect_popup);
-	delete_effect_popup->connect_compat("index_pressed", this, "_delete_effect_pressed");
+	delete_effect_popup->connect("index_pressed", callable_mp(this, &EditorAudioBus::_delete_effect_pressed));
 }
 
 void EditorAudioBusDrop::_notification(int p_what) {
@@ -1029,11 +1014,11 @@ void EditorAudioBuses::_update_buses() {
 		bool is_master = (i == 0);
 		EditorAudioBus *audio_bus = memnew(EditorAudioBus(this, is_master));
 		bus_hb->add_child(audio_bus);
-		audio_bus->connect_compat("delete_request", this, "_delete_bus", varray(audio_bus), CONNECT_DEFERRED);
-		audio_bus->connect_compat("duplicate_request", this, "_duplicate_bus", varray(), CONNECT_DEFERRED);
-		audio_bus->connect_compat("vol_reset_request", this, "_reset_bus_volume", varray(audio_bus), CONNECT_DEFERRED);
-		audio_bus->connect_compat("drop_end_request", this, "_request_drop_end");
-		audio_bus->connect_compat("dropped", this, "_drop_at_index", varray(), CONNECT_DEFERRED);
+		audio_bus->connect("delete_request", callable_mp(this, &EditorAudioBuses::_delete_bus), varray(audio_bus), CONNECT_DEFERRED);
+		audio_bus->connect("duplicate_request", callable_mp(this, &EditorAudioBuses::_duplicate_bus), varray(), CONNECT_DEFERRED);
+		audio_bus->connect("vol_reset_request", callable_mp(this, &EditorAudioBuses::_reset_bus_volume), varray(audio_bus), CONNECT_DEFERRED);
+		audio_bus->connect("drop_end_request", callable_mp(this, &EditorAudioBuses::_request_drop_end));
+		audio_bus->connect("dropped", callable_mp(this, &EditorAudioBuses::_drop_at_index), varray(), CONNECT_DEFERRED);
 	}
 }
 
@@ -1187,7 +1172,7 @@ void EditorAudioBuses::_request_drop_end() {
 
 		bus_hb->add_child(drop_end);
 		drop_end->set_custom_minimum_size(Object::cast_to<Control>(bus_hb->get_child(0))->get_size());
-		drop_end->connect_compat("dropped", this, "_drop_at_index", varray(), CONNECT_DEFERRED);
+		drop_end->connect("dropped", callable_mp(this, &EditorAudioBuses::_drop_at_index), varray(), CONNECT_DEFERRED);
 	}
 }
 
@@ -1303,23 +1288,10 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 
 void EditorAudioBuses::_bind_methods() {
 
-	ClassDB::bind_method("_add_bus", &EditorAudioBuses::_add_bus);
 	ClassDB::bind_method("_update_buses", &EditorAudioBuses::_update_buses);
 	ClassDB::bind_method("_update_bus", &EditorAudioBuses::_update_bus);
 	ClassDB::bind_method("_update_sends", &EditorAudioBuses::_update_sends);
-	ClassDB::bind_method("_delete_bus", &EditorAudioBuses::_delete_bus);
-	ClassDB::bind_method("_request_drop_end", &EditorAudioBuses::_request_drop_end);
-	ClassDB::bind_method("_drop_at_index", &EditorAudioBuses::_drop_at_index);
-	ClassDB::bind_method("_server_save", &EditorAudioBuses::_server_save);
 	ClassDB::bind_method("_select_layout", &EditorAudioBuses::_select_layout);
-	ClassDB::bind_method("_save_as_layout", &EditorAudioBuses::_save_as_layout);
-	ClassDB::bind_method("_load_layout", &EditorAudioBuses::_load_layout);
-	ClassDB::bind_method("_load_default_layout", &EditorAudioBuses::_load_default_layout);
-	ClassDB::bind_method("_new_layout", &EditorAudioBuses::_new_layout);
-	ClassDB::bind_method("_duplicate_bus", &EditorAudioBuses::_duplicate_bus);
-	ClassDB::bind_method("_reset_bus_volume", &EditorAudioBuses::_reset_bus_volume);
-
-	ClassDB::bind_method("_file_dialog_callback", &EditorAudioBuses::_file_dialog_callback);
 }
 
 EditorAudioBuses::EditorAudioBuses() {
@@ -1339,7 +1311,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	top_hb->add_child(add);
 	add->set_text(TTR("Add Bus"));
 	add->set_tooltip(TTR("Add a new Audio Bus to this layout."));
-	add->connect_compat("pressed", this, "_add_bus");
+	add->connect("pressed", callable_mp(this, &EditorAudioBuses::_add_bus));
 
 	VSeparator *separator = memnew(VSeparator);
 	top_hb->add_child(separator);
@@ -1348,25 +1320,25 @@ EditorAudioBuses::EditorAudioBuses() {
 	load->set_text(TTR("Load"));
 	load->set_tooltip(TTR("Load an existing Bus Layout."));
 	top_hb->add_child(load);
-	load->connect_compat("pressed", this, "_load_layout");
+	load->connect("pressed", callable_mp(this, &EditorAudioBuses::_load_layout));
 
 	save_as = memnew(Button);
 	save_as->set_text(TTR("Save As"));
 	save_as->set_tooltip(TTR("Save this Bus Layout to a file."));
 	top_hb->add_child(save_as);
-	save_as->connect_compat("pressed", this, "_save_as_layout");
+	save_as->connect("pressed", callable_mp(this, &EditorAudioBuses::_save_as_layout));
 
 	_default = memnew(Button);
 	_default->set_text(TTR("Load Default"));
 	_default->set_tooltip(TTR("Load the default Bus Layout."));
 	top_hb->add_child(_default);
-	_default->connect_compat("pressed", this, "_load_default_layout");
+	_default->connect("pressed", callable_mp(this, &EditorAudioBuses::_load_default_layout));
 
 	_new = memnew(Button);
 	_new->set_text(TTR("Create"));
 	_new->set_tooltip(TTR("Create a new Bus Layout."));
 	top_hb->add_child(_new);
-	_new->connect_compat("pressed", this, "_new_layout");
+	_new->connect("pressed", callable_mp(this, &EditorAudioBuses::_new_layout));
 
 	bus_scroll = memnew(ScrollContainer);
 	bus_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -1381,7 +1353,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	save_timer->set_wait_time(0.8);
 	save_timer->set_one_shot(true);
 	add_child(save_timer);
-	save_timer->connect_compat("timeout", this, "_server_save");
+	save_timer->connect("timeout", callable_mp(this, &EditorAudioBuses::_server_save));
 
 	set_v_size_flags(SIZE_EXPAND_FILL);
 
@@ -1394,7 +1366,7 @@ EditorAudioBuses::EditorAudioBuses() {
 		file_dialog->add_filter("*." + E->get() + "; Audio Bus Layout");
 	}
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_file_dialog_callback");
+	file_dialog->connect("file_selected", callable_mp(this, &EditorAudioBuses::_file_dialog_callback));
 
 	set_process(true);
 }

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -736,16 +736,7 @@ void EditorAutoloadSettings::autoload_remove(const String &p_name) {
 
 void EditorAutoloadSettings::_bind_methods() {
 
-	ClassDB::bind_method("_autoload_add", &EditorAutoloadSettings::_autoload_add);
-	ClassDB::bind_method("_autoload_selected", &EditorAutoloadSettings::_autoload_selected);
-	ClassDB::bind_method("_autoload_edited", &EditorAutoloadSettings::_autoload_edited);
-	ClassDB::bind_method("_autoload_button_pressed", &EditorAutoloadSettings::_autoload_button_pressed);
-	ClassDB::bind_method("_autoload_activated", &EditorAutoloadSettings::_autoload_activated);
-	ClassDB::bind_method("_autoload_path_text_changed", &EditorAutoloadSettings::_autoload_path_text_changed);
-	ClassDB::bind_method("_autoload_text_entered", &EditorAutoloadSettings::_autoload_text_entered);
-	ClassDB::bind_method("_autoload_text_changed", &EditorAutoloadSettings::_autoload_text_changed);
 	ClassDB::bind_method("_autoload_open", &EditorAutoloadSettings::_autoload_open);
-	ClassDB::bind_method("_autoload_file_callback", &EditorAutoloadSettings::_autoload_file_callback);
 
 	ClassDB::bind_method("get_drag_data_fw", &EditorAutoloadSettings::get_drag_data_fw);
 	ClassDB::bind_method("can_drop_data_fw", &EditorAutoloadSettings::can_drop_data_fw);
@@ -835,8 +826,8 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	autoload_add_path = memnew(EditorLineEditFileChooser);
 	autoload_add_path->set_h_size_flags(SIZE_EXPAND_FILL);
 	autoload_add_path->get_file_dialog()->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	autoload_add_path->get_file_dialog()->connect_compat("file_selected", this, "_autoload_file_callback");
-	autoload_add_path->get_line_edit()->connect_compat("text_changed", this, "_autoload_path_text_changed");
+	autoload_add_path->get_file_dialog()->connect("file_selected", callable_mp(this, &EditorAutoloadSettings::_autoload_file_callback));
+	autoload_add_path->get_line_edit()->connect("text_changed", callable_mp(this, &EditorAutoloadSettings::_autoload_path_text_changed));
 
 	hbc->add_child(autoload_add_path);
 
@@ -846,13 +837,13 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	autoload_add_name = memnew(LineEdit);
 	autoload_add_name->set_h_size_flags(SIZE_EXPAND_FILL);
-	autoload_add_name->connect_compat("text_entered", this, "_autoload_text_entered");
-	autoload_add_name->connect_compat("text_changed", this, "_autoload_text_changed");
+	autoload_add_name->connect("text_entered", callable_mp(this, &EditorAutoloadSettings::_autoload_text_entered));
+	autoload_add_name->connect("text_changed", callable_mp(this, &EditorAutoloadSettings::_autoload_text_changed));
 	hbc->add_child(autoload_add_name);
 
 	add_autoload = memnew(Button);
 	add_autoload->set_text(TTR("Add"));
-	add_autoload->connect_compat("pressed", this, "_autoload_add");
+	add_autoload->connect("pressed", callable_mp(this, &EditorAutoloadSettings::_autoload_add));
 	// The button will be enabled once a valid name is entered (either automatically or manually).
 	add_autoload->set_disabled(true);
 	hbc->add_child(add_autoload);
@@ -882,10 +873,10 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	tree->set_column_expand(3, false);
 	tree->set_column_min_width(3, 120 * EDSCALE);
 
-	tree->connect_compat("cell_selected", this, "_autoload_selected");
-	tree->connect_compat("item_edited", this, "_autoload_edited");
-	tree->connect_compat("button_pressed", this, "_autoload_button_pressed");
-	tree->connect_compat("item_activated", this, "_autoload_activated");
+	tree->connect("cell_selected", callable_mp(this, &EditorAutoloadSettings::_autoload_selected));
+	tree->connect("item_edited", callable_mp(this, &EditorAutoloadSettings::_autoload_edited));
+	tree->connect("button_pressed", callable_mp(this, &EditorAutoloadSettings::_autoload_button_pressed));
+	tree->connect("item_activated", callable_mp(this, &EditorAutoloadSettings::_autoload_activated));
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	add_child(tree, true);

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1024,7 +1024,7 @@ void EditorSelection::add_node(Node *p_node) {
 	}
 	selection[p_node] = meta;
 
-	p_node->connect_compat("tree_exiting", this, "_node_removed", varray(p_node), CONNECT_ONESHOT);
+	p_node->connect("tree_exiting", callable_mp(this, &EditorSelection::_node_removed), varray(p_node), CONNECT_ONESHOT);
 
 	//emit_signal("selection_changed");
 }
@@ -1042,7 +1042,7 @@ void EditorSelection::remove_node(Node *p_node) {
 	if (meta)
 		memdelete(meta);
 	selection.erase(p_node);
-	p_node->disconnect_compat("tree_exiting", this, "_node_removed");
+	p_node->disconnect("tree_exiting", callable_mp(this, &EditorSelection::_node_removed));
 	//emit_signal("selection_changed");
 }
 bool EditorSelection::is_selected(Node *p_node) const {
@@ -1076,7 +1076,6 @@ Array EditorSelection::get_selected_nodes() {
 
 void EditorSelection::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_node_removed"), &EditorSelection::_node_removed);
 	ClassDB::bind_method(D_METHOD("clear"), &EditorSelection::clear);
 	ClassDB::bind_method(D_METHOD("add_node", "node"), &EditorSelection::add_node);
 	ClassDB::bind_method(D_METHOD("remove_node", "node"), &EditorSelection::remove_node);

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -83,7 +83,7 @@ void EditorDirDialog::reload(const String &p_path) {
 void EditorDirDialog::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload));
+		EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload), make_binds(""));
 		reload();
 
 		if (!tree->is_connected("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed))) {
@@ -91,7 +91,7 @@ void EditorDirDialog::_notification(int p_what) {
 		}
 
 		if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &EditorDirDialog::reload))) {
-			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload));
+			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload), make_binds(""));
 		}
 	}
 

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -82,21 +82,21 @@ void EditorDirDialog::reload(const String &p_path) {
 void EditorDirDialog::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "reload");
+		EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload));
 		reload();
 
-		if (!tree->is_connected_compat("item_collapsed", this, "_item_collapsed")) {
-			tree->connect_compat("item_collapsed", this, "_item_collapsed", varray(), CONNECT_DEFERRED);
+		if (!tree->is_connected("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed))) {
+			tree->connect("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed), varray(), CONNECT_DEFERRED);
 		}
 
-		if (!EditorFileSystem::get_singleton()->is_connected_compat("filesystem_changed", this, "reload")) {
-			EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "reload");
+		if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &EditorDirDialog::reload))) {
+			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload));
 		}
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
-		if (EditorFileSystem::get_singleton()->is_connected_compat("filesystem_changed", this, "reload")) {
-			EditorFileSystem::get_singleton()->disconnect_compat("filesystem_changed", this, "reload");
+		if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &EditorDirDialog::reload))) {
+			EditorFileSystem::get_singleton()->disconnect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload));
 		}
 	}
 
@@ -168,11 +168,6 @@ void EditorDirDialog::_make_dir_confirm() {
 
 void EditorDirDialog::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_item_collapsed"), &EditorDirDialog::_item_collapsed);
-	ClassDB::bind_method(D_METHOD("_make_dir"), &EditorDirDialog::_make_dir);
-	ClassDB::bind_method(D_METHOD("_make_dir_confirm"), &EditorDirDialog::_make_dir_confirm);
-	ClassDB::bind_method(D_METHOD("reload"), &EditorDirDialog::reload, DEFVAL(""));
-
 	ADD_SIGNAL(MethodInfo("dir_selected", PropertyInfo(Variant::STRING, "dir")));
 }
 
@@ -189,7 +184,7 @@ EditorDirDialog::EditorDirDialog() {
 	tree->connect_compat("item_activated", this, "_ok");
 
 	makedir = add_button(TTR("Create Folder"), OS::get_singleton()->get_swap_ok_cancel(), "makedir");
-	makedir->connect_compat("pressed", this, "_make_dir");
+	makedir->connect("pressed", callable_mp(this, &EditorDirDialog::_make_dir));
 
 	makedialog = memnew(ConfirmationDialog);
 	makedialog->set_title(TTR("Create Folder"));
@@ -202,7 +197,7 @@ EditorDirDialog::EditorDirDialog() {
 	makedirname = memnew(LineEdit);
 	makevb->add_margin_child(TTR("Name:"), makedirname);
 	makedialog->register_text_enter(makedirname);
-	makedialog->connect_compat("confirmed", this, "_make_dir_confirm");
+	makedialog->connect("confirmed", callable_mp(this, &EditorDirDialog::_make_dir_confirm));
 
 	mkdirerr = memnew(AcceptDialog);
 	mkdirerr->set_text(TTR("Could not create folder."));

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_file_system.h"
 #include "editor/editor_settings.h"
 #include "editor_scale.h"
+
 void EditorDirDialog::_update_dir(TreeItem *p_item, EditorFileSystemDirectory *p_dir, const String &p_select_path) {
 
 	updating = true;

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1213,8 +1213,6 @@ void EditorExport::save_presets() {
 }
 
 void EditorExport::_bind_methods() {
-
-	ClassDB::bind_method("_save", &EditorExport::_save);
 }
 
 void EditorExport::add_export_platform(const Ref<EditorExportPlatform> &p_platform) {
@@ -1416,7 +1414,7 @@ EditorExport::EditorExport() {
 	add_child(save_timer);
 	save_timer->set_wait_time(0.8);
 	save_timer->set_one_shot(true);
-	save_timer->connect_compat("timeout", this, "_save");
+	save_timer->connect("timeout", callable_mp(this, &EditorExport::_save));
 	block_save = false;
 
 	singleton = this;

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -792,16 +792,6 @@ EditorFeatureProfileManager *EditorFeatureProfileManager::singleton = NULL;
 void EditorFeatureProfileManager::_bind_methods() {
 
 	ClassDB::bind_method("_update_selected_profile", &EditorFeatureProfileManager::_update_selected_profile);
-	ClassDB::bind_method("_profile_action", &EditorFeatureProfileManager::_profile_action);
-	ClassDB::bind_method("_create_new_profile", &EditorFeatureProfileManager::_create_new_profile);
-	ClassDB::bind_method("_profile_selected", &EditorFeatureProfileManager::_profile_selected);
-	ClassDB::bind_method("_erase_selected_profile", &EditorFeatureProfileManager::_erase_selected_profile);
-	ClassDB::bind_method("_import_profiles", &EditorFeatureProfileManager::_import_profiles);
-	ClassDB::bind_method("_export_profile", &EditorFeatureProfileManager::_export_profile);
-	ClassDB::bind_method("_class_list_item_selected", &EditorFeatureProfileManager::_class_list_item_selected);
-	ClassDB::bind_method("_class_list_item_edited", &EditorFeatureProfileManager::_class_list_item_edited);
-	ClassDB::bind_method("_property_item_edited", &EditorFeatureProfileManager::_property_item_edited);
-	ClassDB::bind_method("_emit_current_profile_changed", &EditorFeatureProfileManager::_emit_current_profile_changed);
 
 	ADD_SIGNAL(MethodInfo("current_feature_profile_changed"));
 }
@@ -819,7 +809,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	profile_actions[PROFILE_CLEAR] = memnew(Button(TTR("Unset")));
 	name_hbc->add_child(profile_actions[PROFILE_CLEAR]);
 	profile_actions[PROFILE_CLEAR]->set_disabled(true);
-	profile_actions[PROFILE_CLEAR]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_CLEAR));
+	profile_actions[PROFILE_CLEAR]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_CLEAR));
 
 	main_vbc->add_margin_child(TTR("Current Profile:"), name_hbc);
 
@@ -827,34 +817,34 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	profile_list = memnew(OptionButton);
 	profile_list->set_h_size_flags(SIZE_EXPAND_FILL);
 	profiles_hbc->add_child(profile_list);
-	profile_list->connect_compat("item_selected", this, "_profile_selected");
+	profile_list->connect("item_selected", callable_mp(this, &EditorFeatureProfileManager::_profile_selected));
 
 	profile_actions[PROFILE_SET] = memnew(Button(TTR("Make Current")));
 	profiles_hbc->add_child(profile_actions[PROFILE_SET]);
 	profile_actions[PROFILE_SET]->set_disabled(true);
-	profile_actions[PROFILE_SET]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_SET));
+	profile_actions[PROFILE_SET]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_SET));
 
 	profile_actions[PROFILE_ERASE] = memnew(Button(TTR("Remove")));
 	profiles_hbc->add_child(profile_actions[PROFILE_ERASE]);
 	profile_actions[PROFILE_ERASE]->set_disabled(true);
-	profile_actions[PROFILE_ERASE]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_ERASE));
+	profile_actions[PROFILE_ERASE]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_ERASE));
 
 	profiles_hbc->add_child(memnew(VSeparator));
 
 	profile_actions[PROFILE_NEW] = memnew(Button(TTR("New")));
 	profiles_hbc->add_child(profile_actions[PROFILE_NEW]);
-	profile_actions[PROFILE_NEW]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_NEW));
+	profile_actions[PROFILE_NEW]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_NEW));
 
 	profiles_hbc->add_child(memnew(VSeparator));
 
 	profile_actions[PROFILE_IMPORT] = memnew(Button(TTR("Import")));
 	profiles_hbc->add_child(profile_actions[PROFILE_IMPORT]);
-	profile_actions[PROFILE_IMPORT]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_IMPORT));
+	profile_actions[PROFILE_IMPORT]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_IMPORT));
 
 	profile_actions[PROFILE_EXPORT] = memnew(Button(TTR("Export")));
 	profiles_hbc->add_child(profile_actions[PROFILE_EXPORT]);
 	profile_actions[PROFILE_EXPORT]->set_disabled(true);
-	profile_actions[PROFILE_EXPORT]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_EXPORT));
+	profile_actions[PROFILE_EXPORT]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_EXPORT));
 
 	main_vbc->add_margin_child(TTR("Available Profiles:"), profiles_hbc);
 
@@ -870,8 +860,8 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	class_list_vbc->add_margin_child(TTR("Enabled Classes:"), class_list, true);
 	class_list->set_hide_root(true);
 	class_list->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
-	class_list->connect_compat("cell_selected", this, "_class_list_item_selected");
-	class_list->connect_compat("item_edited", this, "_class_list_item_edited", varray(), CONNECT_DEFERRED);
+	class_list->connect("cell_selected", callable_mp(this, &EditorFeatureProfileManager::_class_list_item_selected));
+	class_list->connect("item_edited", callable_mp(this, &EditorFeatureProfileManager::_class_list_item_edited), varray(), CONNECT_DEFERRED);
 
 	VBoxContainer *property_list_vbc = memnew(VBoxContainer);
 	h_split->add_child(property_list_vbc);
@@ -882,7 +872,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	property_list->set_hide_root(true);
 	property_list->set_hide_folding(true);
 	property_list->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
-	property_list->connect_compat("item_edited", this, "_property_item_edited", varray(), CONNECT_DEFERRED);
+	property_list->connect("item_edited", callable_mp(this, &EditorFeatureProfileManager::_property_item_edited), varray(), CONNECT_DEFERRED);
 
 	new_profile_dialog = memnew(ConfirmationDialog);
 	new_profile_dialog->set_title(TTR("New profile name:"));
@@ -890,20 +880,20 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	new_profile_dialog->add_child(new_profile_name);
 	new_profile_name->set_custom_minimum_size(Size2(300 * EDSCALE, 1));
 	add_child(new_profile_dialog);
-	new_profile_dialog->connect_compat("confirmed", this, "_create_new_profile");
+	new_profile_dialog->connect("confirmed", callable_mp(this, &EditorFeatureProfileManager::_create_new_profile));
 	new_profile_dialog->register_text_enter(new_profile_name);
 	new_profile_dialog->get_ok()->set_text(TTR("Create"));
 
 	erase_profile_dialog = memnew(ConfirmationDialog);
 	add_child(erase_profile_dialog);
 	erase_profile_dialog->set_title(TTR("Erase Profile"));
-	erase_profile_dialog->connect_compat("confirmed", this, "_erase_selected_profile");
+	erase_profile_dialog->connect("confirmed", callable_mp(this, &EditorFeatureProfileManager::_erase_selected_profile));
 
 	import_profiles = memnew(EditorFileDialog);
 	add_child(import_profiles);
 	import_profiles->set_mode(EditorFileDialog::MODE_OPEN_FILES);
 	import_profiles->add_filter("*.profile; " + TTR("Godot Feature Profile"));
-	import_profiles->connect_compat("files_selected", this, "_import_profiles");
+	import_profiles->connect("files_selected", callable_mp(this, &EditorFeatureProfileManager::_import_profiles));
 	import_profiles->set_title(TTR("Import Profile(s)"));
 	import_profiles->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
@@ -911,7 +901,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	add_child(export_profile);
 	export_profile->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	export_profile->add_filter("*.profile; " + TTR("Godot Feature Profile"));
-	export_profile->connect_compat("file_selected", this, "_export_profile");
+	export_profile->connect("file_selected", callable_mp(this, &EditorFeatureProfileManager::_export_profile));
 	export_profile->set_title(TTR("Export Profile"));
 	export_profile->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
@@ -921,7 +911,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	update_timer = memnew(Timer);
 	update_timer->set_wait_time(1); //wait a second before updating editor
 	add_child(update_timer);
-	update_timer->connect_compat("timeout", this, "_emit_current_profile_changed");
+	update_timer->connect("timeout", callable_mp(this, &EditorFeatureProfileManager::_emit_current_profile_changed));
 	update_timer->set_one_shot(true);
 
 	updating_features = false;

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1364,19 +1364,7 @@ void EditorFileDialog::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_unhandled_input"), &EditorFileDialog::_unhandled_input);
 
-	ClassDB::bind_method(D_METHOD("_item_selected"), &EditorFileDialog::_item_selected);
-	ClassDB::bind_method(D_METHOD("_multi_selected"), &EditorFileDialog::_multi_selected);
-	ClassDB::bind_method(D_METHOD("_items_clear_selection"), &EditorFileDialog::_items_clear_selection);
-	ClassDB::bind_method(D_METHOD("_item_list_item_rmb_selected"), &EditorFileDialog::_item_list_item_rmb_selected);
-	ClassDB::bind_method(D_METHOD("_item_list_rmb_clicked"), &EditorFileDialog::_item_list_rmb_clicked);
-	ClassDB::bind_method(D_METHOD("_item_menu_id_pressed"), &EditorFileDialog::_item_menu_id_pressed);
-	ClassDB::bind_method(D_METHOD("_item_db_selected"), &EditorFileDialog::_item_dc_selected);
-	ClassDB::bind_method(D_METHOD("_dir_entered"), &EditorFileDialog::_dir_entered);
-	ClassDB::bind_method(D_METHOD("_file_entered"), &EditorFileDialog::_file_entered);
-	ClassDB::bind_method(D_METHOD("_action_pressed"), &EditorFileDialog::_action_pressed);
 	ClassDB::bind_method(D_METHOD("_cancel_pressed"), &EditorFileDialog::_cancel_pressed);
-	ClassDB::bind_method(D_METHOD("_filter_selected"), &EditorFileDialog::_filter_selected);
-	ClassDB::bind_method(D_METHOD("_save_confirm_pressed"), &EditorFileDialog::_save_confirm_pressed);
 
 	ClassDB::bind_method(D_METHOD("clear_filters"), &EditorFileDialog::clear_filters);
 	ClassDB::bind_method(D_METHOD("add_filter", "filter"), &EditorFileDialog::add_filter);
@@ -1391,30 +1379,14 @@ void EditorFileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vbox"), &EditorFileDialog::get_vbox);
 	ClassDB::bind_method(D_METHOD("set_access", "access"), &EditorFileDialog::set_access);
 	ClassDB::bind_method(D_METHOD("get_access"), &EditorFileDialog::get_access);
-	ClassDB::bind_method(D_METHOD("set_show_hidden_files", "show"), &EditorFileDialog::set_show_hidden_files);
 	ClassDB::bind_method(D_METHOD("is_showing_hidden_files"), &EditorFileDialog::is_showing_hidden_files);
-	ClassDB::bind_method(D_METHOD("_select_drive"), &EditorFileDialog::_select_drive);
-	ClassDB::bind_method(D_METHOD("_make_dir"), &EditorFileDialog::_make_dir);
-	ClassDB::bind_method(D_METHOD("_make_dir_confirm"), &EditorFileDialog::_make_dir_confirm);
 	ClassDB::bind_method(D_METHOD("_update_file_name"), &EditorFileDialog::update_file_name);
-	ClassDB::bind_method(D_METHOD("_update_file_list"), &EditorFileDialog::update_file_list);
 	ClassDB::bind_method(D_METHOD("_update_dir"), &EditorFileDialog::update_dir);
 	ClassDB::bind_method(D_METHOD("_thumbnail_done"), &EditorFileDialog::_thumbnail_done);
-	ClassDB::bind_method(D_METHOD("set_display_mode", "mode"), &EditorFileDialog::set_display_mode);
 	ClassDB::bind_method(D_METHOD("get_display_mode"), &EditorFileDialog::get_display_mode);
 	ClassDB::bind_method(D_METHOD("_thumbnail_result"), &EditorFileDialog::_thumbnail_result);
 	ClassDB::bind_method(D_METHOD("set_disable_overwrite_warning", "disable"), &EditorFileDialog::set_disable_overwrite_warning);
 	ClassDB::bind_method(D_METHOD("is_overwrite_warning_disabled"), &EditorFileDialog::is_overwrite_warning_disabled);
-
-	ClassDB::bind_method(D_METHOD("_recent_selected"), &EditorFileDialog::_recent_selected);
-	ClassDB::bind_method(D_METHOD("_go_back"), &EditorFileDialog::_go_back);
-	ClassDB::bind_method(D_METHOD("_go_forward"), &EditorFileDialog::_go_forward);
-	ClassDB::bind_method(D_METHOD("_go_up"), &EditorFileDialog::_go_up);
-
-	ClassDB::bind_method(D_METHOD("_favorite_pressed"), &EditorFileDialog::_favorite_pressed);
-	ClassDB::bind_method(D_METHOD("_favorite_selected"), &EditorFileDialog::_favorite_selected);
-	ClassDB::bind_method(D_METHOD("_favorite_move_up"), &EditorFileDialog::_favorite_move_up);
-	ClassDB::bind_method(D_METHOD("_favorite_move_down"), &EditorFileDialog::_favorite_move_down);
 
 	ClassDB::bind_method(D_METHOD("invalidate"), &EditorFileDialog::invalidate);
 
@@ -1537,9 +1509,9 @@ EditorFileDialog::EditorFileDialog() {
 	pathhb->add_child(dir_next);
 	pathhb->add_child(dir_up);
 
-	dir_prev->connect_compat("pressed", this, "_go_back");
-	dir_next->connect_compat("pressed", this, "_go_forward");
-	dir_up->connect_compat("pressed", this, "_go_up");
+	dir_prev->connect("pressed", callable_mp(this, &EditorFileDialog::_go_back));
+	dir_next->connect("pressed", callable_mp(this, &EditorFileDialog::_go_forward));
+	dir_up->connect("pressed", callable_mp(this, &EditorFileDialog::_go_up));
 
 	pathhb->add_child(memnew(Label(TTR("Path:"))));
 
@@ -1549,20 +1521,20 @@ EditorFileDialog::EditorFileDialog() {
 
 	refresh = memnew(ToolButton);
 	refresh->set_tooltip(TTR("Refresh files."));
-	refresh->connect_compat("pressed", this, "_update_file_list");
+	refresh->connect("pressed", callable_mp(this, &EditorFileDialog::update_file_list));
 	pathhb->add_child(refresh);
 
 	favorite = memnew(ToolButton);
 	favorite->set_toggle_mode(true);
 	favorite->set_tooltip(TTR("(Un)favorite current folder."));
-	favorite->connect_compat("pressed", this, "_favorite_pressed");
+	favorite->connect("pressed", callable_mp(this, &EditorFileDialog::_favorite_pressed));
 	pathhb->add_child(favorite);
 
 	show_hidden = memnew(ToolButton);
 	show_hidden->set_toggle_mode(true);
 	show_hidden->set_pressed(is_showing_hidden_files());
 	show_hidden->set_tooltip(TTR("Toggle the visibility of hidden files."));
-	show_hidden->connect_compat("toggled", this, "set_show_hidden_files");
+	show_hidden->connect("toggled", callable_mp(this, &EditorFileDialog::set_show_hidden_files));
 	pathhb->add_child(show_hidden);
 
 	pathhb->add_child(memnew(VSeparator));
@@ -1571,7 +1543,7 @@ EditorFileDialog::EditorFileDialog() {
 	view_mode_group.instance();
 
 	mode_thumbnails = memnew(ToolButton);
-	mode_thumbnails->connect_compat("pressed", this, "set_display_mode", varray(DISPLAY_THUMBNAILS));
+	mode_thumbnails->connect("pressed", callable_mp(this, &EditorFileDialog::set_display_mode), varray(DISPLAY_THUMBNAILS));
 	mode_thumbnails->set_toggle_mode(true);
 	mode_thumbnails->set_pressed(display_mode == DISPLAY_THUMBNAILS);
 	mode_thumbnails->set_button_group(view_mode_group);
@@ -1579,7 +1551,7 @@ EditorFileDialog::EditorFileDialog() {
 	pathhb->add_child(mode_thumbnails);
 
 	mode_list = memnew(ToolButton);
-	mode_list->connect_compat("pressed", this, "set_display_mode", varray(DISPLAY_LIST));
+	mode_list->connect("pressed", callable_mp(this, &EditorFileDialog::set_display_mode), varray(DISPLAY_LIST));
 	mode_list->set_toggle_mode(true);
 	mode_list->set_pressed(display_mode == DISPLAY_LIST);
 	mode_list->set_button_group(view_mode_group);
@@ -1588,11 +1560,11 @@ EditorFileDialog::EditorFileDialog() {
 
 	drives = memnew(OptionButton);
 	pathhb->add_child(drives);
-	drives->connect_compat("item_selected", this, "_select_drive");
+	drives->connect("item_selected", callable_mp(this, &EditorFileDialog::_select_drive));
 
 	makedir = memnew(Button);
 	makedir->set_text(TTR("Create Folder"));
-	makedir->connect_compat("pressed", this, "_make_dir");
+	makedir->connect("pressed", callable_mp(this, &EditorFileDialog::_make_dir));
 	pathhb->add_child(makedir);
 
 	list_hb = memnew(HSplitContainer);
@@ -1614,15 +1586,15 @@ EditorFileDialog::EditorFileDialog() {
 	fav_hb->add_spacer();
 	fav_up = memnew(ToolButton);
 	fav_hb->add_child(fav_up);
-	fav_up->connect_compat("pressed", this, "_favorite_move_up");
+	fav_up->connect("pressed", callable_mp(this, &EditorFileDialog::_favorite_move_up));
 	fav_down = memnew(ToolButton);
 	fav_hb->add_child(fav_down);
-	fav_down->connect_compat("pressed", this, "_favorite_move_down");
+	fav_down->connect("pressed", callable_mp(this, &EditorFileDialog::_favorite_move_down));
 
 	favorites = memnew(ItemList);
 	fav_vb->add_child(favorites);
 	favorites->set_v_size_flags(SIZE_EXPAND_FILL);
-	favorites->connect_compat("item_selected", this, "_favorite_selected");
+	favorites->connect("item_selected", callable_mp(this, &EditorFileDialog::_favorite_selected));
 
 	VBoxContainer *rec_vb = memnew(VBoxContainer);
 	vsc->add_child(rec_vb);
@@ -1631,7 +1603,7 @@ EditorFileDialog::EditorFileDialog() {
 	recent = memnew(ItemList);
 	recent->set_allow_reselect(true);
 	rec_vb->add_margin_child(TTR("Recent:"), recent, true);
-	recent->connect_compat("item_selected", this, "_recent_selected");
+	recent->connect("item_selected", callable_mp(this, &EditorFileDialog::_recent_selected));
 
 	VBoxContainer *item_vb = memnew(VBoxContainer);
 	list_hb->add_child(item_vb);
@@ -1650,13 +1622,13 @@ EditorFileDialog::EditorFileDialog() {
 
 	item_list = memnew(ItemList);
 	item_list->set_v_size_flags(SIZE_EXPAND_FILL);
-	item_list->connect_compat("item_rmb_selected", this, "_item_list_item_rmb_selected");
-	item_list->connect_compat("rmb_clicked", this, "_item_list_rmb_clicked");
+	item_list->connect("item_rmb_selected", callable_mp(this, &EditorFileDialog::_item_list_item_rmb_selected));
+	item_list->connect("rmb_clicked", callable_mp(this, &EditorFileDialog::_item_list_rmb_clicked));
 	item_list->set_allow_rmb_select(true);
 	list_vb->add_child(item_list);
 
 	item_menu = memnew(PopupMenu);
-	item_menu->connect_compat("id_pressed", this, "_item_menu_id_pressed");
+	item_menu->connect("id_pressed", callable_mp(this, &EditorFileDialog::_item_menu_id_pressed));
 	add_child(item_menu);
 
 	// Other stuff.
@@ -1687,19 +1659,19 @@ EditorFileDialog::EditorFileDialog() {
 	access = ACCESS_RESOURCES;
 	_update_drives();
 
-	connect_compat("confirmed", this, "_action_pressed");
-	item_list->connect_compat("item_selected", this, "_item_selected", varray(), CONNECT_DEFERRED);
-	item_list->connect_compat("multi_selected", this, "_multi_selected", varray(), CONNECT_DEFERRED);
-	item_list->connect_compat("item_activated", this, "_item_db_selected", varray());
-	item_list->connect_compat("nothing_selected", this, "_items_clear_selection");
-	dir->connect_compat("text_entered", this, "_dir_entered");
-	file->connect_compat("text_entered", this, "_file_entered");
-	filter->connect_compat("item_selected", this, "_filter_selected");
+	connect("confirmed", callable_mp(this, &EditorFileDialog::_action_pressed));
+	item_list->connect("item_selected", callable_mp(this, &EditorFileDialog::_item_selected), varray(), CONNECT_DEFERRED);
+	item_list->connect("multi_selected", callable_mp(this, &EditorFileDialog::_multi_selected), varray(), CONNECT_DEFERRED);
+	item_list->connect("item_activated", callable_mp(this, &EditorFileDialog::_item_dc_selected), varray());
+	item_list->connect("nothing_selected", callable_mp(this, &EditorFileDialog::_items_clear_selection));
+	dir->connect("text_entered", callable_mp(this, &EditorFileDialog::_dir_entered));
+	file->connect("text_entered", callable_mp(this, &EditorFileDialog::_file_entered));
+	filter->connect("item_selected", callable_mp(this, &EditorFileDialog::_filter_selected));
 
 	confirm_save = memnew(ConfirmationDialog);
 	confirm_save->set_as_toplevel(true);
 	add_child(confirm_save);
-	confirm_save->connect_compat("confirmed", this, "_save_confirm_pressed");
+	confirm_save->connect("confirmed", callable_mp(this, &EditorFileDialog::_save_confirm_pressed));
 
 	remove_dialog = memnew(DependencyRemoveDialog);
 	add_child(remove_dialog);
@@ -1713,7 +1685,7 @@ EditorFileDialog::EditorFileDialog() {
 	makevb->add_margin_child(TTR("Name:"), makedirname);
 	add_child(makedialog);
 	makedialog->register_text_enter(makedirname);
-	makedialog->connect_compat("confirmed", this, "_make_dir_confirm");
+	makedialog->connect("confirmed", callable_mp(this, &EditorFileDialog::_make_dir_confirm));
 	mkdirerr = memnew(AcceptDialog);
 	mkdirerr->set_text(TTR("Could not create folder."));
 	add_child(mkdirerr);
@@ -1752,8 +1724,6 @@ void EditorLineEditFileChooser::_notification(int p_what) {
 
 void EditorLineEditFileChooser::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_browse"), &EditorLineEditFileChooser::_browse);
-	ClassDB::bind_method(D_METHOD("_chosen"), &EditorLineEditFileChooser::_chosen);
 	ClassDB::bind_method(D_METHOD("get_button"), &EditorLineEditFileChooser::get_button);
 	ClassDB::bind_method(D_METHOD("get_line_edit"), &EditorLineEditFileChooser::get_line_edit);
 	ClassDB::bind_method(D_METHOD("get_file_dialog"), &EditorLineEditFileChooser::get_file_dialog);
@@ -1777,10 +1747,10 @@ EditorLineEditFileChooser::EditorLineEditFileChooser() {
 	line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	button = memnew(Button);
 	add_child(button);
-	button->connect_compat("pressed", this, "_browse");
+	button->connect("pressed", callable_mp(this, &EditorLineEditFileChooser::_browse));
 	dialog = memnew(EditorFileDialog);
 	add_child(dialog);
-	dialog->connect_compat("file_selected", this, "_chosen");
-	dialog->connect_compat("dir_selected", this, "_chosen");
-	dialog->connect_compat("files_selected", this, "_chosen");
+	dialog->connect("file_selected", callable_mp(this, &EditorLineEditFileChooser::_chosen));
+	dialog->connect("dir_selected", callable_mp(this, &EditorLineEditFileChooser::_chosen));
+	dialog->connect("files_selected", callable_mp(this, &EditorLineEditFileChooser::_chosen));
 }

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1529,9 +1529,6 @@ void EditorHelp::set_scroll(int p_scroll) {
 void EditorHelp::_bind_methods() {
 
 	ClassDB::bind_method("_class_list_select", &EditorHelp::_class_list_select);
-	ClassDB::bind_method("_class_desc_select", &EditorHelp::_class_desc_select);
-	ClassDB::bind_method("_class_desc_input", &EditorHelp::_class_desc_input);
-	ClassDB::bind_method("_class_desc_resized", &EditorHelp::_class_desc_resized);
 	ClassDB::bind_method("_request_help", &EditorHelp::_request_help);
 	ClassDB::bind_method("_unhandled_key_input", &EditorHelp::_unhandled_key_input);
 	ClassDB::bind_method("_search", &EditorHelp::_search);
@@ -1551,9 +1548,9 @@ EditorHelp::EditorHelp() {
 	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
 	class_desc->add_color_override("selection_color", get_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
 
-	class_desc->connect_compat("meta_clicked", this, "_class_desc_select");
-	class_desc->connect_compat("gui_input", this, "_class_desc_input");
-	class_desc->connect_compat("resized", this, "_class_desc_resized");
+	class_desc->connect("meta_clicked", callable_mp(this, &EditorHelp::_class_desc_select));
+	class_desc->connect("gui_input", callable_mp(this, &EditorHelp::_class_desc_input));
+	class_desc->connect("resized", callable_mp(this, &EditorHelp::_class_desc_resized));
 	_class_desc_resized();
 
 	// Added second so it opens at the bottom so it won't offset the entire widget.
@@ -1607,7 +1604,6 @@ void EditorHelpBit::_meta_clicked(String p_select) {
 
 void EditorHelpBit::_bind_methods() {
 
-	ClassDB::bind_method("_meta_clicked", &EditorHelpBit::_meta_clicked);
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &EditorHelpBit::set_text);
 	ADD_SIGNAL(MethodInfo("request_hide"));
 }
@@ -1633,7 +1629,7 @@ EditorHelpBit::EditorHelpBit() {
 
 	rich_text = memnew(RichTextLabel);
 	add_child(rich_text);
-	rich_text->connect_compat("meta_clicked", this, "_meta_clicked");
+	rich_text->connect("meta_clicked", callable_mp(this, &EditorHelpBit::_meta_clicked));
 	rich_text->add_color_override("selection_color", get_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
 	rich_text->set_override_selected_font_color(false);
 	set_custom_minimum_size(Size2(0, 70 * EDSCALE));
@@ -1645,8 +1641,8 @@ FindBar::FindBar() {
 	add_child(search_text);
 	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	search_text->set_h_size_flags(SIZE_EXPAND_FILL);
-	search_text->connect_compat("text_changed", this, "_search_text_changed");
-	search_text->connect_compat("text_entered", this, "_search_text_entered");
+	search_text->connect("text_changed", callable_mp(this, &FindBar::_search_text_changed));
+	search_text->connect("text_entered", callable_mp(this, &FindBar::_search_text_entered));
 
 	matches_label = memnew(Label);
 	add_child(matches_label);
@@ -1655,12 +1651,12 @@ FindBar::FindBar() {
 	find_prev = memnew(ToolButton);
 	add_child(find_prev);
 	find_prev->set_focus_mode(FOCUS_NONE);
-	find_prev->connect_compat("pressed", this, "_search_prev");
+	find_prev->connect("pressed", callable_mp(this, &FindBar::search_prev));
 
 	find_next = memnew(ToolButton);
 	add_child(find_next);
 	find_next->set_focus_mode(FOCUS_NONE);
-	find_next->connect_compat("pressed", this, "_search_next");
+	find_next->connect("pressed", callable_mp(this, &FindBar::search_next));
 
 	Control *space = memnew(Control);
 	add_child(space);
@@ -1671,7 +1667,7 @@ FindBar::FindBar() {
 	hide_button->set_focus_mode(FOCUS_NONE);
 	hide_button->set_expand(true);
 	hide_button->set_stretch_mode(TextureButton::STRETCH_KEEP_CENTERED);
-	hide_button->connect_compat("pressed", this, "_hide_pressed");
+	hide_button->connect("pressed", callable_mp(this, &FindBar::_hide_bar));
 }
 
 void FindBar::popup_search() {
@@ -1716,12 +1712,6 @@ void FindBar::_notification(int p_what) {
 void FindBar::_bind_methods() {
 
 	ClassDB::bind_method("_unhandled_input", &FindBar::_unhandled_input);
-
-	ClassDB::bind_method("_search_text_changed", &FindBar::_search_text_changed);
-	ClassDB::bind_method("_search_text_entered", &FindBar::_search_text_entered);
-	ClassDB::bind_method("_search_next", &FindBar::search_next);
-	ClassDB::bind_method("_search_prev", &FindBar::search_prev);
-	ClassDB::bind_method("_hide_pressed", &FindBar::_hide_bar);
 
 	ADD_SIGNAL(MethodInfo("search"));
 }

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -111,7 +111,7 @@ void EditorHelpSearch::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 
-			connect_compat("confirmed", this, "_confirmed");
+			connect("confirmed", callable_mp(this, &EditorHelpSearch::_confirmed));
 			_update_icons();
 		} break;
 		case NOTIFICATION_POPUP_HIDE: {
@@ -147,11 +147,6 @@ void EditorHelpSearch::_notification(int p_what) {
 
 void EditorHelpSearch::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_update_results"), &EditorHelpSearch::_update_results);
-	ClassDB::bind_method(D_METHOD("_search_box_gui_input"), &EditorHelpSearch::_search_box_gui_input);
-	ClassDB::bind_method(D_METHOD("_search_box_text_changed"), &EditorHelpSearch::_search_box_text_changed);
-	ClassDB::bind_method(D_METHOD("_filter_combo_item_selected"), &EditorHelpSearch::_filter_combo_item_selected);
-	ClassDB::bind_method(D_METHOD("_confirmed"), &EditorHelpSearch::_confirmed);
 	ADD_SIGNAL(MethodInfo("go_to_help"));
 }
 
@@ -206,21 +201,21 @@ EditorHelpSearch::EditorHelpSearch() {
 	search_box = memnew(LineEdit);
 	search_box->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	search_box->connect_compat("gui_input", this, "_search_box_gui_input");
-	search_box->connect_compat("text_changed", this, "_search_box_text_changed");
+	search_box->connect("gui_input", callable_mp(this, &EditorHelpSearch::_search_box_gui_input));
+	search_box->connect("text_changed", callable_mp(this, &EditorHelpSearch::_search_box_text_changed));
 	register_text_enter(search_box);
 	hbox->add_child(search_box);
 
 	case_sensitive_button = memnew(ToolButton);
 	case_sensitive_button->set_tooltip(TTR("Case Sensitive"));
-	case_sensitive_button->connect_compat("pressed", this, "_update_results");
+	case_sensitive_button->connect("pressed", callable_mp(this, &EditorHelpSearch::_update_results));
 	case_sensitive_button->set_toggle_mode(true);
 	case_sensitive_button->set_focus_mode(FOCUS_NONE);
 	hbox->add_child(case_sensitive_button);
 
 	hierarchy_button = memnew(ToolButton);
 	hierarchy_button->set_tooltip(TTR("Show Hierarchy"));
-	hierarchy_button->connect_compat("pressed", this, "_update_results");
+	hierarchy_button->connect("pressed", callable_mp(this, &EditorHelpSearch::_update_results));
 	hierarchy_button->set_toggle_mode(true);
 	hierarchy_button->set_pressed(true);
 	hierarchy_button->set_focus_mode(FOCUS_NONE);
@@ -237,7 +232,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	filter_combo->add_item(TTR("Constants Only"), SEARCH_CONSTANTS);
 	filter_combo->add_item(TTR("Properties Only"), SEARCH_PROPERTIES);
 	filter_combo->add_item(TTR("Theme Properties Only"), SEARCH_THEME_ITEMS);
-	filter_combo->connect_compat("item_selected", this, "_filter_combo_item_selected");
+	filter_combo->connect("item_selected", callable_mp(this, &EditorHelpSearch::_filter_combo_item_selected));
 	hbox->add_child(filter_combo);
 
 	// Create the results tree.
@@ -251,7 +246,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	results_tree->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
 	results_tree->set_hide_root(true);
 	results_tree->set_select_mode(Tree::SELECT_ROW);
-	results_tree->connect_compat("item_activated", this, "_confirmed");
+	results_tree->connect("item_activated", callable_mp(this, &EditorHelpSearch::_confirmed));
 	results_tree->connect_compat("item_selected", get_ok(), "set_disabled", varray(false));
 	vbox->add_child(results_tree, true);
 }

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -247,7 +247,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	results_tree->set_hide_root(true);
 	results_tree->set_select_mode(Tree::SELECT_ROW);
 	results_tree->connect("item_activated", callable_mp(this, &EditorHelpSearch::_confirmed));
-	results_tree->connect_compat("item_selected", get_ok(), "set_disabled", varray(false));
+	results_tree->connect("item_selected", callable_mp((BaseButton *)get_ok(), &BaseButton::set_disabled), varray(false));
 	vbox->add_child(results_tree, true);
 }
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -570,7 +570,7 @@ void EditorProperty::_focusable_focused(int p_index) {
 
 void EditorProperty::add_focusable(Control *p_control) {
 
-	p_control->connect_compat("focus_entered", this, "_focusable_focused", varray(focusables.size()));
+	p_control->connect("focus_entered", callable_mp(this, &EditorProperty::_focusable_focused), varray(focusables.size()));
 	focusables.push_back(p_control);
 }
 
@@ -813,7 +813,6 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_edited_object"), &EditorProperty::get_edited_object);
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &EditorProperty::_gui_input);
-	ClassDB::bind_method(D_METHOD("_focusable_focused"), &EditorProperty::_focusable_focused);
 
 	ClassDB::bind_method(D_METHOD("get_tooltip_text"), &EditorProperty::get_tooltip_text);
 
@@ -1339,14 +1338,14 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, Ref<Edit
 		if (ep) {
 
 			ep->object = object;
-			ep->connect_compat("property_changed", this, "_property_changed");
-			ep->connect_compat("property_keyed", this, "_property_keyed");
-			ep->connect_compat("property_keyed_with_value", this, "_property_keyed_with_value");
-			ep->connect_compat("property_checked", this, "_property_checked");
-			ep->connect_compat("selected", this, "_property_selected");
-			ep->connect_compat("multiple_properties_changed", this, "_multiple_properties_changed");
-			ep->connect_compat("resource_selected", this, "_resource_selected", varray(), CONNECT_DEFERRED);
-			ep->connect_compat("object_id_selected", this, "_object_id_selected", varray(), CONNECT_DEFERRED);
+			ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed));
+			ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
+			ep->connect("property_keyed_with_value", callable_mp(this, &EditorInspector::_property_keyed_with_value));
+			ep->connect("property_checked", callable_mp(this, &EditorInspector::_property_checked));
+			ep->connect("selected", callable_mp(this, &EditorInspector::_property_selected));
+			ep->connect("multiple_properties_changed", callable_mp(this, &EditorInspector::_multiple_properties_changed));
+			ep->connect("resource_selected", callable_mp(this, &EditorInspector::_resource_selected), varray(), CONNECT_DEFERRED);
+			ep->connect("object_id_selected", callable_mp(this, &EditorInspector::_object_id_selected), varray(), CONNECT_DEFERRED);
 
 			if (F->get().properties.size()) {
 
@@ -1751,17 +1750,17 @@ void EditorInspector::update_tree() {
 
 				if (ep) {
 
-					ep->connect_compat("property_changed", this, "_property_changed");
+					ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed));
 					if (p.usage & PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED) {
-						ep->connect_compat("property_changed", this, "_property_changed_update_all", varray(), CONNECT_DEFERRED);
+						ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed_update_all), varray(), CONNECT_DEFERRED);
 					}
-					ep->connect_compat("property_keyed", this, "_property_keyed");
-					ep->connect_compat("property_keyed_with_value", this, "_property_keyed_with_value");
-					ep->connect_compat("property_checked", this, "_property_checked");
-					ep->connect_compat("selected", this, "_property_selected");
-					ep->connect_compat("multiple_properties_changed", this, "_multiple_properties_changed");
-					ep->connect_compat("resource_selected", this, "_resource_selected", varray(), CONNECT_DEFERRED);
-					ep->connect_compat("object_id_selected", this, "_object_id_selected", varray(), CONNECT_DEFERRED);
+					ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
+					ep->connect("property_keyed_with_value", callable_mp(this, &EditorInspector::_property_keyed_with_value));
+					ep->connect("property_checked", callable_mp(this, &EditorInspector::_property_checked));
+					ep->connect("selected", callable_mp(this, &EditorInspector::_property_selected));
+					ep->connect("multiple_properties_changed", callable_mp(this, &EditorInspector::_multiple_properties_changed));
+					ep->connect("resource_selected", callable_mp(this, &EditorInspector::_resource_selected), varray(), CONNECT_DEFERRED);
+					ep->connect("object_id_selected", callable_mp(this, &EditorInspector::_object_id_selected), varray(), CONNECT_DEFERRED);
 					if (doc_hint != String()) {
 						ep->set_tooltip(property_prefix + p.name + "::" + doc_hint);
 					} else {
@@ -1889,7 +1888,7 @@ void EditorInspector::set_use_filter(bool p_use) {
 void EditorInspector::register_text_enter(Node *p_line_edit) {
 	search_box = Object::cast_to<LineEdit>(p_line_edit);
 	if (search_box)
-		search_box->connect_compat("text_changed", this, "_filter_changed");
+		search_box->connect("text_changed", callable_mp(this, &EditorInspector::_filter_changed));
 }
 
 void EditorInspector::_filter_changed(const String &p_text) {
@@ -2165,7 +2164,7 @@ void EditorInspector::_node_removed(Node *p_node) {
 void EditorInspector::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_READY) {
-		EditorFeatureProfileManager::get_singleton()->connect_compat("current_feature_profile_changed", this, "_feature_profile_changed");
+		EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &EditorInspector::_feature_profile_changed));
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
@@ -2174,7 +2173,7 @@ void EditorInspector::_notification(int p_what) {
 			add_style_override("bg", get_stylebox("sub_inspector_bg", "Editor"));
 		} else {
 			add_style_override("bg", get_stylebox("bg", "Tree"));
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
+			get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 		}
 	}
 	if (p_what == NOTIFICATION_PREDELETE) {
@@ -2183,7 +2182,7 @@ void EditorInspector::_notification(int p_what) {
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
 		if (!sub_inspector) {
-			get_tree()->disconnect_compat("node_removed", this, "_node_removed");
+			get_tree()->disconnect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 		}
 		edit(NULL);
 	}
@@ -2281,21 +2280,7 @@ void EditorInspector::_feature_profile_changed() {
 
 void EditorInspector::_bind_methods() {
 
-	ClassDB::bind_method("_property_changed", &EditorInspector::_property_changed, DEFVAL(""), DEFVAL(false));
-	ClassDB::bind_method("_multiple_properties_changed", &EditorInspector::_multiple_properties_changed);
-	ClassDB::bind_method("_property_changed_update_all", &EditorInspector::_property_changed_update_all);
-
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
-	ClassDB::bind_method("_node_removed", &EditorInspector::_node_removed);
-	ClassDB::bind_method("_filter_changed", &EditorInspector::_filter_changed);
-	ClassDB::bind_method("_property_keyed", &EditorInspector::_property_keyed);
-	ClassDB::bind_method("_property_keyed_with_value", &EditorInspector::_property_keyed_with_value);
-	ClassDB::bind_method("_property_checked", &EditorInspector::_property_checked);
-	ClassDB::bind_method("_property_selected", &EditorInspector::_property_selected);
-	ClassDB::bind_method("_resource_selected", &EditorInspector::_resource_selected);
-	ClassDB::bind_method("_object_id_selected", &EditorInspector::_object_id_selected);
-	ClassDB::bind_method("_vscroll_changed", &EditorInspector::_vscroll_changed);
-	ClassDB::bind_method("_feature_profile_changed", &EditorInspector::_feature_profile_changed);
 
 	ClassDB::bind_method("refresh", &EditorInspector::refresh);
 
@@ -2337,6 +2322,6 @@ EditorInspector::EditorInspector() {
 	property_focusable = -1;
 	sub_inspector = false;
 
-	get_v_scrollbar()->connect_compat("value_changed", this, "_vscroll_changed");
+	get_v_scrollbar()->connect("value_changed", callable_mp(this, &EditorInspector::_vscroll_changed));
 	update_scroll_request = -1;
 }

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "editor_layouts_dialog.h"
+
 #include "core/class_db.h"
 #include "core/io/config_file.h"
 #include "core/os/keyboard.h"
@@ -128,7 +129,7 @@ EditorLayoutsDialog::EditorLayoutsDialog() {
 	name->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 5);
 	name->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, -5);
 	name->connect("gui_input", callable_mp(this, &EditorLayoutsDialog::_line_gui_input));
-	name->connect_compat("focus_entered", layout_names, "unselect_all");
+	name->connect("focus_entered", callable_mp(layout_names, &ItemList::unselect_all));
 }
 
 void EditorLayoutsDialog::set_name_line_enabled(bool p_enabled) {

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -63,7 +63,6 @@ void EditorLayoutsDialog::_line_gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void EditorLayoutsDialog::_bind_methods() {
-	ClassDB::bind_method("_line_gui_input", &EditorLayoutsDialog::_line_gui_input);
 
 	ADD_SIGNAL(MethodInfo("name_confirmed", PropertyInfo(Variant::STRING, "name")));
 }
@@ -128,7 +127,7 @@ EditorLayoutsDialog::EditorLayoutsDialog() {
 	name->set_margin(MARGIN_TOP, 5);
 	name->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 5);
 	name->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, -5);
-	name->connect_compat("gui_input", this, "_line_gui_input");
+	name->connect("gui_input", callable_mp(this, &EditorLayoutsDialog::_line_gui_input));
 	name->connect_compat("focus_entered", layout_names, "unselect_all");
 }
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -138,8 +138,6 @@ void EditorLog::_undo_redo_cbk(void *p_self, const String &p_name) {
 
 void EditorLog::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_clear_request"), &EditorLog::_clear_request);
-	ClassDB::bind_method(D_METHOD("_copy_request"), &EditorLog::_copy_request);
 	ADD_SIGNAL(MethodInfo("clear_request"));
 	ADD_SIGNAL(MethodInfo("copy_request"));
 }
@@ -159,13 +157,13 @@ EditorLog::EditorLog() {
 	hb->add_child(copybutton);
 	copybutton->set_text(TTR("Copy"));
 	copybutton->set_shortcut(ED_SHORTCUT("editor/copy_output", TTR("Copy Selection"), KEY_MASK_CMD | KEY_C));
-	copybutton->connect_compat("pressed", this, "_copy_request");
+	copybutton->connect("pressed", callable_mp(this, &EditorLog::_copy_request));
 
 	clearbutton = memnew(Button);
 	hb->add_child(clearbutton);
 	clearbutton->set_text(TTR("Clear"));
 	clearbutton->set_shortcut(ED_SHORTCUT("editor/clear_output", TTR("Clear Output"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_K));
-	clearbutton->connect_compat("pressed", this, "_clear_request");
+	clearbutton->connect("pressed", callable_mp(this, &EditorLog::_clear_request));
 
 	log = memnew(RichTextLabel);
 	log->set_scroll_follow(true);

--- a/editor/editor_network_profiler.cpp
+++ b/editor/editor_network_profiler.cpp
@@ -35,9 +35,6 @@
 #include "editor_settings.h"
 
 void EditorNetworkProfiler::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_update_frame"), &EditorNetworkProfiler::_update_frame);
-	ClassDB::bind_method(D_METHOD("_activate_pressed"), &EditorNetworkProfiler::_activate_pressed);
-	ClassDB::bind_method(D_METHOD("_clear_pressed"), &EditorNetworkProfiler::_clear_pressed);
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));
 }
 
@@ -142,12 +139,12 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
-	activate->connect_compat("pressed", this, "_activate_pressed");
+	activate->connect("pressed", callable_mp(this, &EditorNetworkProfiler::_activate_pressed));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
-	clear_button->connect_compat("pressed", this, "_clear_pressed");
+	clear_button->connect("pressed", callable_mp(this, &EditorNetworkProfiler::_clear_pressed));
 	hb->add_child(clear_button);
 
 	hb->add_spacer();
@@ -207,5 +204,5 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);
 	add_child(frame_delay);
-	frame_delay->connect_compat("timeout", this, "_update_frame");
+	frame_delay->connect("timeout", callable_mp(this, &EditorNetworkProfiler::_update_frame));
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2972,7 +2972,7 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 
 		ToolButton *tb = memnew(ToolButton);
 		tb->set_toggle_mode(true);
-		tb->connect_compat("pressed", singleton, "_editor_select", varray(singleton->main_editor_buttons.size()));
+		tb->connect("pressed", callable_mp(singleton, &EditorNode::_editor_select), varray(singleton->main_editor_buttons.size()));
 		tb->set_text(p_editor->get_name());
 		Ref<Texture2D> icon = p_editor->get_icon();
 
@@ -5472,6 +5472,8 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("edit_item_resource", &EditorNode::edit_item_resource);
 
 	ClassDB::bind_method(D_METHOD("get_gui_base"), &EditorNode::get_gui_base);
+
+	ClassDB::bind_method(D_METHOD("_on_plugin_ready"), &EditorNode::_on_plugin_ready); // Still used by some connect_compat.
 
 	ClassDB::bind_method("_screenshot", &EditorNode::_screenshot);
 	ClassDB::bind_method("_save_screenshot", &EditorNode::_save_screenshot);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -374,8 +374,8 @@ void EditorNode::_notification(int p_what) {
 			get_tree()->get_root()->set_as_audio_listener(false);
 			get_tree()->get_root()->set_as_audio_listener_2d(false);
 			get_tree()->set_auto_accept_quit(false);
-			get_tree()->connect_compat("files_dropped", this, "_dropped_files");
-			get_tree()->connect_compat("global_menu_action", this, "_global_menu_action");
+			get_tree()->connect("files_dropped", callable_mp(this, &EditorNode::_dropped_files));
+			get_tree()->connect("global_menu_action", callable_mp(this, &EditorNode::_global_menu_action));
 
 			/* DO NOT LOAD SCENES HERE, WAIT FOR FILE SCANNING AND REIMPORT TO COMPLETE */
 		} break;
@@ -4803,7 +4803,7 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 ToolButton *EditorNode::add_bottom_panel_item(String p_text, Control *p_item) {
 
 	ToolButton *tb = memnew(ToolButton);
-	tb->connect_compat("toggled", this, "_bottom_panel_switch", varray(bottom_panel_items.size()));
+	tb->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch), varray(bottom_panel_items.size()));
 	tb->set_text(p_text);
 	tb->set_toggle_mode(true);
 	tb->set_focus_mode(Control::FOCUS_NONE);
@@ -4865,8 +4865,8 @@ void EditorNode::raise_bottom_panel_item(Control *p_item) {
 	}
 
 	for (int i = 0; i < bottom_panel_items.size(); i++) {
-		bottom_panel_items[i].button->disconnect_compat("toggled", this, "_bottom_panel_switch");
-		bottom_panel_items[i].button->connect_compat("toggled", this, "_bottom_panel_switch", varray(i));
+		bottom_panel_items[i].button->disconnect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch));
+		bottom_panel_items[i].button->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch), varray(i));
 	}
 }
 
@@ -4887,8 +4887,8 @@ void EditorNode::remove_bottom_panel_item(Control *p_item) {
 	}
 
 	for (int i = 0; i < bottom_panel_items.size(); i++) {
-		bottom_panel_items[i].button->disconnect_compat("toggled", this, "_bottom_panel_switch");
-		bottom_panel_items[i].button->connect_compat("toggled", this, "_bottom_panel_switch", varray(i));
+		bottom_panel_items[i].button->disconnect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch));
+		bottom_panel_items[i].button->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch), varray(i));
 	}
 }
 
@@ -5445,92 +5445,35 @@ void EditorNode::_feature_profile_changed() {
 
 void EditorNode::_bind_methods() {
 
-	ClassDB::bind_method("_menu_option", &EditorNode::_menu_option);
-	ClassDB::bind_method("_tool_menu_option", &EditorNode::_tool_menu_option);
-	ClassDB::bind_method("_menu_confirm_current", &EditorNode::_menu_confirm_current);
-	ClassDB::bind_method("_dialog_action", &EditorNode::_dialog_action);
 	ClassDB::bind_method("_editor_select", &EditorNode::_editor_select);
 	ClassDB::bind_method("_node_renamed", &EditorNode::_node_renamed);
 	ClassDB::bind_method("edit_node", &EditorNode::edit_node);
 	ClassDB::bind_method("_unhandled_input", &EditorNode::_unhandled_input);
-	ClassDB::bind_method("_update_file_menu_opened", &EditorNode::_update_file_menu_opened);
-	ClassDB::bind_method("_update_file_menu_closed", &EditorNode::_update_file_menu_closed);
 
 	ClassDB::bind_method(D_METHOD("push_item", "object", "property", "inspector_only"), &EditorNode::push_item, DEFVAL(""), DEFVAL(false));
 
 	ClassDB::bind_method("_get_scene_metadata", &EditorNode::_get_scene_metadata);
 	ClassDB::bind_method("set_edited_scene", &EditorNode::set_edited_scene);
 	ClassDB::bind_method("open_request", &EditorNode::open_request);
-	ClassDB::bind_method("_inherit_request", &EditorNode::_inherit_request);
-	ClassDB::bind_method("_instance_request", &EditorNode::_instance_request);
 	ClassDB::bind_method("_close_messages", &EditorNode::_close_messages);
 	ClassDB::bind_method("_show_messages", &EditorNode::_show_messages);
-	ClassDB::bind_method("_vp_resized", &EditorNode::_vp_resized);
-	ClassDB::bind_method("_quick_opened", &EditorNode::_quick_opened);
-	ClassDB::bind_method("_quick_run", &EditorNode::_quick_run);
-
-	ClassDB::bind_method("_open_recent_scene", &EditorNode::_open_recent_scene);
 
 	ClassDB::bind_method("stop_child_process", &EditorNode::stop_child_process);
 
 	ClassDB::bind_method("get_script_create_dialog", &EditorNode::get_script_create_dialog);
 
-	ClassDB::bind_method("_sources_changed", &EditorNode::_sources_changed);
-	ClassDB::bind_method("_fs_changed", &EditorNode::_fs_changed);
-	ClassDB::bind_method("_dock_select_draw", &EditorNode::_dock_select_draw);
-	ClassDB::bind_method("_dock_select_input", &EditorNode::_dock_select_input);
-	ClassDB::bind_method("_dock_pre_popup", &EditorNode::_dock_pre_popup);
-	ClassDB::bind_method("_dock_split_dragged", &EditorNode::_dock_split_dragged);
-	ClassDB::bind_method("_save_docks", &EditorNode::_save_docks);
-	ClassDB::bind_method("_dock_popup_exit", &EditorNode::_dock_popup_exit);
-	ClassDB::bind_method("_dock_move_left", &EditorNode::_dock_move_left);
-	ClassDB::bind_method("_dock_move_right", &EditorNode::_dock_move_right);
-	ClassDB::bind_method("_dock_tab_changed", &EditorNode::_dock_tab_changed);
-
-	ClassDB::bind_method("_layout_menu_option", &EditorNode::_layout_menu_option);
-
 	ClassDB::bind_method("set_current_scene", &EditorNode::set_current_scene);
 	ClassDB::bind_method("set_current_version", &EditorNode::set_current_version);
-	ClassDB::bind_method("_scene_tab_changed", &EditorNode::_scene_tab_changed);
-	ClassDB::bind_method("_scene_tab_closed", &EditorNode::_scene_tab_closed);
-	ClassDB::bind_method("_scene_tab_hover", &EditorNode::_scene_tab_hover);
-	ClassDB::bind_method("_scene_tab_exit", &EditorNode::_scene_tab_exit);
-	ClassDB::bind_method("_scene_tab_input", &EditorNode::_scene_tab_input);
-	ClassDB::bind_method("_reposition_active_tab", &EditorNode::_reposition_active_tab);
 	ClassDB::bind_method("_thumbnail_done", &EditorNode::_thumbnail_done);
-	ClassDB::bind_method("_scene_tab_script_edited", &EditorNode::_scene_tab_script_edited);
 	ClassDB::bind_method("_set_main_scene_state", &EditorNode::_set_main_scene_state);
-	ClassDB::bind_method("_update_scene_tabs", &EditorNode::_update_scene_tabs);
-	ClassDB::bind_method("_discard_changes", &EditorNode::_discard_changes);
 	ClassDB::bind_method("_update_recent_scenes", &EditorNode::_update_recent_scenes);
 
 	ClassDB::bind_method("_clear_undo_history", &EditorNode::_clear_undo_history);
-	ClassDB::bind_method("_dropped_files", &EditorNode::_dropped_files);
-	ClassDB::bind_method(D_METHOD("_global_menu_action"), &EditorNode::_global_menu_action, DEFVAL(Variant()));
-	ClassDB::bind_method("_toggle_distraction_free_mode", &EditorNode::_toggle_distraction_free_mode);
-	ClassDB::bind_method("_version_control_menu_option", &EditorNode::_version_control_menu_option);
 	ClassDB::bind_method("edit_item_resource", &EditorNode::edit_item_resource);
 
 	ClassDB::bind_method(D_METHOD("get_gui_base"), &EditorNode::get_gui_base);
-	ClassDB::bind_method(D_METHOD("_bottom_panel_switch"), &EditorNode::_bottom_panel_switch);
-
-	ClassDB::bind_method(D_METHOD("_open_imported"), &EditorNode::_open_imported);
-	ClassDB::bind_method(D_METHOD("_inherit_imported"), &EditorNode::_inherit_imported);
-
-	ClassDB::bind_method("_copy_warning", &EditorNode::_copy_warning);
-
-	ClassDB::bind_method(D_METHOD("_resources_reimported"), &EditorNode::_resources_reimported);
-	ClassDB::bind_method(D_METHOD("_bottom_panel_raise_toggled"), &EditorNode::_bottom_panel_raise_toggled);
-
-	ClassDB::bind_method(D_METHOD("_on_plugin_ready"), &EditorNode::_on_plugin_ready);
-
-	ClassDB::bind_method(D_METHOD("_video_driver_selected"), &EditorNode::_video_driver_selected);
-
-	ClassDB::bind_method(D_METHOD("_resources_changed"), &EditorNode::_resources_changed);
-	ClassDB::bind_method(D_METHOD("_feature_profile_changed"), &EditorNode::_feature_profile_changed);
 
 	ClassDB::bind_method("_screenshot", &EditorNode::_screenshot);
-	ClassDB::bind_method("_request_screenshot", &EditorNode::_request_screenshot);
 	ClassDB::bind_method("_save_screenshot", &EditorNode::_save_screenshot);
 
 	ADD_SIGNAL(MethodInfo("play_pressed"));
@@ -5943,8 +5886,8 @@ EditorNode::EditorNode() {
 	hsplits.push_back(right_hsplit);
 
 	for (int i = 0; i < vsplits.size(); i++) {
-		vsplits[i]->connect_compat("dragged", this, "_dock_split_dragged");
-		hsplits[i]->connect_compat("dragged", this, "_dock_split_dragged");
+		vsplits[i]->connect("dragged", callable_mp(this, &EditorNode::_dock_split_dragged));
+		hsplits[i]->connect("dragged", callable_mp(this, &EditorNode::_dock_split_dragged));
 	}
 
 	dock_select_popup = memnew(PopupPanel);
@@ -5956,7 +5899,7 @@ EditorNode::EditorNode() {
 	dock_tab_move_left = memnew(ToolButton);
 	dock_tab_move_left->set_icon(theme->get_icon("Back", "EditorIcons"));
 	dock_tab_move_left->set_focus_mode(Control::FOCUS_NONE);
-	dock_tab_move_left->connect_compat("pressed", this, "_dock_move_left");
+	dock_tab_move_left->connect("pressed", callable_mp(this, &EditorNode::_dock_move_left));
 	dock_hb->add_child(dock_tab_move_left);
 
 	Label *dock_label = memnew(Label);
@@ -5968,16 +5911,16 @@ EditorNode::EditorNode() {
 	dock_tab_move_right = memnew(ToolButton);
 	dock_tab_move_right->set_icon(theme->get_icon("Forward", "EditorIcons"));
 	dock_tab_move_right->set_focus_mode(Control::FOCUS_NONE);
-	dock_tab_move_right->connect_compat("pressed", this, "_dock_move_right");
+	dock_tab_move_right->connect("pressed", callable_mp(this, &EditorNode::_dock_move_right));
 
 	dock_hb->add_child(dock_tab_move_right);
 	dock_vb->add_child(dock_hb);
 
 	dock_select = memnew(Control);
 	dock_select->set_custom_minimum_size(Size2(128, 64) * EDSCALE);
-	dock_select->connect_compat("gui_input", this, "_dock_select_input");
-	dock_select->connect_compat("draw", this, "_dock_select_draw");
-	dock_select->connect_compat("mouse_exited", this, "_dock_popup_exit");
+	dock_select->connect("gui_input", callable_mp(this, &EditorNode::_dock_select_input));
+	dock_select->connect("draw", callable_mp(this, &EditorNode::_dock_select_draw));
+	dock_select->connect("mouse_exited", callable_mp(this, &EditorNode::_dock_popup_exit));
 	dock_select->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	dock_vb->add_child(dock_select);
 
@@ -5988,11 +5931,11 @@ EditorNode::EditorNode() {
 		dock_slot[i]->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
 		dock_slot[i]->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		dock_slot[i]->set_popup(dock_select_popup);
-		dock_slot[i]->connect_compat("pre_popup_pressed", this, "_dock_pre_popup", varray(i));
+		dock_slot[i]->connect("pre_popup_pressed", callable_mp(this, &EditorNode::_dock_pre_popup), varray(i));
 		dock_slot[i]->set_tab_align(TabContainer::ALIGN_LEFT);
 		dock_slot[i]->set_drag_to_rearrange_enabled(true);
 		dock_slot[i]->set_tabs_rearrange_group(1);
-		dock_slot[i]->connect_compat("tab_changed", this, "_dock_tab_changed");
+		dock_slot[i]->connect("tab_changed", callable_mp(this, &EditorNode::_dock_tab_changed));
 		dock_slot[i]->set_use_hidden_tabs_for_min_size(true);
 	}
 
@@ -6000,7 +5943,7 @@ EditorNode::EditorNode() {
 	add_child(dock_drag_timer);
 	dock_drag_timer->set_wait_time(0.5);
 	dock_drag_timer->set_one_shot(true);
-	dock_drag_timer->connect_compat("timeout", this, "_save_docks");
+	dock_drag_timer->connect("timeout", callable_mp(this, &EditorNode::_save_docks));
 
 	top_split = memnew(VSplitContainer);
 	center_split->add_child(top_split);
@@ -6033,21 +5976,21 @@ EditorNode::EditorNode() {
 	scene_tabs->set_tab_close_display_policy((bool(EDITOR_DEF("interface/scene_tabs/always_show_close_button", false)) ? Tabs::CLOSE_BUTTON_SHOW_ALWAYS : Tabs::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
 	scene_tabs->set_min_width(int(EDITOR_DEF("interface/scene_tabs/minimum_width", 50)) * EDSCALE);
 	scene_tabs->set_drag_to_rearrange_enabled(true);
-	scene_tabs->connect_compat("tab_changed", this, "_scene_tab_changed");
-	scene_tabs->connect_compat("right_button_pressed", this, "_scene_tab_script_edited");
-	scene_tabs->connect_compat("tab_close", this, "_scene_tab_closed", varray(SCENE_TAB_CLOSE));
-	scene_tabs->connect_compat("tab_hover", this, "_scene_tab_hover");
-	scene_tabs->connect_compat("mouse_exited", this, "_scene_tab_exit");
-	scene_tabs->connect_compat("gui_input", this, "_scene_tab_input");
-	scene_tabs->connect_compat("reposition_active_tab_request", this, "_reposition_active_tab");
-	scene_tabs->connect_compat("resized", this, "_update_scene_tabs");
+	scene_tabs->connect("tab_changed", callable_mp(this, &EditorNode::_scene_tab_changed));
+	scene_tabs->connect("right_button_pressed", callable_mp(this, &EditorNode::_scene_tab_script_edited));
+	scene_tabs->connect("tab_close", callable_mp(this, &EditorNode::_scene_tab_closed), varray(SCENE_TAB_CLOSE));
+	scene_tabs->connect("tab_hover", callable_mp(this, &EditorNode::_scene_tab_hover));
+	scene_tabs->connect("mouse_exited", callable_mp(this, &EditorNode::_scene_tab_exit));
+	scene_tabs->connect("gui_input", callable_mp(this, &EditorNode::_scene_tab_input));
+	scene_tabs->connect("reposition_active_tab_request", callable_mp(this, &EditorNode::_reposition_active_tab));
+	scene_tabs->connect("resized", callable_mp(this, &EditorNode::_update_scene_tabs));
 
 	tabbar_container = memnew(HBoxContainer);
 	scene_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	scene_tabs_context_menu = memnew(PopupMenu);
 	tabbar_container->add_child(scene_tabs_context_menu);
-	scene_tabs_context_menu->connect_compat("id_pressed", this, "_menu_option");
+	scene_tabs_context_menu->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 	scene_tabs_context_menu->set_hide_on_window_lose_focus(true);
 
 	srt->add_child(tabbar_container);
@@ -6059,7 +6002,7 @@ EditorNode::EditorNode() {
 	distraction_free->set_shortcut(ED_SHORTCUT("editor/distraction_free_mode", TTR("Distraction Free Mode"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_F11));
 #endif
 	distraction_free->set_tooltip(TTR("Toggle distraction-free mode."));
-	distraction_free->connect_compat("pressed", this, "_toggle_distraction_free_mode");
+	distraction_free->connect("pressed", callable_mp(this, &EditorNode::_toggle_distraction_free_mode));
 	distraction_free->set_icon(gui_base->get_icon("DistractionFree", "EditorIcons"));
 	distraction_free->set_toggle_mode(true);
 
@@ -6069,7 +6012,7 @@ EditorNode::EditorNode() {
 	scene_tab_add->set_tooltip(TTR("Add a new scene."));
 	scene_tab_add->set_icon(gui_base->get_icon("Add", "EditorIcons"));
 	scene_tab_add->add_color_override("icon_color_normal", Color(0.6f, 0.6f, 0.6f, 0.8f));
-	scene_tab_add->connect_compat("pressed", this, "_menu_option", make_binds(FILE_NEW_SCENE));
+	scene_tab_add->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_NEW_SCENE));
 
 	scene_root_parent = memnew(PanelContainer);
 	scene_root_parent->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
@@ -6104,14 +6047,14 @@ EditorNode::EditorNode() {
 	prev_scene->set_icon(gui_base->get_icon("PrevScene", "EditorIcons"));
 	prev_scene->set_tooltip(TTR("Go to previously opened scene."));
 	prev_scene->set_disabled(true);
-	prev_scene->connect_compat("pressed", this, "_menu_option", make_binds(FILE_OPEN_PREV));
+	prev_scene->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_OPEN_PREV));
 	gui_base->add_child(prev_scene);
 	prev_scene->set_position(Point2(3, 24));
 	prev_scene->hide();
 
 	accept = memnew(AcceptDialog);
 	gui_base->add_child(accept);
-	accept->connect_compat("confirmed", this, "_menu_confirm_current");
+	accept->connect("confirmed", callable_mp(this, &EditorNode::_menu_confirm_current));
 
 	project_export = memnew(ProjectExportDialog);
 	gui_base->add_child(project_export);
@@ -6138,12 +6081,12 @@ EditorNode::EditorNode() {
 	gui_base->add_child(feature_profile_manager);
 	about = memnew(EditorAbout);
 	gui_base->add_child(about);
-	feature_profile_manager->connect_compat("current_feature_profile_changed", this, "_feature_profile_changed");
+	feature_profile_manager->connect("current_feature_profile_changed", callable_mp(this, &EditorNode::_feature_profile_changed));
 
 	warning = memnew(AcceptDialog);
 	warning->add_button(TTR("Copy Text"), true, "copy");
 	gui_base->add_child(warning);
-	warning->connect_compat("custom_action", this, "_copy_warning");
+	warning->connect("custom_action", callable_mp(this, &EditorNode::_copy_warning));
 
 	ED_SHORTCUT("editor/next_tab", TTR("Next tab"), KEY_MASK_CMD + KEY_TAB);
 	ED_SHORTCUT("editor/prev_tab", TTR("Previous tab"), KEY_MASK_CMD + KEY_MASK_SHIFT + KEY_TAB);
@@ -6177,7 +6120,7 @@ EditorNode::EditorNode() {
 	p->add_submenu_item(TTR("Convert To..."), "Export");
 	pm_export->add_shortcut(ED_SHORTCUT("editor/convert_to_MeshLibrary", TTR("MeshLibrary...")), FILE_EXPORT_MESH_LIBRARY);
 	pm_export->add_shortcut(ED_SHORTCUT("editor/convert_to_TileSet", TTR("TileSet...")), FILE_EXPORT_TILESET);
-	pm_export->connect_compat("id_pressed", this, "_menu_option");
+	pm_export->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("editor/undo", TTR("Undo"), KEY_MASK_CMD + KEY_Z), EDIT_UNDO, true);
@@ -6190,7 +6133,7 @@ EditorNode::EditorNode() {
 	recent_scenes = memnew(PopupMenu);
 	recent_scenes->set_name("RecentScenes");
 	p->add_child(recent_scenes);
-	recent_scenes->connect_compat("id_pressed", this, "_open_recent_scene");
+	recent_scenes->connect("id_pressed", callable_mp(this, &EditorNode::_open_recent_scene));
 
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("editor/file_quit", TTR("Quit"), KEY_MASK_CMD + KEY_Q), FILE_QUIT, true);
@@ -6206,11 +6149,11 @@ EditorNode::EditorNode() {
 	p = project_menu->get_popup();
 	p->set_hide_on_window_lose_focus(true);
 	p->add_shortcut(ED_SHORTCUT("editor/project_settings", TTR("Project Settings...")), RUN_SETTINGS);
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 
 	vcs_actions_menu = VersionControlEditorPlugin::get_singleton()->get_version_control_actions_panel();
 	vcs_actions_menu->set_name("Version Control");
-	vcs_actions_menu->connect_compat("index_pressed", this, "_version_control_menu_option");
+	vcs_actions_menu->connect("index_pressed", callable_mp(this, &EditorNode::_version_control_menu_option));
 	p->add_separator();
 	p->add_child(vcs_actions_menu);
 	p->add_submenu_item(TTR("Version Control"), "Version Control");
@@ -6223,12 +6166,12 @@ EditorNode::EditorNode() {
 	p->add_item(TTR("Open Project Data Folder"), RUN_PROJECT_DATA_FOLDER);
 
 	plugin_config_dialog = memnew(PluginConfigDialog);
-	plugin_config_dialog->connect_compat("plugin_ready", this, "_on_plugin_ready");
+	plugin_config_dialog->connect("plugin_ready", callable_mp(this, &EditorNode::_on_plugin_ready));
 	gui_base->add_child(plugin_config_dialog);
 
 	tool_menu = memnew(PopupMenu);
 	tool_menu->set_name("Tools");
-	tool_menu->connect_compat("index_pressed", this, "_tool_menu_option");
+	tool_menu->connect("index_pressed", callable_mp(this, &EditorNode::_tool_menu_option));
 	p->add_child(tool_menu);
 	p->add_submenu_item(TTR("Tools"), "Tools");
 	tool_menu->add_item(TTR("Orphan Resource Explorer..."), TOOLS_ORPHAN_RESOURCES);
@@ -6279,7 +6222,7 @@ EditorNode::EditorNode() {
 	p->add_radio_check_item(TTR("Debug 2 instances"), RUN_DEBUG_TWO);
 	p->set_item_checked(p->get_item_index(RUN_DEBUG_ONE), true);
 
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 
 	menu_hb->add_spacer();
 
@@ -6298,7 +6241,7 @@ EditorNode::EditorNode() {
 	editor_layouts = memnew(PopupMenu);
 	editor_layouts->set_name("Layouts");
 	p->add_child(editor_layouts);
-	editor_layouts->connect_compat("id_pressed", this, "_layout_menu_option");
+	editor_layouts->connect("id_pressed", callable_mp(this, &EditorNode::_layout_menu_option));
 	p->add_submenu_item(TTR("Editor Layout"), "Layouts");
 	p->add_separator();
 #ifdef OSX_ENABLED
@@ -6340,7 +6283,7 @@ EditorNode::EditorNode() {
 
 	p = help_menu->get_popup();
 	p->set_hide_on_window_lose_focus(true);
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 	p->add_icon_shortcut(gui_base->get_icon("HelpSearch", "EditorIcons"), ED_SHORTCUT("editor/editor_help", TTR("Search"), KEY_MASK_SHIFT | KEY_F1), HELP_SEARCH);
 	p->add_separator();
 	p->add_icon_shortcut(gui_base->get_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/online_docs", TTR("Online Docs")), HELP_DOCS);
@@ -6358,7 +6301,7 @@ EditorNode::EditorNode() {
 	play_button->set_toggle_mode(true);
 	play_button->set_icon(gui_base->get_icon("MainPlay", "EditorIcons"));
 	play_button->set_focus_mode(Control::FOCUS_NONE);
-	play_button->connect_compat("pressed", this, "_menu_option", make_binds(RUN_PLAY));
+	play_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY));
 	play_button->set_tooltip(TTR("Play the project."));
 #ifdef OSX_ENABLED
 	play_button->set_shortcut(ED_SHORTCUT("editor/play", TTR("Play"), KEY_MASK_CMD | KEY_B));
@@ -6383,7 +6326,7 @@ EditorNode::EditorNode() {
 	play_hb->add_child(stop_button);
 	stop_button->set_focus_mode(Control::FOCUS_NONE);
 	stop_button->set_icon(gui_base->get_icon("Stop", "EditorIcons"));
-	stop_button->connect_compat("pressed", this, "_menu_option", make_binds(RUN_STOP));
+	stop_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_STOP));
 	stop_button->set_tooltip(TTR("Stop the scene."));
 	stop_button->set_disabled(true);
 #ifdef OSX_ENABLED
@@ -6394,14 +6337,14 @@ EditorNode::EditorNode() {
 
 	run_native = memnew(EditorRunNative);
 	play_hb->add_child(run_native);
-	run_native->connect_compat("native_run", this, "_menu_option", varray(RUN_PLAY_NATIVE));
+	run_native->connect("native_run", callable_mp(this, &EditorNode::_menu_option), varray(RUN_PLAY_NATIVE));
 
 	play_scene_button = memnew(ToolButton);
 	play_hb->add_child(play_scene_button);
 	play_scene_button->set_toggle_mode(true);
 	play_scene_button->set_focus_mode(Control::FOCUS_NONE);
 	play_scene_button->set_icon(gui_base->get_icon("PlayScene", "EditorIcons"));
-	play_scene_button->connect_compat("pressed", this, "_menu_option", make_binds(RUN_PLAY_SCENE));
+	play_scene_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY_SCENE));
 	play_scene_button->set_tooltip(TTR("Play the edited scene."));
 #ifdef OSX_ENABLED
 	play_scene_button->set_shortcut(ED_SHORTCUT("editor/play_scene", TTR("Play Scene"), KEY_MASK_CMD | KEY_R));
@@ -6414,7 +6357,7 @@ EditorNode::EditorNode() {
 	play_custom_scene_button->set_toggle_mode(true);
 	play_custom_scene_button->set_focus_mode(Control::FOCUS_NONE);
 	play_custom_scene_button->set_icon(gui_base->get_icon("PlayCustom", "EditorIcons"));
-	play_custom_scene_button->connect_compat("pressed", this, "_menu_option", make_binds(RUN_PLAY_CUSTOM_SCENE));
+	play_custom_scene_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY_CUSTOM_SCENE));
 	play_custom_scene_button->set_tooltip(TTR("Play custom scene"));
 #ifdef OSX_ENABLED
 	play_custom_scene_button->set_shortcut(ED_SHORTCUT("editor/play_custom_scene", TTR("Play Custom Scene"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_R));
@@ -6429,7 +6372,7 @@ EditorNode::EditorNode() {
 	video_driver = memnew(OptionButton);
 	video_driver->set_flat(true);
 	video_driver->set_focus_mode(Control::FOCUS_NONE);
-	video_driver->connect_compat("item_selected", this, "_video_driver_selected");
+	video_driver->connect("item_selected", callable_mp(this, &EditorNode::_video_driver_selected));
 	video_driver->add_font_override("font", gui_base->get_font("bold", "EditorFonts"));
 	// TODO re-enable when GLES2 is ported
 	video_driver->set_disabled(true);
@@ -6454,7 +6397,7 @@ EditorNode::EditorNode() {
 	video_restart_dialog = memnew(ConfirmationDialog);
 	video_restart_dialog->set_text(TTR("Changing the video driver requires restarting the editor."));
 	video_restart_dialog->get_ok()->set_text(TTR("Save & Restart"));
-	video_restart_dialog->connect_compat("confirmed", this, "_menu_option", varray(SET_VIDEO_DRIVER_SAVE_AND_RESTART));
+	video_restart_dialog->connect("confirmed", callable_mp(this, &EditorNode::_menu_option), varray(SET_VIDEO_DRIVER_SAVE_AND_RESTART));
 	gui_base->add_child(video_restart_dialog);
 
 	progress_hb = memnew(BackgroundProgress);
@@ -6463,13 +6406,13 @@ EditorNode::EditorNode() {
 	gui_base->add_child(layout_dialog);
 	layout_dialog->set_hide_on_ok(false);
 	layout_dialog->set_size(Size2(225, 270) * EDSCALE);
-	layout_dialog->connect_compat("name_confirmed", this, "_dialog_action");
+	layout_dialog->connect("name_confirmed", callable_mp(this, &EditorNode::_dialog_action));
 
 	update_spinner = memnew(MenuButton);
 	update_spinner->set_tooltip(TTR("Spins when the editor window redraws."));
 	right_menu_hb->add_child(update_spinner);
 	update_spinner->set_icon(gui_base->get_icon("Progress1", "EditorIcons"));
-	update_spinner->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	update_spinner->get_popup()->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 	p = update_spinner->get_popup();
 	p->add_radio_check_item(TTR("Update Continuously"), SETTINGS_UPDATE_CONTINUOUSLY);
 	p->add_radio_check_item(TTR("Update When Changed"), SETTINGS_UPDATE_WHEN_CHANGED);
@@ -6485,9 +6428,9 @@ EditorNode::EditorNode() {
 	node_dock = memnew(NodeDock);
 
 	filesystem_dock = memnew(FileSystemDock(this));
-	filesystem_dock->connect_compat("inherit", this, "_inherit_request");
-	filesystem_dock->connect_compat("instance", this, "_instance_request");
-	filesystem_dock->connect_compat("display_mode_changed", this, "_save_docks");
+	filesystem_dock->connect("inherit", callable_mp(this, &EditorNode::_inherit_request));
+	filesystem_dock->connect("instance", callable_mp(this, &EditorNode::_instance_request));
+	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_docks));
 
 	// Scene: Top left
 	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(scene_tree_dock);
@@ -6573,7 +6516,7 @@ EditorNode::EditorNode() {
 	bottom_panel_hb->add_child(bottom_panel_raise);
 	bottom_panel_raise->hide();
 	bottom_panel_raise->set_toggle_mode(true);
-	bottom_panel_raise->connect_compat("toggled", this, "_bottom_panel_raise_toggled");
+	bottom_panel_raise->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_raise_toggled));
 
 	log = memnew(EditorLog);
 	ToolButton *output_button = add_bottom_panel_item(TTR("Output"), log);
@@ -6581,37 +6524,37 @@ EditorNode::EditorNode() {
 
 	old_split_ofs = 0;
 
-	center_split->connect_compat("resized", this, "_vp_resized");
+	center_split->connect("resized", callable_mp(this, &EditorNode::_vp_resized));
 
 	orphan_resources = memnew(OrphanResourcesDialog);
 	gui_base->add_child(orphan_resources);
 
 	confirmation = memnew(ConfirmationDialog);
 	gui_base->add_child(confirmation);
-	confirmation->connect_compat("confirmed", this, "_menu_confirm_current");
+	confirmation->connect("confirmed", callable_mp(this, &EditorNode::_menu_confirm_current));
 
 	save_confirmation = memnew(ConfirmationDialog);
 	save_confirmation->add_button(TTR("Don't Save"), OS::get_singleton()->get_swap_ok_cancel(), "discard");
 	gui_base->add_child(save_confirmation);
-	save_confirmation->connect_compat("confirmed", this, "_menu_confirm_current");
-	save_confirmation->connect_compat("custom_action", this, "_discard_changes");
+	save_confirmation->connect("confirmed", callable_mp(this, &EditorNode::_menu_confirm_current));
+	save_confirmation->connect("custom_action", callable_mp(this, &EditorNode::_discard_changes));
 
 	custom_build_manage_templates = memnew(ConfirmationDialog);
 	custom_build_manage_templates->set_text(TTR("Android build template is missing, please install relevant templates."));
 	custom_build_manage_templates->get_ok()->set_text(TTR("Manage Templates"));
-	custom_build_manage_templates->connect_compat("confirmed", this, "_menu_option", varray(SETTINGS_MANAGE_EXPORT_TEMPLATES));
+	custom_build_manage_templates->connect("confirmed", callable_mp(this, &EditorNode::_menu_option), varray(SETTINGS_MANAGE_EXPORT_TEMPLATES));
 	gui_base->add_child(custom_build_manage_templates);
 
 	install_android_build_template = memnew(ConfirmationDialog);
 	install_android_build_template->set_text(TTR("This will set up your project for custom Android builds by installing the source template to \"res://android/build\".\nYou can then apply modifications and build your own custom APK on export (adding modules, changing the AndroidManifest.xml, etc.).\nNote that in order to make custom builds instead of using pre-built APKs, the \"Use Custom Build\" option should be enabled in the Android export preset."));
 	install_android_build_template->get_ok()->set_text(TTR("Install"));
-	install_android_build_template->connect_compat("confirmed", this, "_menu_confirm_current");
+	install_android_build_template->connect("confirmed", callable_mp(this, &EditorNode::_menu_confirm_current));
 	gui_base->add_child(install_android_build_template);
 
 	remove_android_build_template = memnew(ConfirmationDialog);
 	remove_android_build_template->set_text(TTR("The Android build template is already installed in this project and it won't be overwritten.\nRemove the \"res://android/build\" directory manually before attempting this operation again."));
 	remove_android_build_template->get_ok()->set_text(TTR("Show in File Manager"));
-	remove_android_build_template->connect_compat("confirmed", this, "_menu_option", varray(FILE_EXPLORE_ANDROID_BUILD_TEMPLATES));
+	remove_android_build_template->connect("confirmed", callable_mp(this, &EditorNode::_menu_option), varray(FILE_EXPLORE_ANDROID_BUILD_TEMPLATES));
 	gui_base->add_child(remove_android_build_template);
 
 	file_templates = memnew(EditorFileDialog);
@@ -6630,7 +6573,7 @@ EditorNode::EditorNode() {
 	file_export_lib = memnew(EditorFileDialog);
 	file_export_lib->set_title(TTR("Export Library"));
 	file_export_lib->set_mode(EditorFileDialog::MODE_SAVE_FILE);
-	file_export_lib->connect_compat("file_selected", this, "_dialog_action");
+	file_export_lib->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
 	file_export_lib_merge = memnew(CheckBox);
 	file_export_lib_merge->set_text(TTR("Merge With Existing"));
 	file_export_lib_merge->set_pressed(true);
@@ -6647,16 +6590,16 @@ EditorNode::EditorNode() {
 		file_script->add_filter("*." + E->get());
 	}
 	gui_base->add_child(file_script);
-	file_script->connect_compat("file_selected", this, "_dialog_action");
+	file_script->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
 
-	file_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
-	file_menu->connect_compat("about_to_show", this, "_update_file_menu_opened");
-	file_menu->get_popup()->connect_compat("popup_hide", this, "_update_file_menu_closed");
+	file_menu->get_popup()->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
+	file_menu->connect("about_to_show", callable_mp(this, &EditorNode::_update_file_menu_opened));
+	file_menu->get_popup()->connect("popup_hide", callable_mp(this, &EditorNode::_update_file_menu_closed));
 
-	settings_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	settings_menu->get_popup()->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 
-	file->connect_compat("file_selected", this, "_dialog_action");
-	file_templates->connect_compat("file_selected", this, "_dialog_action");
+	file->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
+	file_templates->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
 
 	preview_gen = memnew(AudioStreamPreviewGenerator);
 	add_child(preview_gen);
@@ -6793,8 +6736,8 @@ EditorNode::EditorNode() {
 	open_imported = memnew(ConfirmationDialog);
 	open_imported->get_ok()->set_text(TTR("Open Anyway"));
 	new_inherited_button = open_imported->add_button(TTR("New Inherited"), !OS::get_singleton()->get_swap_ok_cancel(), "inherit");
-	open_imported->connect_compat("confirmed", this, "_open_imported");
-	open_imported->connect_compat("custom_action", this, "_inherit_imported");
+	open_imported->connect("confirmed", callable_mp(this, &EditorNode::_open_imported));
+	open_imported->connect("custom_action", callable_mp(this, &EditorNode::_inherit_imported));
 	gui_base->add_child(open_imported);
 
 	saved_version = 1;
@@ -6803,11 +6746,11 @@ EditorNode::EditorNode() {
 
 	quick_open = memnew(EditorQuickOpen);
 	gui_base->add_child(quick_open);
-	quick_open->connect_compat("quick_open", this, "_quick_opened");
+	quick_open->connect("quick_open", callable_mp(this, &EditorNode::_quick_opened));
 
 	quick_run = memnew(EditorQuickOpen);
 	gui_base->add_child(quick_run);
-	quick_run->connect_compat("quick_open", this, "_quick_run");
+	quick_run->connect("quick_open", callable_mp(this, &EditorNode::_quick_run));
 
 	_update_recent_scenes();
 
@@ -6829,10 +6772,10 @@ EditorNode::EditorNode() {
 	execute_output_dialog->set_title("");
 	gui_base->add_child(execute_output_dialog);
 
-	EditorFileSystem::get_singleton()->connect_compat("sources_changed", this, "_sources_changed");
-	EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "_fs_changed");
-	EditorFileSystem::get_singleton()->connect_compat("resources_reimported", this, "_resources_reimported");
-	EditorFileSystem::get_singleton()->connect_compat("resources_reload", this, "_resources_changed");
+	EditorFileSystem::get_singleton()->connect("sources_changed", callable_mp(this, &EditorNode::_sources_changed));
+	EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorNode::_fs_changed));
+	EditorFileSystem::get_singleton()->connect("resources_reimported", callable_mp(this, &EditorNode::_resources_reimported));
+	EditorFileSystem::get_singleton()->connect("resources_reload", callable_mp(this, &EditorNode::_resources_changed));
 
 	_build_icon_type_cache();
 
@@ -6841,7 +6784,7 @@ EditorNode::EditorNode() {
 	pick_main_scene = memnew(ConfirmationDialog);
 	gui_base->add_child(pick_main_scene);
 	pick_main_scene->get_ok()->set_text(TTR("Select"));
-	pick_main_scene->connect_compat("confirmed", this, "_menu_option", varray(SETTINGS_PICK_MAIN_SCENE));
+	pick_main_scene->connect("confirmed", callable_mp(this, &EditorNode::_menu_option), varray(SETTINGS_PICK_MAIN_SCENE));
 
 	for (int i = 0; i < _init_callbacks.size(); i++)
 		_init_callbacks[i]();
@@ -6881,7 +6824,7 @@ EditorNode::EditorNode() {
 	screenshot_timer = memnew(Timer);
 	screenshot_timer->set_one_shot(true);
 	screenshot_timer->set_wait_time(settings_menu->get_popup()->get_submenu_popup_delay() + 0.1f);
-	screenshot_timer->connect_compat("timeout", this, "_request_screenshot");
+	screenshot_timer->connect("timeout", callable_mp(this, &EditorNode::_request_screenshot));
 	add_child(screenshot_timer);
 	screenshot_timer->set_owner(get_owner());
 }

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -142,9 +142,6 @@ void EditorPath::_notification(int p_what) {
 }
 
 void EditorPath::_bind_methods() {
-
-	ClassDB::bind_method("_about_to_show", &EditorPath::_about_to_show);
-	ClassDB::bind_method("_id_pressed", &EditorPath::_id_pressed);
 }
 
 EditorPath::EditorPath(EditorHistory *p_history) {
@@ -152,6 +149,6 @@ EditorPath::EditorPath(EditorHistory *p_history) {
 	history = p_history;
 	set_clip_text(true);
 	set_text_align(ALIGN_LEFT);
-	get_popup()->connect_compat("about_to_show", this, "_about_to_show");
-	get_popup()->connect_compat("id_pressed", this, "_id_pressed");
+	get_popup()->connect("about_to_show", callable_mp(this, &EditorPath::_about_to_show));
+	get_popup()->connect("id_pressed", callable_mp(this, &EditorPath::_id_pressed));
 }

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -44,7 +44,7 @@ void EditorPluginSettings::_notification(int p_what) {
 		update_plugins();
 	} else if (p_what == Node::NOTIFICATION_READY) {
 		plugin_config_dialog->connect_compat("plugin_ready", EditorNode::get_singleton(), "_on_plugin_ready");
-		plugin_list->connect_compat("button_pressed", this, "_cell_button_pressed");
+		plugin_list->connect("button_pressed", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
 	}
 }
 
@@ -202,11 +202,6 @@ void EditorPluginSettings::_cell_button_pressed(Object *p_item, int p_column, in
 }
 
 void EditorPluginSettings::_bind_methods() {
-
-	ClassDB::bind_method("update_plugins", &EditorPluginSettings::update_plugins);
-	ClassDB::bind_method("_create_clicked", &EditorPluginSettings::_create_clicked);
-	ClassDB::bind_method("_plugin_activity_changed", &EditorPluginSettings::_plugin_activity_changed);
-	ClassDB::bind_method("_cell_button_pressed", &EditorPluginSettings::_cell_button_pressed);
 }
 
 EditorPluginSettings::EditorPluginSettings() {
@@ -219,10 +214,10 @@ EditorPluginSettings::EditorPluginSettings() {
 	title_hb->add_child(memnew(Label(TTR("Installed Plugins:"))));
 	title_hb->add_spacer();
 	create_plugin = memnew(Button(TTR("Create")));
-	create_plugin->connect_compat("pressed", this, "_create_clicked");
+	create_plugin->connect("pressed", callable_mp(this, &EditorPluginSettings::_create_clicked));
 	title_hb->add_child(create_plugin);
 	update_list = memnew(Button(TTR("Update")));
-	update_list->connect_compat("pressed", this, "update_plugins");
+	update_list->connect("pressed", callable_mp(this, &EditorPluginSettings::update_plugins));
 	title_hb->add_child(update_list);
 	add_child(title_hb);
 
@@ -245,7 +240,7 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list->set_column_min_width(3, 80 * EDSCALE);
 	plugin_list->set_column_min_width(4, 40 * EDSCALE);
 	plugin_list->set_hide_root(true);
-	plugin_list->connect_compat("item_edited", this, "_plugin_activity_changed");
+	plugin_list->connect("item_edited", callable_mp(this, &EditorPluginSettings::_plugin_activity_changed));
 
 	VBoxContainer *mc = memnew(VBoxContainer);
 	mc->add_child(plugin_list);

--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -598,17 +598,6 @@ void EditorProfiler::_combo_changed(int) {
 
 void EditorProfiler::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_update_frame"), &EditorProfiler::_update_frame);
-	ClassDB::bind_method(D_METHOD("_update_plot"), &EditorProfiler::_update_plot);
-	ClassDB::bind_method(D_METHOD("_activate_pressed"), &EditorProfiler::_activate_pressed);
-	ClassDB::bind_method(D_METHOD("_clear_pressed"), &EditorProfiler::_clear_pressed);
-	ClassDB::bind_method(D_METHOD("_graph_tex_draw"), &EditorProfiler::_graph_tex_draw);
-	ClassDB::bind_method(D_METHOD("_graph_tex_input"), &EditorProfiler::_graph_tex_input);
-	ClassDB::bind_method(D_METHOD("_graph_tex_mouse_exit"), &EditorProfiler::_graph_tex_mouse_exit);
-	ClassDB::bind_method(D_METHOD("_cursor_metric_changed"), &EditorProfiler::_cursor_metric_changed);
-	ClassDB::bind_method(D_METHOD("_combo_changed"), &EditorProfiler::_combo_changed);
-
-	ClassDB::bind_method(D_METHOD("_item_edited"), &EditorProfiler::_item_edited);
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));
 	ADD_SIGNAL(MethodInfo("break_request"));
 }
@@ -686,12 +675,12 @@ EditorProfiler::EditorProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
-	activate->connect_compat("pressed", this, "_activate_pressed");
+	activate->connect("pressed", callable_mp(this, &EditorProfiler::_activate_pressed));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
-	clear_button->connect_compat("pressed", this, "_clear_pressed");
+	clear_button->connect("pressed", callable_mp(this, &EditorProfiler::_clear_pressed));
 	hb->add_child(clear_button);
 
 	hb->add_child(memnew(Label(TTR("Measure:"))));
@@ -701,7 +690,7 @@ EditorProfiler::EditorProfiler() {
 	display_mode->add_item(TTR("Average Time (sec)"));
 	display_mode->add_item(TTR("Frame %"));
 	display_mode->add_item(TTR("Physics Frame %"));
-	display_mode->connect_compat("item_selected", this, "_combo_changed");
+	display_mode->connect("item_selected", callable_mp(this, &EditorProfiler::_combo_changed));
 
 	hb->add_child(display_mode);
 
@@ -710,7 +699,7 @@ EditorProfiler::EditorProfiler() {
 	display_time = memnew(OptionButton);
 	display_time->add_item(TTR("Inclusive"));
 	display_time->add_item(TTR("Self"));
-	display_time->connect_compat("item_selected", this, "_combo_changed");
+	display_time->connect("item_selected", callable_mp(this, &EditorProfiler::_combo_changed));
 
 	hb->add_child(display_time);
 
@@ -721,7 +710,7 @@ EditorProfiler::EditorProfiler() {
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
 	hb->add_child(cursor_metric_edit);
-	cursor_metric_edit->connect_compat("value_changed", this, "_cursor_metric_changed");
+	cursor_metric_edit->connect("value_changed", callable_mp(this, &EditorProfiler::_cursor_metric_changed));
 
 	hb->add_constant_override("separation", 8 * EDSCALE);
 
@@ -745,14 +734,14 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_title(2, TTR("Calls"));
 	variables->set_column_expand(2, false);
 	variables->set_column_min_width(2, 60 * EDSCALE);
-	variables->connect_compat("item_edited", this, "_item_edited");
+	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
 
 	graph = memnew(TextureRect);
 	graph->set_expand(true);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
-	graph->connect_compat("draw", this, "_graph_tex_draw");
-	graph->connect_compat("gui_input", this, "_graph_tex_input");
-	graph->connect_compat("mouse_exited", this, "_graph_tex_mouse_exit");
+	graph->connect("draw", callable_mp(this, &EditorProfiler::_graph_tex_draw));
+	graph->connect("gui_input", callable_mp(this, &EditorProfiler::_graph_tex_input));
+	graph->connect("mouse_exited", callable_mp(this, &EditorProfiler::_graph_tex_mouse_exit));
 
 	h_split->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -768,13 +757,13 @@ EditorProfiler::EditorProfiler() {
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);
 	add_child(frame_delay);
-	frame_delay->connect_compat("timeout", this, "_update_frame");
+	frame_delay->connect("timeout", callable_mp(this, &EditorProfiler::_update_frame));
 
 	plot_delay = memnew(Timer);
 	plot_delay->set_wait_time(0.1);
 	plot_delay->set_one_shot(true);
 	add_child(plot_delay);
-	plot_delay->connect_compat("timeout", this, "_update_plot");
+	plot_delay->connect("timeout", callable_mp(this, &EditorProfiler::_update_plot));
 
 	plot_sigs.insert("physics_frame_time");
 	plot_sigs.insert("category_frame_time");

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -87,17 +87,14 @@ void EditorPropertyText::set_placeholder(const String &p_string) {
 }
 
 void EditorPropertyText::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_text_changed", "txt"), &EditorPropertyText::_text_changed);
-	ClassDB::bind_method(D_METHOD("_text_entered", "txt"), &EditorPropertyText::_text_entered);
 }
 
 EditorPropertyText::EditorPropertyText() {
 	text = memnew(LineEdit);
 	add_child(text);
 	add_focusable(text);
-	text->connect_compat("text_changed", this, "_text_changed");
-	text->connect_compat("text_entered", this, "_text_entered");
+	text->connect("text_changed", callable_mp(this, &EditorPropertyText::_text_changed));
+	text->connect("text_entered", callable_mp(this, &EditorPropertyText::_text_entered));
 
 	string_name = false;
 	updating = false;
@@ -118,7 +115,7 @@ void EditorPropertyMultilineText::_open_big_text() {
 
 	if (!big_text_dialog) {
 		big_text = memnew(TextEdit);
-		big_text->connect_compat("text_changed", this, "_big_text_changed");
+		big_text->connect("text_changed", callable_mp(this, &EditorPropertyMultilineText::_big_text_changed));
 		big_text->set_wrap_enabled(true);
 		big_text_dialog = memnew(AcceptDialog);
 		big_text_dialog->add_child(big_text);
@@ -153,10 +150,6 @@ void EditorPropertyMultilineText::_notification(int p_what) {
 }
 
 void EditorPropertyMultilineText::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_text_changed"), &EditorPropertyMultilineText::_text_changed);
-	ClassDB::bind_method(D_METHOD("_big_text_changed"), &EditorPropertyMultilineText::_big_text_changed);
-	ClassDB::bind_method(D_METHOD("_open_big_text"), &EditorPropertyMultilineText::_open_big_text);
 }
 
 EditorPropertyMultilineText::EditorPropertyMultilineText() {
@@ -164,13 +157,13 @@ EditorPropertyMultilineText::EditorPropertyMultilineText() {
 	add_child(hb);
 	set_bottom_editor(hb);
 	text = memnew(TextEdit);
-	text->connect_compat("text_changed", this, "_text_changed");
+	text->connect("text_changed", callable_mp(this, &EditorPropertyMultilineText::_text_changed));
 	text->set_wrap_enabled(true);
 	add_focusable(text);
 	hb->add_child(text);
 	text->set_h_size_flags(SIZE_EXPAND_FILL);
 	open_big_text = memnew(ToolButton);
-	open_big_text->connect_compat("pressed", this, "_open_big_text");
+	open_big_text->connect("pressed", callable_mp(this, &EditorPropertyMultilineText::_open_big_text));
 	hb->add_child(open_big_text);
 	big_text_dialog = NULL;
 	big_text = NULL;
@@ -208,8 +201,6 @@ void EditorPropertyTextEnum::setup(const Vector<String> &p_options, bool p_strin
 }
 
 void EditorPropertyTextEnum::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_option_selected"), &EditorPropertyTextEnum::_option_selected);
 }
 
 EditorPropertyTextEnum::EditorPropertyTextEnum() {
@@ -220,7 +211,7 @@ EditorPropertyTextEnum::EditorPropertyTextEnum() {
 
 	add_child(options);
 	add_focusable(options);
-	options->connect_compat("item_selected", this, "_option_selected");
+	options->connect("item_selected", callable_mp(this, &EditorPropertyTextEnum::_option_selected));
 }
 ///////////////////// PATH /////////////////////////
 
@@ -233,8 +224,8 @@ void EditorPropertyPath::_path_pressed() {
 
 	if (!dialog) {
 		dialog = memnew(EditorFileDialog);
-		dialog->connect_compat("file_selected", this, "_path_selected");
-		dialog->connect_compat("dir_selected", this, "_path_selected");
+		dialog->connect("file_selected", callable_mp(this, &EditorPropertyPath::_path_selected));
+		dialog->connect("dir_selected", callable_mp(this, &EditorPropertyPath::_path_selected));
 		add_child(dialog);
 	}
 
@@ -297,10 +288,6 @@ void EditorPropertyPath::_path_focus_exited() {
 }
 
 void EditorPropertyPath::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_path_pressed"), &EditorPropertyPath::_path_pressed);
-	ClassDB::bind_method(D_METHOD("_path_selected"), &EditorPropertyPath::_path_selected);
-	ClassDB::bind_method(D_METHOD("_path_focus_exited"), &EditorPropertyPath::_path_focus_exited);
 }
 
 EditorPropertyPath::EditorPropertyPath() {
@@ -308,8 +295,8 @@ EditorPropertyPath::EditorPropertyPath() {
 	add_child(path_hb);
 	path = memnew(LineEdit);
 	path_hb->add_child(path);
-	path->connect_compat("text_entered", this, "_path_selected");
-	path->connect_compat("focus_exited", this, "_path_focus_exited");
+	path->connect("text_entered", callable_mp(this, &EditorPropertyPath::_path_selected));
+	path->connect("focus_exited", callable_mp(this, &EditorPropertyPath::_path_focus_exited));
 	path->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	path_edit = memnew(Button);
@@ -317,7 +304,7 @@ EditorPropertyPath::EditorPropertyPath() {
 	path_hb->add_child(path_edit);
 	add_focusable(path);
 	dialog = NULL;
-	path_edit->connect_compat("pressed", this, "_path_pressed");
+	path_edit->connect("pressed", callable_mp(this, &EditorPropertyPath::_path_pressed));
 	folder = false;
 	global = false;
 	save_mode = false;
@@ -351,8 +338,6 @@ void EditorPropertyClassName::_dialog_created() {
 }
 
 void EditorPropertyClassName::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_dialog_created"), &EditorPropertyClassName::_dialog_created);
-	ClassDB::bind_method(D_METHOD("_property_selected"), &EditorPropertyClassName::_property_selected);
 }
 
 EditorPropertyClassName::EditorPropertyClassName() {
@@ -361,10 +346,10 @@ EditorPropertyClassName::EditorPropertyClassName() {
 	add_child(property);
 	add_focusable(property);
 	property->set_text(selected_type);
-	property->connect_compat("pressed", this, "_property_selected");
+	property->connect("pressed", callable_mp(this, &EditorPropertyClassName::_property_selected));
 	dialog = memnew(CreateDialog);
 	dialog->set_base_type(base_type);
-	dialog->connect_compat("create", this, "_dialog_created");
+	dialog->connect("create", callable_mp(this, &EditorPropertyClassName::_dialog_created));
 	add_child(dialog);
 }
 
@@ -380,7 +365,7 @@ void EditorPropertyMember::_property_select() {
 
 	if (!selector) {
 		selector = memnew(PropertySelector);
-		selector->connect_compat("selected", this, "_property_selected");
+		selector->connect("selected", callable_mp(this, &EditorPropertyMember::_property_selected));
 		add_child(selector);
 	}
 
@@ -460,8 +445,6 @@ void EditorPropertyMember::update_property() {
 }
 
 void EditorPropertyMember::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_property_selected"), &EditorPropertyMember::_property_selected);
-	ClassDB::bind_method(D_METHOD("_property_select"), &EditorPropertyMember::_property_select);
 }
 
 EditorPropertyMember::EditorPropertyMember() {
@@ -470,7 +453,7 @@ EditorPropertyMember::EditorPropertyMember() {
 	property->set_clip_text(true);
 	add_child(property);
 	add_focusable(property);
-	property->connect_compat("pressed", this, "_property_select");
+	property->connect("pressed", callable_mp(this, &EditorPropertyMember::_property_select));
 }
 
 ///////////////////// CHECK /////////////////////////
@@ -486,8 +469,6 @@ void EditorPropertyCheck::update_property() {
 }
 
 void EditorPropertyCheck::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_checkbox_pressed"), &EditorPropertyCheck::_checkbox_pressed);
 }
 
 EditorPropertyCheck::EditorPropertyCheck() {
@@ -495,7 +476,7 @@ EditorPropertyCheck::EditorPropertyCheck() {
 	checkbox->set_text(TTR("On"));
 	add_child(checkbox);
 	add_focusable(checkbox);
-	checkbox->connect_compat("pressed", this, "_checkbox_pressed");
+	checkbox->connect("pressed", callable_mp(this, &EditorPropertyCheck::_checkbox_pressed));
 }
 
 ///////////////////// ENUM /////////////////////////
@@ -536,8 +517,6 @@ void EditorPropertyEnum::set_option_button_clip(bool p_enable) {
 }
 
 void EditorPropertyEnum::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_option_selected"), &EditorPropertyEnum::_option_selected);
 }
 
 EditorPropertyEnum::EditorPropertyEnum() {
@@ -546,7 +525,7 @@ EditorPropertyEnum::EditorPropertyEnum() {
 	options->set_flat(true);
 	add_child(options);
 	add_focusable(options);
-	options->connect_compat("item_selected", this, "_option_selected");
+	options->connect("item_selected", callable_mp(this, &EditorPropertyEnum::_option_selected));
 }
 
 ///////////////////// FLAGS /////////////////////////
@@ -591,7 +570,7 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 			CheckBox *cb = memnew(CheckBox);
 			cb->set_text(option);
 			cb->set_clip_text(true);
-			cb->connect_compat("pressed", this, "_flag_toggled");
+			cb->connect("pressed", callable_mp(this, &EditorPropertyFlags::_flag_toggled));
 			add_focusable(cb);
 			vbox->add_child(cb);
 			flags.push_back(cb);
@@ -605,8 +584,6 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 }
 
 void EditorPropertyFlags::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_flag_toggled"), &EditorPropertyFlags::_flag_toggled);
 }
 
 EditorPropertyFlags::EditorPropertyFlags() {
@@ -791,10 +768,6 @@ void EditorPropertyLayers::_menu_pressed(int p_menu) {
 }
 
 void EditorPropertyLayers::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_grid_changed"), &EditorPropertyLayers::_grid_changed);
-	ClassDB::bind_method(D_METHOD("_button_pressed"), &EditorPropertyLayers::_button_pressed);
-	ClassDB::bind_method(D_METHOD("_menu_pressed"), &EditorPropertyLayers::_menu_pressed);
 }
 
 EditorPropertyLayers::EditorPropertyLayers() {
@@ -802,19 +775,19 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
 	grid = memnew(EditorPropertyLayersGrid);
-	grid->connect_compat("flag_changed", this, "_grid_changed");
+	grid->connect("flag_changed", callable_mp(this, &EditorPropertyLayers::_grid_changed));
 	grid->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(grid);
 	button = memnew(Button);
 	button->set_toggle_mode(true);
 	button->set_text("..");
-	button->connect_compat("pressed", this, "_button_pressed");
+	button->connect("pressed", callable_mp(this, &EditorPropertyLayers::_button_pressed));
 	hb->add_child(button);
 	set_bottom_editor(hb);
 	layers = memnew(PopupMenu);
 	add_child(layers);
 	layers->set_hide_on_checkable_item_selection(false);
-	layers->connect_compat("id_pressed", this, "_menu_pressed");
+	layers->connect("id_pressed", callable_mp(this, &EditorPropertyLayers::_menu_pressed));
 	layers->connect_compat("popup_hide", button, "set_pressed", varray(false));
 }
 
@@ -840,7 +813,6 @@ void EditorPropertyInteger::update_property() {
 }
 
 void EditorPropertyInteger::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyInteger::_value_changed);
 }
 
 void EditorPropertyInteger::setup(int64_t p_min, int64_t p_max, int64_t p_step, bool p_allow_greater, bool p_allow_lesser) {
@@ -856,7 +828,7 @@ EditorPropertyInteger::EditorPropertyInteger() {
 	spin->set_flat(true);
 	add_child(spin);
 	add_focusable(spin);
-	spin->connect_compat("value_changed", this, "_value_changed");
+	spin->connect("value_changed", callable_mp(this, &EditorPropertyInteger::_value_changed));
 	setting = false;
 }
 
@@ -889,14 +861,13 @@ void EditorPropertyObjectID::setup(const String &p_base_type) {
 }
 
 void EditorPropertyObjectID::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_edit_pressed"), &EditorPropertyObjectID::_edit_pressed);
 }
 
 EditorPropertyObjectID::EditorPropertyObjectID() {
 	edit = memnew(Button);
 	add_child(edit);
 	add_focusable(edit);
-	edit->connect_compat("pressed", this, "_edit_pressed");
+	edit->connect("pressed", callable_mp(this, &EditorPropertyObjectID::_edit_pressed));
 }
 
 ///////////////////// FLOAT /////////////////////////
@@ -916,8 +887,6 @@ void EditorPropertyFloat::update_property() {
 }
 
 void EditorPropertyFloat::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyFloat::_value_changed);
 }
 
 void EditorPropertyFloat::setup(double p_min, double p_max, double p_step, bool p_no_slider, bool p_exp_range, bool p_greater, bool p_lesser) {
@@ -936,7 +905,7 @@ EditorPropertyFloat::EditorPropertyFloat() {
 	spin->set_flat(true);
 	add_child(spin);
 	add_focusable(spin);
-	spin->connect_compat("value_changed", this, "_value_changed");
+	spin->connect("value_changed", callable_mp(this, &EditorPropertyFloat::_value_changed));
 	setting = false;
 }
 
@@ -1103,26 +1072,19 @@ void EditorPropertyEasing::_notification(int p_what) {
 }
 
 void EditorPropertyEasing::_bind_methods() {
-
-	ClassDB::bind_method("_draw_easing", &EditorPropertyEasing::_draw_easing);
-	ClassDB::bind_method("_drag_easing", &EditorPropertyEasing::_drag_easing);
-	ClassDB::bind_method("_set_preset", &EditorPropertyEasing::_set_preset);
-
-	ClassDB::bind_method("_spin_value_changed", &EditorPropertyEasing::_spin_value_changed);
-	ClassDB::bind_method("_spin_focus_exited", &EditorPropertyEasing::_spin_focus_exited);
 }
 
 EditorPropertyEasing::EditorPropertyEasing() {
 
 	easing_draw = memnew(Control);
-	easing_draw->connect_compat("draw", this, "_draw_easing");
-	easing_draw->connect_compat("gui_input", this, "_drag_easing");
+	easing_draw->connect("draw", callable_mp(this, &EditorPropertyEasing::_draw_easing));
+	easing_draw->connect("gui_input", callable_mp(this, &EditorPropertyEasing::_drag_easing));
 	easing_draw->set_default_cursor_shape(Control::CURSOR_MOVE);
 	add_child(easing_draw);
 
 	preset = memnew(PopupMenu);
 	add_child(preset);
-	preset->connect_compat("id_pressed", this, "_set_preset");
+	preset->connect("id_pressed", callable_mp(this, &EditorPropertyEasing::_set_preset));
 
 	spin = memnew(EditorSpinSlider);
 	spin->set_flat(true);
@@ -1132,8 +1094,8 @@ EditorPropertyEasing::EditorPropertyEasing() {
 	spin->set_hide_slider(true);
 	spin->set_allow_lesser(true);
 	spin->set_allow_greater(true);
-	spin->connect_compat("value_changed", this, "_spin_value_changed");
-	spin->get_line_edit()->connect_compat("focus_exited", this, "_spin_focus_exited");
+	spin->connect("value_changed", callable_mp(this, &EditorPropertyEasing::_spin_value_changed));
+	spin->get_line_edit()->connect("focus_exited", callable_mp(this, &EditorPropertyEasing::_spin_focus_exited));
 	spin->hide();
 	add_child(spin);
 
@@ -1175,8 +1137,6 @@ void EditorPropertyVector2::_notification(int p_what) {
 }
 
 void EditorPropertyVector2::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyVector2::_value_changed);
 }
 
 void EditorPropertyVector2::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
@@ -1211,7 +1171,7 @@ EditorPropertyVector2::EditorPropertyVector2() {
 		spin[i]->set_label(desc[i]);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyVector2::_value_changed), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1258,8 +1218,6 @@ void EditorPropertyRect2::_notification(int p_what) {
 	}
 }
 void EditorPropertyRect2::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyRect2::_value_changed);
 }
 
 void EditorPropertyRect2::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
@@ -1295,7 +1253,7 @@ EditorPropertyRect2::EditorPropertyRect2() {
 		spin[i]->set_flat(true);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyRect2::_value_changed), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1340,8 +1298,6 @@ void EditorPropertyVector3::_notification(int p_what) {
 	}
 }
 void EditorPropertyVector3::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyVector3::_value_changed);
 }
 
 void EditorPropertyVector3::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
@@ -1376,7 +1332,7 @@ EditorPropertyVector3::EditorPropertyVector3() {
 		spin[i]->set_label(desc[i]);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyVector3::_value_changed), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1422,8 +1378,6 @@ void EditorPropertyPlane::_notification(int p_what) {
 	}
 }
 void EditorPropertyPlane::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyPlane::_value_changed);
 }
 
 void EditorPropertyPlane::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
@@ -1459,7 +1413,7 @@ EditorPropertyPlane::EditorPropertyPlane() {
 		spin[i]->set_label(desc[i]);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyPlane::_value_changed), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1506,8 +1460,6 @@ void EditorPropertyQuat::_notification(int p_what) {
 	}
 }
 void EditorPropertyQuat::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyQuat::_value_changed);
 }
 
 void EditorPropertyQuat::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
@@ -1542,7 +1494,7 @@ EditorPropertyQuat::EditorPropertyQuat() {
 		spin[i]->set_label(desc[i]);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyQuat::_value_changed), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1595,8 +1547,6 @@ void EditorPropertyAABB::_notification(int p_what) {
 	}
 }
 void EditorPropertyAABB::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyAABB::_value_changed);
 }
 
 void EditorPropertyAABB::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
@@ -1624,7 +1574,7 @@ EditorPropertyAABB::EditorPropertyAABB() {
 		g->add_child(spin[i]);
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyAABB::_value_changed), varray(desc[i]));
 	}
 	set_bottom_editor(g);
 	setting = false;
@@ -1671,8 +1621,6 @@ void EditorPropertyTransform2D::_notification(int p_what) {
 	}
 }
 void EditorPropertyTransform2D::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyTransform2D::_value_changed);
 }
 
 void EditorPropertyTransform2D::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
@@ -1699,7 +1647,7 @@ EditorPropertyTransform2D::EditorPropertyTransform2D() {
 		g->add_child(spin[i]);
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyTransform2D::_value_changed), varray(desc[i]));
 	}
 	set_bottom_editor(g);
 	setting = false;
@@ -1752,8 +1700,6 @@ void EditorPropertyBasis::_notification(int p_what) {
 	}
 }
 void EditorPropertyBasis::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyBasis::_value_changed);
 }
 
 void EditorPropertyBasis::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
@@ -1780,7 +1726,7 @@ EditorPropertyBasis::EditorPropertyBasis() {
 		g->add_child(spin[i]);
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyBasis::_value_changed), varray(desc[i]));
 	}
 	set_bottom_editor(g);
 	setting = false;
@@ -1839,8 +1785,6 @@ void EditorPropertyTransform::_notification(int p_what) {
 	}
 }
 void EditorPropertyTransform::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyTransform::_value_changed);
 }
 
 void EditorPropertyTransform::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
@@ -1867,7 +1811,7 @@ EditorPropertyTransform::EditorPropertyTransform() {
 		g->add_child(spin[i]);
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyTransform::_value_changed), varray(desc[i]));
 	}
 	set_bottom_editor(g);
 	setting = false;
@@ -1895,10 +1839,6 @@ void EditorPropertyColor::_picker_created() {
 }
 
 void EditorPropertyColor::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_color_changed"), &EditorPropertyColor::_color_changed);
-	ClassDB::bind_method(D_METHOD("_popup_closed"), &EditorPropertyColor::_popup_closed);
-	ClassDB::bind_method(D_METHOD("_picker_created"), &EditorPropertyColor::_picker_created);
 }
 
 void EditorPropertyColor::update_property() {
@@ -1932,9 +1872,9 @@ EditorPropertyColor::EditorPropertyColor() {
 	picker = memnew(ColorPickerButton);
 	add_child(picker);
 	picker->set_flat(true);
-	picker->connect_compat("color_changed", this, "_color_changed");
-	picker->connect_compat("popup_closed", this, "_popup_closed");
-	picker->connect_compat("picker_created", this, "_picker_created");
+	picker->connect("color_changed", callable_mp(this, &EditorPropertyColor::_color_changed));
+	picker->connect("popup_closed", callable_mp(this, &EditorPropertyColor::_popup_closed));
+	picker->connect("picker_created", callable_mp(this, &EditorPropertyColor::_picker_created));
 }
 
 ////////////// NODE PATH //////////////////////
@@ -1981,7 +1921,7 @@ void EditorPropertyNodePath::_node_assign() {
 		scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
 		scene_tree->get_scene_tree()->set_valid_types(valid_types);
 		add_child(scene_tree);
-		scene_tree->connect_compat("selected", this, "_node_selected");
+		scene_tree->connect("selected", callable_mp(this, &EditorPropertyNodePath::_node_selected));
 	}
 	scene_tree->popup_centered_ratio();
 }
@@ -2049,10 +1989,6 @@ void EditorPropertyNodePath::_notification(int p_what) {
 }
 
 void EditorPropertyNodePath::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_node_selected"), &EditorPropertyNodePath::_node_selected);
-	ClassDB::bind_method(D_METHOD("_node_assign"), &EditorPropertyNodePath::_node_assign);
-	ClassDB::bind_method(D_METHOD("_node_clear"), &EditorPropertyNodePath::_node_clear);
 }
 
 EditorPropertyNodePath::EditorPropertyNodePath() {
@@ -2063,12 +1999,12 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 	assign->set_flat(true);
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
-	assign->connect_compat("pressed", this, "_node_assign");
+	assign->connect("pressed", callable_mp(this, &EditorPropertyNodePath::_node_assign));
 	hbc->add_child(assign);
 
 	clear = memnew(Button);
 	clear->set_flat(true);
-	clear->connect_compat("pressed", this, "_node_clear");
+	clear->connect("pressed", callable_mp(this, &EditorPropertyNodePath::_node_clear));
 	hbc->add_child(clear);
 	use_path_from_scene_root = false;
 
@@ -2135,7 +2071,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 
 			if (!file) {
 				file = memnew(EditorFileDialog);
-				file->connect_compat("file_selected", this, "_file_selected");
+				file->connect("file_selected", callable_mp(this, &EditorPropertyResource::_file_selected));
 				add_child(file);
 			}
 			file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
@@ -2304,7 +2240,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 					scene_tree->get_scene_tree()->set_valid_types(valid_types);
 					scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
 					add_child(scene_tree);
-					scene_tree->connect_compat("selected", this, "_viewport_selected");
+					scene_tree->connect("selected", callable_mp(this, &EditorPropertyResource::_viewport_selected));
 					scene_tree->set_title(TTR("Pick a Viewport"));
 				}
 				scene_tree->popup_centered_ratio();
@@ -2622,9 +2558,9 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->set_sub_inspector(true);
 				sub_inspector->set_enable_capitalize_paths(true);
 
-				sub_inspector->connect_compat("property_keyed", this, "_sub_inspector_property_keyed");
-				sub_inspector->connect_compat("resource_selected", this, "_sub_inspector_resource_selected");
-				sub_inspector->connect_compat("object_id_selected", this, "_sub_inspector_object_id_selected");
+				sub_inspector->connect("property_keyed", callable_mp(this, &EditorPropertyResource::_sub_inspector_property_keyed));
+				sub_inspector->connect("resource_selected", callable_mp(this, &EditorPropertyResource::_sub_inspector_resource_selected));
+				sub_inspector->connect("object_id_selected", callable_mp(this, &EditorPropertyResource::_sub_inspector_object_id_selected));
 				sub_inspector->set_keying(is_keying());
 				sub_inspector->set_read_only(is_read_only());
 				sub_inspector->set_use_folding(is_using_folding());
@@ -2876,21 +2812,11 @@ void EditorPropertyResource::set_use_sub_inspector(bool p_enable) {
 
 void EditorPropertyResource::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_file_selected"), &EditorPropertyResource::_file_selected);
-	ClassDB::bind_method(D_METHOD("_menu_option"), &EditorPropertyResource::_menu_option);
-	ClassDB::bind_method(D_METHOD("_update_menu"), &EditorPropertyResource::_update_menu);
 	ClassDB::bind_method(D_METHOD("_resource_preview"), &EditorPropertyResource::_resource_preview);
-	ClassDB::bind_method(D_METHOD("_resource_selected"), &EditorPropertyResource::_resource_selected);
-	ClassDB::bind_method(D_METHOD("_viewport_selected"), &EditorPropertyResource::_viewport_selected);
-	ClassDB::bind_method(D_METHOD("_sub_inspector_property_keyed"), &EditorPropertyResource::_sub_inspector_property_keyed);
-	ClassDB::bind_method(D_METHOD("_sub_inspector_resource_selected"), &EditorPropertyResource::_sub_inspector_resource_selected);
-	ClassDB::bind_method(D_METHOD("_sub_inspector_object_id_selected"), &EditorPropertyResource::_sub_inspector_object_id_selected);
 	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &EditorPropertyResource::get_drag_data_fw);
 	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &EditorPropertyResource::can_drop_data_fw);
 	ClassDB::bind_method(D_METHOD("drop_data_fw"), &EditorPropertyResource::drop_data_fw);
-	ClassDB::bind_method(D_METHOD("_button_draw"), &EditorPropertyResource::_button_draw);
 	ClassDB::bind_method(D_METHOD("_open_editor_pressed"), &EditorPropertyResource::_open_editor_pressed);
-	ClassDB::bind_method(D_METHOD("_button_input"), &EditorPropertyResource::_button_input);
 	ClassDB::bind_method(D_METHOD("_fold_other_editors"), &EditorPropertyResource::_fold_other_editors);
 }
 
@@ -2907,9 +2833,9 @@ EditorPropertyResource::EditorPropertyResource() {
 	assign->set_flat(true);
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
-	assign->connect_compat("pressed", this, "_resource_selected");
+	assign->connect("pressed", callable_mp(this, &EditorPropertyResource::_resource_selected));
 	assign->set_drag_forwarding(this);
-	assign->connect_compat("draw", this, "_button_draw");
+	assign->connect("draw", callable_mp(this, &EditorPropertyResource::_button_draw));
 	hbc->add_child(assign);
 	add_focusable(assign);
 
@@ -2920,18 +2846,18 @@ EditorPropertyResource::EditorPropertyResource() {
 	preview->set_margin(MARGIN_BOTTOM, -1);
 	preview->set_margin(MARGIN_RIGHT, -1);
 	assign->add_child(preview);
-	assign->connect_compat("gui_input", this, "_button_input");
+	assign->connect("gui_input", callable_mp(this, &EditorPropertyResource::_button_input));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
 	edit = memnew(Button);
 	edit->set_flat(true);
 	edit->set_toggle_mode(true);
-	menu->connect_compat("id_pressed", this, "_menu_option");
+	menu->connect("id_pressed", callable_mp(this, &EditorPropertyResource::_menu_option));
 	menu->connect_compat("popup_hide", edit, "set_pressed", varray(false));
-	edit->connect_compat("pressed", this, "_update_menu");
+	edit->connect("pressed", callable_mp(this, &EditorPropertyResource::_update_menu));
 	hbc->add_child(edit);
-	edit->connect_compat("gui_input", this, "_button_input");
+	edit->connect("gui_input", callable_mp(this, &EditorPropertyResource::_button_input));
 	add_focusable(edit);
 
 	file = NULL;

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -788,7 +788,7 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	add_child(layers);
 	layers->set_hide_on_checkable_item_selection(false);
 	layers->connect("id_pressed", callable_mp(this, &EditorPropertyLayers::_menu_pressed));
-	layers->connect_compat("popup_hide", button, "set_pressed", varray(false));
+	layers->connect("popup_hide", callable_mp((BaseButton *)button, &BaseButton::set_pressed), varray(false));
 }
 
 ///////////////////// INT /////////////////////////
@@ -2854,7 +2854,7 @@ EditorPropertyResource::EditorPropertyResource() {
 	edit->set_flat(true);
 	edit->set_toggle_mode(true);
 	menu->connect("id_pressed", callable_mp(this, &EditorPropertyResource::_menu_option));
-	menu->connect_compat("popup_hide", edit, "set_pressed", varray(false));
+	menu->connect("popup_hide", callable_mp((BaseButton *)edit, &BaseButton::set_pressed), varray(false));
 	edit->connect("pressed", callable_mp(this, &EditorPropertyResource::_update_menu));
 	hbc->add_child(edit);
 	edit->connect("gui_input", callable_mp(this, &EditorPropertyResource::_button_input));

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -290,7 +290,7 @@ void EditorPropertyArray::update_property() {
 			length->set_max(1000000);
 			length->set_h_size_flags(SIZE_EXPAND_FILL);
 			hbc->add_child(length);
-			length->connect_compat("value_changed", this, "_length_changed");
+			length->connect("value_changed", callable_mp(this, &EditorPropertyArray::_length_changed));
 
 			page_hb = memnew(HBoxContainer);
 			vbox->add_child(page_hb);
@@ -301,7 +301,7 @@ void EditorPropertyArray::update_property() {
 			page->set_step(1);
 			page_hb->add_child(page);
 			page->set_h_size_flags(SIZE_EXPAND_FILL);
-			page->connect_compat("value_changed", this, "_page_changed");
+			page->connect("value_changed", callable_mp(this, &EditorPropertyArray::_page_changed));
 		} else {
 			//bye bye children of the box
 			while (vbox->get_child_count() > 2) {
@@ -353,8 +353,8 @@ void EditorPropertyArray::update_property() {
 			prop->set_object_and_property(object.ptr(), prop_name);
 			prop->set_label(itos(i + offset));
 			prop->set_selectable(false);
-			prop->connect_compat("property_changed", this, "_property_changed");
-			prop->connect_compat("object_id_selected", this, "_object_id_selected");
+			prop->connect("property_changed", callable_mp(this, &EditorPropertyArray::_property_changed));
+			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyArray::_object_id_selected));
 			prop->set_h_size_flags(SIZE_EXPAND_FILL);
 
 			HBoxContainer *hb = memnew(HBoxContainer);
@@ -369,12 +369,12 @@ void EditorPropertyArray::update_property() {
 				Button *edit = memnew(Button);
 				edit->set_icon(get_icon("Edit", "EditorIcons"));
 				hb->add_child(edit);
-				edit->connect_compat("pressed", this, "_change_type", varray(edit, i + offset));
+				edit->connect("pressed", callable_mp(this, &EditorPropertyArray::_change_type), varray(edit, i + offset));
 			} else {
 
 				Button *remove = memnew(Button);
 				remove->set_icon(get_icon("Remove", "EditorIcons"));
-				remove->connect_compat("pressed", this, "_remove_pressed", varray(i + offset));
+				remove->connect("pressed", callable_mp(this, &EditorPropertyArray::_remove_pressed), varray(i + offset));
 				hb->add_child(remove);
 			}
 
@@ -484,14 +484,6 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 }
 
 void EditorPropertyArray::_bind_methods() {
-	ClassDB::bind_method("_edit_pressed", &EditorPropertyArray::_edit_pressed);
-	ClassDB::bind_method("_page_changed", &EditorPropertyArray::_page_changed);
-	ClassDB::bind_method("_length_changed", &EditorPropertyArray::_length_changed);
-	ClassDB::bind_method("_property_changed", &EditorPropertyArray::_property_changed, DEFVAL(String()), DEFVAL(false));
-	ClassDB::bind_method("_change_type", &EditorPropertyArray::_change_type);
-	ClassDB::bind_method("_change_type_menu", &EditorPropertyArray::_change_type_menu);
-	ClassDB::bind_method("_object_id_selected", &EditorPropertyArray::_object_id_selected);
-	ClassDB::bind_method("_remove_pressed", &EditorPropertyArray::_remove_pressed);
 }
 
 EditorPropertyArray::EditorPropertyArray() {
@@ -503,7 +495,7 @@ EditorPropertyArray::EditorPropertyArray() {
 	edit->set_flat(true);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
-	edit->connect_compat("pressed", this, "_edit_pressed");
+	edit->connect("pressed", callable_mp(this, &EditorPropertyArray::_edit_pressed));
 	edit->set_toggle_mode(true);
 	add_child(edit);
 	add_focusable(edit);
@@ -513,7 +505,7 @@ EditorPropertyArray::EditorPropertyArray() {
 	updating = false;
 	change_type = memnew(PopupMenu);
 	add_child(change_type);
-	change_type->connect_compat("id_pressed", this, "_change_type_menu");
+	change_type->connect("id_pressed", callable_mp(this, &EditorPropertyArray::_change_type_menu));
 
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 		String type = Variant::get_type_name(Variant::Type(i));
@@ -661,7 +653,7 @@ void EditorPropertyDictionary::update_property() {
 			page->set_step(1);
 			page_hb->add_child(page);
 			page->set_h_size_flags(SIZE_EXPAND_FILL);
-			page->connect_compat("value_changed", this, "_page_changed");
+			page->connect("value_changed", callable_mp(this, &EditorPropertyDictionary::_page_changed));
 		} else {
 			// Queue children for deletion, deleting immediately might cause errors.
 			for (int i = 1; i < vbox->get_child_count(); i++) {
@@ -922,8 +914,8 @@ void EditorPropertyDictionary::update_property() {
 			}
 
 			prop->set_selectable(false);
-			prop->connect_compat("property_changed", this, "_property_changed");
-			prop->connect_compat("object_id_selected", this, "_object_id_selected");
+			prop->connect("property_changed", callable_mp(this, &EditorPropertyDictionary::_property_changed));
+			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
 
 			HBoxContainer *hb = memnew(HBoxContainer);
 			if (add_vbox) {
@@ -936,14 +928,14 @@ void EditorPropertyDictionary::update_property() {
 			Button *edit = memnew(Button);
 			edit->set_icon(get_icon("Edit", "EditorIcons"));
 			hb->add_child(edit);
-			edit->connect_compat("pressed", this, "_change_type", varray(edit, change_index));
+			edit->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_change_type), varray(edit, change_index));
 
 			prop->update_property();
 
 			if (i == amount + 1) {
 				Button *butt_add_item = memnew(Button);
 				butt_add_item->set_text(TTR("Add Key/Value Pair"));
-				butt_add_item->connect_compat("pressed", this, "_add_key_value");
+				butt_add_item->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_add_key_value));
 				add_vbox->add_child(butt_add_item);
 			}
 		}
@@ -987,13 +979,6 @@ void EditorPropertyDictionary::_page_changed(double p_page) {
 }
 
 void EditorPropertyDictionary::_bind_methods() {
-	ClassDB::bind_method("_edit_pressed", &EditorPropertyDictionary::_edit_pressed);
-	ClassDB::bind_method("_page_changed", &EditorPropertyDictionary::_page_changed);
-	ClassDB::bind_method("_property_changed", &EditorPropertyDictionary::_property_changed, DEFVAL(String()), DEFVAL(false));
-	ClassDB::bind_method("_change_type", &EditorPropertyDictionary::_change_type);
-	ClassDB::bind_method("_change_type_menu", &EditorPropertyDictionary::_change_type_menu);
-	ClassDB::bind_method("_add_key_value", &EditorPropertyDictionary::_add_key_value);
-	ClassDB::bind_method("_object_id_selected", &EditorPropertyDictionary::_object_id_selected);
 }
 
 EditorPropertyDictionary::EditorPropertyDictionary() {
@@ -1005,7 +990,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	edit->set_flat(true);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
-	edit->connect_compat("pressed", this, "_edit_pressed");
+	edit->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_edit_pressed));
 	edit->set_toggle_mode(true);
 	add_child(edit);
 	add_focusable(edit);
@@ -1014,7 +999,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	updating = false;
 	change_type = memnew(PopupMenu);
 	add_child(change_type);
-	change_type->connect_compat("id_pressed", this, "_change_type_menu");
+	change_type->connect("id_pressed", callable_mp(this, &EditorPropertyDictionary::_change_type_menu));
 
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 		String type = Variant::get_type_name(Variant::Type(i));

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -55,8 +55,8 @@ void EditorRunNative::_notification(int p_what) {
 					small_icon.instance();
 					small_icon->create_from_image(im);
 					MenuButton *mb = memnew(MenuButton);
-					mb->get_popup()->connect_compat("id_pressed", this, "_run_native", varray(i));
-					mb->connect_compat("pressed", this, "_run_native", varray(-1, i));
+					mb->get_popup()->connect("id_pressed", callable_mp(this, &EditorRunNative::_run_native), varray(i));
+					mb->connect("pressed", callable_mp(this, &EditorRunNative::_run_native), varray(-1, i));
 					mb->set_icon(small_icon);
 					add_child(mb);
 					menus[i] = mb;
@@ -153,8 +153,6 @@ void EditorRunNative::resume_run_native() {
 }
 
 void EditorRunNative::_bind_methods() {
-
-	ClassDB::bind_method("_run_native", &EditorRunNative::_run_native);
 
 	ADD_SIGNAL(MethodInfo("native_run"));
 }

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -133,9 +133,6 @@ public:
 
 void SectionedInspector::_bind_methods() {
 
-	ClassDB::bind_method("_section_selected", &SectionedInspector::_section_selected);
-	ClassDB::bind_method("_search_changed", &SectionedInspector::_search_changed);
-
 	ClassDB::bind_method("update_category_list", &SectionedInspector::update_category_list);
 }
 
@@ -294,7 +291,7 @@ void SectionedInspector::register_search_box(LineEdit *p_box) {
 
 	search_box = p_box;
 	inspector->register_text_enter(p_box);
-	search_box->connect_compat("text_changed", this, "_search_changed");
+	search_box->connect("text_changed", callable_mp(this, &SectionedInspector::_search_changed));
 }
 
 void SectionedInspector::_search_changed(const String &p_what) {
@@ -332,7 +329,7 @@ SectionedInspector::SectionedInspector() :
 	right_vb->add_child(inspector, true);
 	inspector->set_use_doc_hints(true);
 
-	sections->connect_compat("cell_selected", this, "_section_selected");
+	sections->connect("cell_selected", callable_mp(this, &SectionedInspector::_section_selected));
 }
 
 SectionedInspector::~SectionedInspector() {

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -463,12 +463,6 @@ void EditorSpinSlider::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_flat"), &EditorSpinSlider::is_flat);
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &EditorSpinSlider::_gui_input);
-	ClassDB::bind_method(D_METHOD("_grabber_mouse_entered"), &EditorSpinSlider::_grabber_mouse_entered);
-	ClassDB::bind_method(D_METHOD("_grabber_mouse_exited"), &EditorSpinSlider::_grabber_mouse_exited);
-	ClassDB::bind_method(D_METHOD("_grabber_gui_input"), &EditorSpinSlider::_grabber_gui_input);
-	ClassDB::bind_method(D_METHOD("_value_input_closed"), &EditorSpinSlider::_value_input_closed);
-	ClassDB::bind_method(D_METHOD("_value_input_entered"), &EditorSpinSlider::_value_input_entered);
-	ClassDB::bind_method(D_METHOD("_value_focus_exited"), &EditorSpinSlider::_value_focus_exited);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "label"), "set_label", "get_label");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "read_only"), "set_read_only", "is_read_only");
@@ -490,9 +484,9 @@ EditorSpinSlider::EditorSpinSlider() {
 	grabber->hide();
 	grabber->set_as_toplevel(true);
 	grabber->set_mouse_filter(MOUSE_FILTER_STOP);
-	grabber->connect_compat("mouse_entered", this, "_grabber_mouse_entered");
-	grabber->connect_compat("mouse_exited", this, "_grabber_mouse_exited");
-	grabber->connect_compat("gui_input", this, "_grabber_gui_input");
+	grabber->connect("mouse_entered", callable_mp(this, &EditorSpinSlider::_grabber_mouse_entered));
+	grabber->connect("mouse_exited", callable_mp(this, &EditorSpinSlider::_grabber_mouse_exited));
+	grabber->connect("gui_input", callable_mp(this, &EditorSpinSlider::_grabber_gui_input));
 	mouse_over_spin = false;
 	mouse_over_grabber = false;
 	mousewheel_over_grabber = false;
@@ -502,9 +496,9 @@ EditorSpinSlider::EditorSpinSlider() {
 	add_child(value_input);
 	value_input->set_as_toplevel(true);
 	value_input->hide();
-	value_input->connect_compat("modal_closed", this, "_value_input_closed");
-	value_input->connect_compat("text_entered", this, "_value_input_entered");
-	value_input->connect_compat("focus_exited", this, "_value_focus_exited");
+	value_input->connect("modal_closed", callable_mp(this, &EditorSpinSlider::_value_input_closed));
+	value_input->connect("text_entered", callable_mp(this, &EditorSpinSlider::_value_input_entered));
+	value_input->connect("focus_exited", callable_mp(this, &EditorSpinSlider::_value_focus_exited));
 	value_input_just_closed = false;
 	hide_slider = false;
 	read_only = false;

--- a/editor/editor_sub_scene.cpp
+++ b/editor/editor_sub_scene.cpp
@@ -217,11 +217,6 @@ void EditorSubScene::clear() {
 
 void EditorSubScene::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_path_selected"), &EditorSubScene::_path_selected);
-	ClassDB::bind_method(D_METHOD("_path_changed"), &EditorSubScene::_path_changed);
-	ClassDB::bind_method(D_METHOD("_path_browse"), &EditorSubScene::_path_browse);
-	ClassDB::bind_method(D_METHOD("_item_multi_selected"), &EditorSubScene::_item_multi_selected);
-	ClassDB::bind_method(D_METHOD("_selected_changed"), &EditorSubScene::_selected_changed);
 	ADD_SIGNAL(MethodInfo("subscene_selected"));
 }
 
@@ -239,22 +234,22 @@ EditorSubScene::EditorSubScene() {
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	path = memnew(LineEdit);
-	path->connect_compat("text_entered", this, "_path_changed");
+	path->connect("text_entered", callable_mp(this, &EditorSubScene::_path_changed));
 	hb->add_child(path);
 	path->set_h_size_flags(SIZE_EXPAND_FILL);
 	Button *b = memnew(Button);
 	b->set_text(TTR("Browse"));
 	hb->add_child(b);
-	b->connect_compat("pressed", this, "_path_browse");
+	b->connect("pressed", callable_mp(this, &EditorSubScene::_path_browse));
 	vb->add_margin_child(TTR("Scene Path:"), hb);
 
 	tree = memnew(Tree);
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	vb->add_margin_child(TTR("Import From Node:"), tree, true);
 	tree->set_select_mode(Tree::SELECT_MULTI);
-	tree->connect_compat("multi_selected", this, "_item_multi_selected");
+	tree->connect("multi_selected", callable_mp(this, &EditorSubScene::_item_multi_selected));
 	//tree->connect("nothing_selected", this, "_deselect_items");
-	tree->connect_compat("cell_selected", this, "_selected_changed");
+	tree->connect("cell_selected", callable_mp(this, &EditorSubScene::_selected_changed));
 
 	tree->connect_compat("item_activated", this, "_ok", make_binds(), CONNECT_DEFERRED);
 
@@ -269,5 +264,5 @@ EditorSubScene::EditorSubScene() {
 
 	file_dialog->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_path_selected");
+	file_dialog->connect("file_selected", callable_mp(this, &EditorSubScene::_path_selected));
 }

--- a/editor/editor_visual_profiler.cpp
+++ b/editor/editor_visual_profiler.cpp
@@ -666,17 +666,6 @@ void EditorVisualProfiler::_combo_changed(int) {
 
 void EditorVisualProfiler::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_update_frame"), &EditorVisualProfiler::_update_frame, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("_update_plot"), &EditorVisualProfiler::_update_plot);
-	ClassDB::bind_method(D_METHOD("_activate_pressed"), &EditorVisualProfiler::_activate_pressed);
-	ClassDB::bind_method(D_METHOD("_clear_pressed"), &EditorVisualProfiler::_clear_pressed);
-	ClassDB::bind_method(D_METHOD("_graph_tex_draw"), &EditorVisualProfiler::_graph_tex_draw);
-	ClassDB::bind_method(D_METHOD("_graph_tex_input"), &EditorVisualProfiler::_graph_tex_input);
-	ClassDB::bind_method(D_METHOD("_graph_tex_mouse_exit"), &EditorVisualProfiler::_graph_tex_mouse_exit);
-	ClassDB::bind_method(D_METHOD("_cursor_metric_changed"), &EditorVisualProfiler::_cursor_metric_changed);
-	ClassDB::bind_method(D_METHOD("_combo_changed"), &EditorVisualProfiler::_combo_changed);
-
-	ClassDB::bind_method(D_METHOD("_item_selected"), &EditorVisualProfiler::_item_selected);
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));
 }
 
@@ -753,12 +742,12 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
-	activate->connect_compat("pressed", this, "_activate_pressed");
+	activate->connect("pressed", callable_mp(this, &EditorVisualProfiler::_activate_pressed));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
-	clear_button->connect_compat("pressed", this, "_clear_pressed");
+	clear_button->connect("pressed", callable_mp(this, &EditorVisualProfiler::_clear_pressed));
 	hb->add_child(clear_button);
 
 	hb->add_child(memnew(Label(TTR("Measure:"))));
@@ -766,18 +755,18 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	display_mode = memnew(OptionButton);
 	display_mode->add_item(TTR("Frame Time (msec)"));
 	display_mode->add_item(TTR("Frame %"));
-	display_mode->connect_compat("item_selected", this, "_combo_changed");
+	display_mode->connect("item_selected", callable_mp(this, &EditorVisualProfiler::_combo_changed));
 
 	hb->add_child(display_mode);
 
 	frame_relative = memnew(CheckBox(TTR("Fit to Frame")));
 	frame_relative->set_pressed(true);
 	hb->add_child(frame_relative);
-	frame_relative->connect_compat("pressed", this, "_update_plot");
+	frame_relative->connect("pressed", callable_mp(this, &EditorVisualProfiler::_update_plot));
 	linked = memnew(CheckBox(TTR("Linked")));
 	linked->set_pressed(true);
 	hb->add_child(linked);
-	linked->connect_compat("pressed", this, "_update_plot");
+	linked->connect("pressed", callable_mp(this, &EditorVisualProfiler::_update_plot));
 
 	hb->add_spacer();
 
@@ -786,7 +775,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
 	hb->add_child(cursor_metric_edit);
-	cursor_metric_edit->connect_compat("value_changed", this, "_cursor_metric_changed");
+	cursor_metric_edit->connect("value_changed", callable_mp(this, &EditorVisualProfiler::_cursor_metric_changed));
 
 	hb->add_constant_override("separation", 8 * EDSCALE);
 
@@ -810,15 +799,15 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->set_column_title(2, TTR("GPU"));
 	variables->set_column_expand(2, false);
 	variables->set_column_min_width(2, 60 * EDSCALE);
-	variables->connect_compat("cell_selected", this, "_item_selected");
+	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
 
 	graph = memnew(TextureRect);
 	graph->set_expand(true);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
 	//graph->set_ignore_mouse(false);
-	graph->connect_compat("draw", this, "_graph_tex_draw");
-	graph->connect_compat("gui_input", this, "_graph_tex_input");
-	graph->connect_compat("mouse_exited", this, "_graph_tex_mouse_exit");
+	graph->connect("draw", callable_mp(this, &EditorVisualProfiler::_graph_tex_draw));
+	graph->connect("gui_input", callable_mp(this, &EditorVisualProfiler::_graph_tex_input));
+	graph->connect("mouse_exited", callable_mp(this, &EditorVisualProfiler::_graph_tex_mouse_exit));
 
 	h_split->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -835,13 +824,13 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);
 	add_child(frame_delay);
-	frame_delay->connect_compat("timeout", this, "_update_frame");
+	frame_delay->connect("timeout", callable_mp(this, &EditorVisualProfiler::_update_frame));
 
 	plot_delay = memnew(Timer);
 	plot_delay->set_wait_time(0.1);
 	plot_delay->set_one_shot(true);
 	add_child(plot_delay);
-	plot_delay->connect_compat("timeout", this, "_update_plot");
+	plot_delay->connect("timeout", callable_mp(this, &EditorVisualProfiler::_update_plot));
 
 	seeking = false;
 	graph_height_cpu = 1;

--- a/editor/editor_visual_profiler.cpp
+++ b/editor/editor_visual_profiler.cpp
@@ -667,6 +667,7 @@ void EditorVisualProfiler::_combo_changed(int) {
 void EditorVisualProfiler::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));
+	ADD_SIGNAL(MethodInfo("break_request"));
 }
 
 void EditorVisualProfiler::set_enabled(bool p_enable) {

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -93,14 +93,14 @@ void ExportTemplateManager::_update_template_list() {
 			Button *redownload = memnew(Button);
 			redownload->set_text(TTR("Redownload"));
 			current_hb->add_child(redownload);
-			redownload->connect_compat("pressed", this, "_download_template", varray(current_version));
+			redownload->connect("pressed", callable_mp(this, &ExportTemplateManager::_download_template), varray(current_version));
 		}
 
 		Button *uninstall = memnew(Button);
 		uninstall->set_text(TTR("Uninstall"));
 		current_hb->add_child(uninstall);
 		current->set_text(current_version + " " + TTR("(Installed)"));
-		uninstall->connect_compat("pressed", this, "_uninstall_template", varray(current_version));
+		uninstall->connect("pressed", callable_mp(this, &ExportTemplateManager::_uninstall_template), varray(current_version));
 
 	} else {
 		current->add_color_override("font_color", get_color("error_color", "Editor"));
@@ -112,7 +112,7 @@ void ExportTemplateManager::_update_template_list() {
 			redownload->set_tooltip(TTR("Official export templates aren't available for development builds."));
 		}
 
-		redownload->connect_compat("pressed", this, "_download_template", varray(current_version));
+		redownload->connect("pressed", callable_mp(this, &ExportTemplateManager::_download_template), varray(current_version));
 		current_hb->add_child(redownload);
 		current->set_text(current_version + " " + TTR("(Missing)"));
 	}
@@ -134,7 +134,7 @@ void ExportTemplateManager::_update_template_list() {
 
 		uninstall->set_text(TTR("Uninstall"));
 		hbc->add_child(uninstall);
-		uninstall->connect_compat("pressed", this, "_uninstall_template", varray(E->get()));
+		uninstall->connect("pressed", callable_mp(this, &ExportTemplateManager::_uninstall_template), varray(E->get()));
 
 		installed_vb->add_child(hbc);
 	}
@@ -385,7 +385,7 @@ void ExportTemplateManager::_http_download_mirror_completed(int p_status, int p_
 			ERR_CONTINUE(!m.has("url") || !m.has("name"));
 			LinkButton *lb = memnew(LinkButton);
 			lb->set_text(m["name"]);
-			lb->connect_compat("pressed", this, "_begin_template_download", varray(m["url"]));
+			lb->connect("pressed", callable_mp(this, &ExportTemplateManager::_begin_template_download), varray(m["url"]));
 			template_list->add_child(lb);
 			mirrors_found = true;
 		}
@@ -655,15 +655,6 @@ Error ExportTemplateManager::install_android_template() {
 }
 
 void ExportTemplateManager::_bind_methods() {
-
-	ClassDB::bind_method("_download_template", &ExportTemplateManager::_download_template);
-	ClassDB::bind_method("_uninstall_template", &ExportTemplateManager::_uninstall_template);
-	ClassDB::bind_method("_uninstall_template_confirm", &ExportTemplateManager::_uninstall_template_confirm);
-	ClassDB::bind_method("_install_from_file", &ExportTemplateManager::_install_from_file);
-	ClassDB::bind_method("_http_download_mirror_completed", &ExportTemplateManager::_http_download_mirror_completed);
-	ClassDB::bind_method("_http_download_templates_completed", &ExportTemplateManager::_http_download_templates_completed);
-	ClassDB::bind_method("_begin_template_download", &ExportTemplateManager::_begin_template_download);
-	ClassDB::bind_method("_window_template_downloader_closed", &ExportTemplateManager::_window_template_downloader_closed);
 }
 
 ExportTemplateManager::ExportTemplateManager() {
@@ -689,14 +680,14 @@ ExportTemplateManager::ExportTemplateManager() {
 	remove_confirm = memnew(ConfirmationDialog);
 	remove_confirm->set_title(TTR("Remove Template"));
 	add_child(remove_confirm);
-	remove_confirm->connect_compat("confirmed", this, "_uninstall_template_confirm");
+	remove_confirm->connect("confirmed", callable_mp(this, &ExportTemplateManager::_uninstall_template_confirm));
 
 	template_open = memnew(FileDialog);
 	template_open->set_title(TTR("Select Template File"));
 	template_open->add_filter("*.tpz ; " + TTR("Godot Export Templates"));
 	template_open->set_access(FileDialog::ACCESS_FILESYSTEM);
 	template_open->set_mode(FileDialog::MODE_OPEN_FILE);
-	template_open->connect_compat("file_selected", this, "_install_from_file", varray(true));
+	template_open->connect("file_selected", callable_mp(this, &ExportTemplateManager::_install_from_file), varray(true));
 	add_child(template_open);
 
 	set_title(TTR("Export Template Manager"));
@@ -704,18 +695,18 @@ ExportTemplateManager::ExportTemplateManager() {
 
 	request_mirror = memnew(HTTPRequest);
 	add_child(request_mirror);
-	request_mirror->connect_compat("request_completed", this, "_http_download_mirror_completed");
+	request_mirror->connect("request_completed", callable_mp(this, &ExportTemplateManager::_http_download_mirror_completed));
 
 	download_templates = memnew(HTTPRequest);
 	add_child(download_templates);
-	download_templates->connect_compat("request_completed", this, "_http_download_templates_completed");
+	download_templates->connect("request_completed", callable_mp(this, &ExportTemplateManager::_http_download_templates_completed));
 
 	template_downloader = memnew(AcceptDialog);
 	template_downloader->set_title(TTR("Download Templates"));
 	template_downloader->get_ok()->set_text(TTR("Close"));
 	template_downloader->set_exclusive(true);
 	add_child(template_downloader);
-	template_downloader->connect_compat("popup_hide", this, "_window_template_downloader_closed");
+	template_downloader->connect("popup_hide", callable_mp(this, &ExportTemplateManager::_window_template_downloader_closed));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	template_downloader->add_child(vbc);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -300,19 +300,19 @@ void FileSystemDock::_notification(int p_what) {
 			if (initialized)
 				return;
 			initialized = true;
-			EditorFeatureProfileManager::get_singleton()->connect_compat("current_feature_profile_changed", this, "_feature_profile_changed");
+			EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &FileSystemDock::_feature_profile_changed));
 
-			EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "_fs_changed");
-			EditorResourcePreview::get_singleton()->connect_compat("preview_invalidated", this, "_preview_invalidated");
+			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &FileSystemDock::_fs_changed));
+			EditorResourcePreview::get_singleton()->connect("preview_invalidated", callable_mp(this, &FileSystemDock::_preview_invalidated));
 
 			String ei = "EditorIcons";
 			button_reload->set_icon(get_icon("Reload", ei));
 			button_toggle_display_mode->set_icon(get_icon("Panels2", ei));
-			button_file_list_display_mode->connect_compat("pressed", this, "_toggle_file_display");
+			button_file_list_display_mode->connect("pressed", callable_mp(this, &FileSystemDock::_toggle_file_display));
 
-			files->connect_compat("item_activated", this, "_file_list_activate_file");
-			button_hist_next->connect_compat("pressed", this, "_fw_history");
-			button_hist_prev->connect_compat("pressed", this, "_bw_history");
+			files->connect("item_activated", callable_mp(this, &FileSystemDock::_file_list_activate_file));
+			button_hist_next->connect("pressed", callable_mp(this, &FileSystemDock::_fw_history));
+			button_hist_prev->connect("pressed", callable_mp(this, &FileSystemDock::_bw_history));
 			tree_search_box->set_right_icon(get_icon("Search", ei));
 			tree_search_box->set_clear_button_enabled(true);
 			file_list_search_box->set_right_icon(get_icon("Search", ei));
@@ -320,10 +320,10 @@ void FileSystemDock::_notification(int p_what) {
 
 			button_hist_next->set_icon(get_icon("Forward", ei));
 			button_hist_prev->set_icon(get_icon("Back", ei));
-			file_list_popup->connect_compat("id_pressed", this, "_file_list_rmb_option");
-			tree_popup->connect_compat("id_pressed", this, "_tree_rmb_option");
+			file_list_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_file_list_rmb_option));
+			tree_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_tree_rmb_option));
 
-			current_path->connect_compat("text_entered", this, "_navigate_to_path");
+			current_path->connect("text_entered", callable_mp(this, &FileSystemDock::_navigate_to_path));
 
 			always_show_folders = bool(EditorSettings::get_singleton()->get("docks/filesystem/always_show_folders"));
 
@@ -2453,57 +2453,19 @@ void FileSystemDock::_feature_profile_changed() {
 }
 
 void FileSystemDock::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_file_list_gui_input"), &FileSystemDock::_file_list_gui_input);
-	ClassDB::bind_method(D_METHOD("_tree_gui_input"), &FileSystemDock::_tree_gui_input);
 
 	ClassDB::bind_method(D_METHOD("_update_tree"), &FileSystemDock::_update_tree);
-	ClassDB::bind_method(D_METHOD("_rescan"), &FileSystemDock::_rescan);
-
-	ClassDB::bind_method(D_METHOD("_toggle_split_mode"), &FileSystemDock::_toggle_split_mode);
-
-	ClassDB::bind_method(D_METHOD("_tree_rmb_option", "option"), &FileSystemDock::_tree_rmb_option);
-	ClassDB::bind_method(D_METHOD("_tree_rmb_select"), &FileSystemDock::_tree_rmb_select);
-	ClassDB::bind_method(D_METHOD("_tree_empty_selected"), &FileSystemDock::_tree_empty_selected);
-
-	ClassDB::bind_method(D_METHOD("_file_list_rmb_option", "option"), &FileSystemDock::_file_list_rmb_option);
-	ClassDB::bind_method(D_METHOD("_file_list_rmb_select"), &FileSystemDock::_file_list_rmb_select);
-	ClassDB::bind_method(D_METHOD("_file_list_rmb_pressed"), &FileSystemDock::_file_list_rmb_pressed);
-	ClassDB::bind_method(D_METHOD("_tree_rmb_empty"), &FileSystemDock::_tree_rmb_empty);
-
-	ClassDB::bind_method(D_METHOD("_file_deleted"), &FileSystemDock::_file_deleted);
-	ClassDB::bind_method(D_METHOD("_folder_deleted"), &FileSystemDock::_folder_deleted);
 
 	ClassDB::bind_method(D_METHOD("_file_list_thumbnail_done"), &FileSystemDock::_file_list_thumbnail_done);
 	ClassDB::bind_method(D_METHOD("_tree_thumbnail_done"), &FileSystemDock::_tree_thumbnail_done);
-	ClassDB::bind_method(D_METHOD("_file_list_activate_file"), &FileSystemDock::_file_list_activate_file);
-	ClassDB::bind_method(D_METHOD("_tree_activate_file"), &FileSystemDock::_tree_activate_file);
 	ClassDB::bind_method(D_METHOD("_select_file"), &FileSystemDock::_select_file);
-	ClassDB::bind_method(D_METHOD("_navigate_to_path"), &FileSystemDock::_navigate_to_path, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("_toggle_file_display"), &FileSystemDock::_toggle_file_display);
-	ClassDB::bind_method(D_METHOD("_fw_history"), &FileSystemDock::_fw_history);
-	ClassDB::bind_method(D_METHOD("_bw_history"), &FileSystemDock::_bw_history);
-	ClassDB::bind_method(D_METHOD("_fs_changed"), &FileSystemDock::_fs_changed);
-	ClassDB::bind_method(D_METHOD("_tree_multi_selected"), &FileSystemDock::_tree_multi_selected);
-	ClassDB::bind_method(D_METHOD("_make_dir_confirm"), &FileSystemDock::_make_dir_confirm);
-	ClassDB::bind_method(D_METHOD("_make_scene_confirm"), &FileSystemDock::_make_scene_confirm);
-	ClassDB::bind_method(D_METHOD("_resource_created"), &FileSystemDock::_resource_created);
-	ClassDB::bind_method(D_METHOD("_move_operation_confirm", "to_path", "overwrite"), &FileSystemDock::_move_operation_confirm, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("_move_with_overwrite"), &FileSystemDock::_move_with_overwrite);
-	ClassDB::bind_method(D_METHOD("_rename_operation_confirm"), &FileSystemDock::_rename_operation_confirm);
-	ClassDB::bind_method(D_METHOD("_duplicate_operation_confirm"), &FileSystemDock::_duplicate_operation_confirm);
-
-	ClassDB::bind_method(D_METHOD("_search_changed"), &FileSystemDock::_search_changed);
 
 	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &FileSystemDock::get_drag_data_fw);
 	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &FileSystemDock::can_drop_data_fw);
 	ClassDB::bind_method(D_METHOD("drop_data_fw"), &FileSystemDock::drop_data_fw);
 	ClassDB::bind_method(D_METHOD("navigate_to_path"), &FileSystemDock::navigate_to_path);
 
-	ClassDB::bind_method(D_METHOD("_preview_invalidated"), &FileSystemDock::_preview_invalidated);
-	ClassDB::bind_method(D_METHOD("_file_multi_selected"), &FileSystemDock::_file_multi_selected);
 	ClassDB::bind_method(D_METHOD("_update_import_dock"), &FileSystemDock::_update_import_dock);
-
-	ClassDB::bind_method(D_METHOD("_feature_profile_changed"), &FileSystemDock::_feature_profile_changed);
 
 	ADD_SIGNAL(MethodInfo("inherit", PropertyInfo(Variant::STRING, "file")));
 	ADD_SIGNAL(MethodInfo("instance", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files")));
@@ -2552,7 +2514,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 
 	button_reload = memnew(Button);
 	button_reload->set_flat(true);
-	button_reload->connect_compat("pressed", this, "_rescan");
+	button_reload->connect("pressed", callable_mp(this, &FileSystemDock::_rescan));
 	button_reload->set_focus_mode(FOCUS_NONE);
 	button_reload->set_tooltip(TTR("Re-Scan Filesystem"));
 	button_reload->hide();
@@ -2561,7 +2523,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	button_toggle_display_mode = memnew(Button);
 	button_toggle_display_mode->set_flat(true);
 	button_toggle_display_mode->set_toggle_mode(true);
-	button_toggle_display_mode->connect_compat("toggled", this, "_toggle_split_mode");
+	button_toggle_display_mode->connect("toggled", callable_mp(this, &FileSystemDock::_toggle_split_mode));
 	button_toggle_display_mode->set_focus_mode(FOCUS_NONE);
 	button_toggle_display_mode->set_tooltip(TTR("Toggle Split Mode"));
 	toolbar_hbc->add_child(button_toggle_display_mode);
@@ -2573,7 +2535,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	tree_search_box = memnew(LineEdit);
 	tree_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	tree_search_box->set_placeholder(TTR("Search files"));
-	tree_search_box->connect_compat("text_changed", this, "_search_changed", varray(tree_search_box));
+	tree_search_box->connect("text_changed", callable_mp(this, &FileSystemDock::_search_changed), varray(tree_search_box));
 	toolbar2_hbc->add_child(tree_search_box);
 
 	file_list_popup = memnew(PopupMenu);
@@ -2597,12 +2559,12 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	tree->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
 	split_box->add_child(tree);
 
-	tree->connect_compat("item_activated", this, "_tree_activate_file");
-	tree->connect_compat("multi_selected", this, "_tree_multi_selected");
-	tree->connect_compat("item_rmb_selected", this, "_tree_rmb_select");
-	tree->connect_compat("empty_rmb", this, "_tree_rmb_empty");
-	tree->connect_compat("nothing_selected", this, "_tree_empty_selected");
-	tree->connect_compat("gui_input", this, "_tree_gui_input");
+	tree->connect("item_activated", callable_mp(this, &FileSystemDock::_tree_activate_file));
+	tree->connect("multi_selected", callable_mp(this, &FileSystemDock::_tree_multi_selected));
+	tree->connect("item_rmb_selected", callable_mp(this, &FileSystemDock::_tree_rmb_select));
+	tree->connect("empty_rmb", callable_mp(this, &FileSystemDock::_tree_rmb_empty));
+	tree->connect("nothing_selected", callable_mp(this, &FileSystemDock::_tree_empty_selected));
+	tree->connect("gui_input", callable_mp(this, &FileSystemDock::_tree_gui_input));
 
 	file_list_vb = memnew(VBoxContainer);
 	file_list_vb->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -2614,7 +2576,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	file_list_search_box = memnew(LineEdit);
 	file_list_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	file_list_search_box->set_placeholder(TTR("Search files"));
-	file_list_search_box->connect_compat("text_changed", this, "_search_changed", varray(file_list_search_box));
+	file_list_search_box->connect("text_changed", callable_mp(this, &FileSystemDock::_search_changed), varray(file_list_search_box));
 	path_hb->add_child(file_list_search_box);
 
 	button_file_list_display_mode = memnew(ToolButton);
@@ -2624,10 +2586,10 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	files->set_v_size_flags(SIZE_EXPAND_FILL);
 	files->set_select_mode(ItemList::SELECT_MULTI);
 	files->set_drag_forwarding(this);
-	files->connect_compat("item_rmb_selected", this, "_file_list_rmb_select");
-	files->connect_compat("gui_input", this, "_file_list_gui_input");
-	files->connect_compat("multi_selected", this, "_file_multi_selected");
-	files->connect_compat("rmb_clicked", this, "_file_list_rmb_pressed");
+	files->connect("item_rmb_selected", callable_mp(this, &FileSystemDock::_file_list_rmb_select));
+	files->connect("gui_input", callable_mp(this, &FileSystemDock::_file_list_gui_input));
+	files->connect("multi_selected", callable_mp(this, &FileSystemDock::_file_multi_selected));
+	files->connect("rmb_clicked", callable_mp(this, &FileSystemDock::_file_list_rmb_pressed));
 	files->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
 	files->set_allow_rmb_select(true);
 	file_list_vb->add_child(files);
@@ -2651,14 +2613,14 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	add_child(owners_editor);
 
 	remove_dialog = memnew(DependencyRemoveDialog);
-	remove_dialog->connect_compat("file_removed", this, "_file_deleted");
-	remove_dialog->connect_compat("folder_removed", this, "_folder_deleted");
+	remove_dialog->connect("file_removed", callable_mp(this, &FileSystemDock::_file_deleted));
+	remove_dialog->connect("folder_removed", callable_mp(this, &FileSystemDock::_folder_deleted));
 	add_child(remove_dialog);
 
 	move_dialog = memnew(EditorDirDialog);
 	move_dialog->get_ok()->set_text(TTR("Move"));
 	add_child(move_dialog);
-	move_dialog->connect_compat("dir_selected", this, "_move_operation_confirm");
+	move_dialog->connect("dir_selected", callable_mp(this, &FileSystemDock::_move_operation_confirm));
 
 	rename_dialog = memnew(ConfirmationDialog);
 	VBoxContainer *rename_dialog_vb = memnew(VBoxContainer);
@@ -2669,13 +2631,13 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	rename_dialog->get_ok()->set_text(TTR("Rename"));
 	add_child(rename_dialog);
 	rename_dialog->register_text_enter(rename_dialog_text);
-	rename_dialog->connect_compat("confirmed", this, "_rename_operation_confirm");
+	rename_dialog->connect("confirmed", callable_mp(this, &FileSystemDock::_rename_operation_confirm));
 
 	overwrite_dialog = memnew(ConfirmationDialog);
 	overwrite_dialog->set_text(TTR("There is already file or folder with the same name in this location."));
 	overwrite_dialog->get_ok()->set_text(TTR("Overwrite"));
 	add_child(overwrite_dialog);
-	overwrite_dialog->connect_compat("confirmed", this, "_move_with_overwrite");
+	overwrite_dialog->connect("confirmed", callable_mp(this, &FileSystemDock::_move_with_overwrite));
 
 	duplicate_dialog = memnew(ConfirmationDialog);
 	VBoxContainer *duplicate_dialog_vb = memnew(VBoxContainer);
@@ -2686,7 +2648,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	duplicate_dialog->get_ok()->set_text(TTR("Duplicate"));
 	add_child(duplicate_dialog);
 	duplicate_dialog->register_text_enter(duplicate_dialog_text);
-	duplicate_dialog->connect_compat("confirmed", this, "_duplicate_operation_confirm");
+	duplicate_dialog->connect("confirmed", callable_mp(this, &FileSystemDock::_duplicate_operation_confirm));
 
 	make_dir_dialog = memnew(ConfirmationDialog);
 	make_dir_dialog->set_title(TTR("Create Folder"));
@@ -2697,7 +2659,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	make_folder_dialog_vb->add_margin_child(TTR("Name:"), make_dir_dialog_text);
 	add_child(make_dir_dialog);
 	make_dir_dialog->register_text_enter(make_dir_dialog_text);
-	make_dir_dialog->connect_compat("confirmed", this, "_make_dir_confirm");
+	make_dir_dialog->connect("confirmed", callable_mp(this, &FileSystemDock::_make_dir_confirm));
 
 	make_scene_dialog = memnew(ConfirmationDialog);
 	make_scene_dialog->set_title(TTR("Create Scene"));
@@ -2708,7 +2670,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	make_scene_dialog_vb->add_margin_child(TTR("Name:"), make_scene_dialog_text);
 	add_child(make_scene_dialog);
 	make_scene_dialog->register_text_enter(make_scene_dialog_text);
-	make_scene_dialog->connect_compat("confirmed", this, "_make_scene_confirm");
+	make_scene_dialog->connect("confirmed", callable_mp(this, &FileSystemDock::_make_scene_confirm));
 
 	make_script_dialog = memnew(ScriptCreateDialog);
 	make_script_dialog->set_title(TTR("Create Script"));
@@ -2717,7 +2679,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	new_resource_dialog = memnew(CreateDialog);
 	add_child(new_resource_dialog);
 	new_resource_dialog->set_base_type("Resource");
-	new_resource_dialog->connect_compat("create", this, "_resource_created");
+	new_resource_dialog->connect("create", callable_mp(this, &FileSystemDock::_resource_created));
 
 	searched_string = String();
 	uncollapsed_paths_before_search = Vector<String>();

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -557,8 +557,8 @@ const char *FindInFilesPanel::SIGNAL_FILES_MODIFIED = "files_modified";
 FindInFilesPanel::FindInFilesPanel() {
 
 	_finder = memnew(FindInFiles);
-	_finder->connect_compat(FindInFiles::SIGNAL_RESULT_FOUND, this, "_on_result_found");
-	_finder->connect_compat(FindInFiles::SIGNAL_FINISHED, this, "_on_finished");
+	_finder->connect(FindInFiles::SIGNAL_RESULT_FOUND, callable_mp(this, &FindInFilesPanel::_on_result_found));
+	_finder->connect(FindInFiles::SIGNAL_FINISHED, callable_mp(this, &FindInFilesPanel::_on_finished));
 	add_child(_finder);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -319,8 +319,8 @@ FindInFilesDialog::FindInFilesDialog() {
 
 	_search_text_line_edit = memnew(LineEdit);
 	_search_text_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
-	_search_text_line_edit->connect_compat("text_changed", this, "_on_search_text_modified");
-	_search_text_line_edit->connect_compat("text_entered", this, "_on_search_text_entered");
+	_search_text_line_edit->connect("text_changed", callable_mp(this, &FindInFilesDialog::_on_search_text_modified));
+	_search_text_line_edit->connect("text_entered", callable_mp(this, &FindInFilesDialog::_on_search_text_entered));
 	gc->add_child(_search_text_line_edit);
 
 	_replace_label = memnew(Label);
@@ -330,7 +330,7 @@ FindInFilesDialog::FindInFilesDialog() {
 
 	_replace_text_line_edit = memnew(LineEdit);
 	_replace_text_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
-	_replace_text_line_edit->connect_compat("text_entered", this, "_on_replace_text_entered");
+	_replace_text_line_edit->connect("text_entered", callable_mp(this, &FindInFilesDialog::_on_replace_text_entered));
 	_replace_text_line_edit->hide();
 	gc->add_child(_replace_text_line_edit);
 
@@ -367,12 +367,12 @@ FindInFilesDialog::FindInFilesDialog() {
 
 		Button *folder_button = memnew(Button);
 		folder_button->set_text("...");
-		folder_button->connect_compat("pressed", this, "_on_folder_button_pressed");
+		folder_button->connect("pressed", callable_mp(this, &FindInFilesDialog::_on_folder_button_pressed));
 		hbc->add_child(folder_button);
 
 		_folder_dialog = memnew(FileDialog);
 		_folder_dialog->set_mode(FileDialog::MODE_OPEN_DIR);
-		_folder_dialog->connect_compat("dir_selected", this, "_on_folder_selected");
+		_folder_dialog->connect("dir_selected", callable_mp(this, &FindInFilesDialog::_on_folder_selected));
 		add_child(_folder_dialog);
 
 		gc->add_child(hbc);
@@ -546,12 +546,6 @@ void FindInFilesDialog::_on_folder_selected(String path) {
 
 void FindInFilesDialog::_bind_methods() {
 
-	ClassDB::bind_method("_on_folder_button_pressed", &FindInFilesDialog::_on_folder_button_pressed);
-	ClassDB::bind_method("_on_folder_selected", &FindInFilesDialog::_on_folder_selected);
-	ClassDB::bind_method("_on_search_text_modified", &FindInFilesDialog::_on_search_text_modified);
-	ClassDB::bind_method("_on_search_text_entered", &FindInFilesDialog::_on_search_text_entered);
-	ClassDB::bind_method("_on_replace_text_entered", &FindInFilesDialog::_on_replace_text_entered);
-
 	ADD_SIGNAL(MethodInfo(SIGNAL_FIND_REQUESTED));
 	ADD_SIGNAL(MethodInfo(SIGNAL_REPLACE_REQUESTED));
 }
@@ -596,7 +590,7 @@ FindInFilesPanel::FindInFilesPanel() {
 
 		_cancel_button = memnew(Button);
 		_cancel_button->set_text(TTR("Cancel"));
-		_cancel_button->connect_compat("pressed", this, "_on_cancel_button_clicked");
+		_cancel_button->connect("pressed", callable_mp(this, &FindInFilesPanel::_on_cancel_button_clicked));
 		_cancel_button->hide();
 		hbc->add_child(_cancel_button);
 
@@ -606,8 +600,8 @@ FindInFilesPanel::FindInFilesPanel() {
 	_results_display = memnew(Tree);
 	_results_display->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("source", "EditorFonts"));
 	_results_display->set_v_size_flags(SIZE_EXPAND_FILL);
-	_results_display->connect_compat("item_selected", this, "_on_result_selected");
-	_results_display->connect_compat("item_edited", this, "_on_item_edited");
+	_results_display->connect("item_selected", callable_mp(this, &FindInFilesPanel::_on_result_selected));
+	_results_display->connect("item_edited", callable_mp(this, &FindInFilesPanel::_on_item_edited));
 	_results_display->set_hide_root(true);
 	_results_display->set_select_mode(Tree::SELECT_ROW);
 	_results_display->set_allow_rmb_select(true);
@@ -625,12 +619,12 @@ FindInFilesPanel::FindInFilesPanel() {
 
 		_replace_line_edit = memnew(LineEdit);
 		_replace_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
-		_replace_line_edit->connect_compat("text_changed", this, "_on_replace_text_changed");
+		_replace_line_edit->connect("text_changed", callable_mp(this, &FindInFilesPanel::_on_replace_text_changed));
 		_replace_container->add_child(_replace_line_edit);
 
 		_replace_all_button = memnew(Button);
 		_replace_all_button->set_text(TTR("Replace all (no undo)"));
-		_replace_all_button->connect_compat("pressed", this, "_on_replace_all_clicked");
+		_replace_all_button->connect("pressed", callable_mp(this, &FindInFilesPanel::_on_replace_all_clicked));
 		_replace_container->add_child(_replace_all_button);
 
 		_replace_container->hide();
@@ -968,12 +962,7 @@ void FindInFilesPanel::set_progress_visible(bool visible) {
 void FindInFilesPanel::_bind_methods() {
 
 	ClassDB::bind_method("_on_result_found", &FindInFilesPanel::_on_result_found);
-	ClassDB::bind_method("_on_item_edited", &FindInFilesPanel::_on_item_edited);
 	ClassDB::bind_method("_on_finished", &FindInFilesPanel::_on_finished);
-	ClassDB::bind_method("_on_cancel_button_clicked", &FindInFilesPanel::_on_cancel_button_clicked);
-	ClassDB::bind_method("_on_result_selected", &FindInFilesPanel::_on_result_selected);
-	ClassDB::bind_method("_on_replace_text_changed", &FindInFilesPanel::_on_replace_text_changed);
-	ClassDB::bind_method("_on_replace_all_clicked", &FindInFilesPanel::_on_replace_all_clicked);
 	ClassDB::bind_method("_draw_result_text", &FindInFilesPanel::draw_result_text);
 
 	ADD_SIGNAL(MethodInfo(SIGNAL_RESULT_SELECTED,

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -389,19 +389,10 @@ void GroupDialog::edit() {
 }
 
 void GroupDialog::_bind_methods() {
-	ClassDB::bind_method("_add_pressed", &GroupDialog::_add_pressed);
-	ClassDB::bind_method("_removed_pressed", &GroupDialog::_removed_pressed);
-	ClassDB::bind_method("_delete_group_pressed", &GroupDialog::_delete_group_pressed);
 	ClassDB::bind_method("_delete_group_item", &GroupDialog::_delete_group_item);
 
-	ClassDB::bind_method("_group_selected", &GroupDialog::_group_selected);
-	ClassDB::bind_method("_add_group_pressed", &GroupDialog::_add_group_pressed);
 	ClassDB::bind_method("_add_group", &GroupDialog::_add_group);
 
-	ClassDB::bind_method("_add_filter_changed", &GroupDialog::_add_filter_changed);
-	ClassDB::bind_method("_remove_filter_changed", &GroupDialog::_remove_filter_changed);
-
-	ClassDB::bind_method("_group_renamed", &GroupDialog::_group_renamed);
 	ClassDB::bind_method("_rename_group_item", &GroupDialog::_rename_group_item);
 
 	ADD_SIGNAL(MethodInfo("group_edited"));
@@ -436,9 +427,9 @@ GroupDialog::GroupDialog() {
 	groups->set_allow_rmb_select(true);
 	groups->set_v_size_flags(SIZE_EXPAND_FILL);
 	groups->add_constant_override("draw_guides", 1);
-	groups->connect_compat("item_selected", this, "_group_selected");
-	groups->connect_compat("button_pressed", this, "_delete_group_pressed");
-	groups->connect_compat("item_edited", this, "_group_renamed");
+	groups->connect("item_selected", callable_mp(this, &GroupDialog::_group_selected));
+	groups->connect("button_pressed", callable_mp(this, &GroupDialog::_delete_group_pressed));
+	groups->connect("item_edited", callable_mp(this, &GroupDialog::_group_renamed));
 
 	HBoxContainer *chbc = memnew(HBoxContainer);
 	vbc_left->add_child(chbc);
@@ -447,12 +438,12 @@ GroupDialog::GroupDialog() {
 	add_group_text = memnew(LineEdit);
 	chbc->add_child(add_group_text);
 	add_group_text->set_h_size_flags(SIZE_EXPAND_FILL);
-	add_group_text->connect_compat("text_entered", this, "_add_group_pressed");
+	add_group_text->connect("text_entered", callable_mp(this, &GroupDialog::_add_group_pressed));
 
 	Button *add_group_button = memnew(Button);
 	add_group_button->set_text(TTR("Add"));
 	chbc->add_child(add_group_button);
-	add_group_button->connect_compat("pressed", this, "_add_group_pressed", varray(String()));
+	add_group_button->connect("pressed", callable_mp(this, &GroupDialog::_add_group_pressed), varray(String()));
 
 	VBoxContainer *vbc_add = memnew(VBoxContainer);
 	hbc->add_child(vbc_add);
@@ -478,7 +469,7 @@ GroupDialog::GroupDialog() {
 	add_filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_filter->set_placeholder(TTR("Filter nodes"));
 	add_filter_hbc->add_child(add_filter);
-	add_filter->connect_compat("text_changed", this, "_add_filter_changed");
+	add_filter->connect("text_changed", callable_mp(this, &GroupDialog::_add_filter_changed));
 
 	VBoxContainer *vbc_buttons = memnew(VBoxContainer);
 	hbc->add_child(vbc_buttons);
@@ -487,7 +478,7 @@ GroupDialog::GroupDialog() {
 
 	add_button = memnew(ToolButton);
 	add_button->set_text(TTR("Add"));
-	add_button->connect_compat("pressed", this, "_add_pressed");
+	add_button->connect("pressed", callable_mp(this, &GroupDialog::_add_pressed));
 
 	vbc_buttons->add_child(add_button);
 	vbc_buttons->add_spacer();
@@ -496,7 +487,7 @@ GroupDialog::GroupDialog() {
 
 	remove_button = memnew(ToolButton);
 	remove_button->set_text(TTR("Remove"));
-	remove_button->connect_compat("pressed", this, "_removed_pressed");
+	remove_button->connect("pressed", callable_mp(this, &GroupDialog::_removed_pressed));
 
 	vbc_buttons->add_child(remove_button);
 
@@ -524,7 +515,7 @@ GroupDialog::GroupDialog() {
 	remove_filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	remove_filter->set_placeholder(TTR("Filter nodes"));
 	remove_filter_hbc->add_child(remove_filter);
-	remove_filter->connect_compat("text_changed", this, "_remove_filter_changed");
+	remove_filter->connect("text_changed", callable_mp(this, &GroupDialog::_remove_filter_changed));
 
 	group_empty = memnew(Label());
 	group_empty->set_text(TTR("Empty groups will be automatically removed."));
@@ -668,12 +659,6 @@ void GroupsEditor::_show_group_dialog() {
 }
 
 void GroupsEditor::_bind_methods() {
-
-	ClassDB::bind_method("_add_group", &GroupsEditor::_add_group);
-	ClassDB::bind_method("_remove_group", &GroupsEditor::_remove_group);
-	ClassDB::bind_method("update_tree", &GroupsEditor::update_tree);
-
-	ClassDB::bind_method("_show_group_dialog", &GroupsEditor::_show_group_dialog);
 }
 
 GroupsEditor::GroupsEditor() {
@@ -685,12 +670,12 @@ GroupsEditor::GroupsEditor() {
 	group_dialog = memnew(GroupDialog);
 	group_dialog->set_as_toplevel(true);
 	add_child(group_dialog);
-	group_dialog->connect_compat("group_edited", this, "update_tree");
+	group_dialog->connect("group_edited", callable_mp(this, &GroupsEditor::update_tree));
 
 	Button *group_dialog_button = memnew(Button);
 	group_dialog_button->set_text(TTR("Manage Groups"));
 	vbc->add_child(group_dialog_button);
-	group_dialog_button->connect_compat("pressed", this, "_show_group_dialog");
+	group_dialog_button->connect("pressed", callable_mp(this, &GroupsEditor::_show_group_dialog));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	vbc->add_child(hbc);
@@ -698,18 +683,18 @@ GroupsEditor::GroupsEditor() {
 	group_name = memnew(LineEdit);
 	group_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	hbc->add_child(group_name);
-	group_name->connect_compat("text_entered", this, "_add_group");
+	group_name->connect("text_entered", callable_mp(this, &GroupsEditor::_add_group));
 
 	add = memnew(Button);
 	add->set_text(TTR("Add"));
 	hbc->add_child(add);
-	add->connect_compat("pressed", this, "_add_group", varray(String()));
+	add->connect("pressed", callable_mp(this, &GroupsEditor::_add_group), varray(String()));
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	vbc->add_child(tree);
-	tree->connect_compat("button_pressed", this, "_remove_group");
+	tree->connect("button_pressed", callable_mp(this, &GroupsEditor::_remove_group));
 	tree->add_constant_override("draw_guides", 1);
 	add_constant_override("separation", 3 * EDSCALE);
 }

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -512,11 +512,6 @@ void ImportDock::_property_toggled(const StringName &p_prop, bool p_checked) {
 void ImportDock::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_reimport"), &ImportDock::_reimport);
-	ClassDB::bind_method(D_METHOD("_preset_selected"), &ImportDock::_preset_selected);
-	ClassDB::bind_method(D_METHOD("_importer_selected"), &ImportDock::_importer_selected);
-	ClassDB::bind_method(D_METHOD("_property_toggled"), &ImportDock::_property_toggled);
-	ClassDB::bind_method(D_METHOD("_reimport_and_restart"), &ImportDock::_reimport_and_restart);
-	ClassDB::bind_method(D_METHOD("_reimport_attempt"), &ImportDock::_reimport_attempt);
 }
 
 void ImportDock::initialize_import_options() const {
@@ -537,26 +532,26 @@ ImportDock::ImportDock() {
 	add_margin_child(TTR("Import As:"), hb);
 	import_as = memnew(OptionButton);
 	import_as->set_disabled(true);
-	import_as->connect_compat("item_selected", this, "_importer_selected");
+	import_as->connect("item_selected", callable_mp(this, &ImportDock::_importer_selected));
 	hb->add_child(import_as);
 	import_as->set_h_size_flags(SIZE_EXPAND_FILL);
 	preset = memnew(MenuButton);
 	preset->set_text(TTR("Preset"));
 	preset->set_disabled(true);
-	preset->get_popup()->connect_compat("index_pressed", this, "_preset_selected");
+	preset->get_popup()->connect("index_pressed", callable_mp(this, &ImportDock::_preset_selected));
 	hb->add_child(preset);
 
 	import_opts = memnew(EditorInspector);
 	add_child(import_opts);
 	import_opts->set_v_size_flags(SIZE_EXPAND_FILL);
-	import_opts->connect_compat("property_toggled", this, "_property_toggled");
+	import_opts->connect("property_toggled", callable_mp(this, &ImportDock::_property_toggled));
 
 	hb = memnew(HBoxContainer);
 	add_child(hb);
 	import = memnew(Button);
 	import->set_text(TTR("Reimport"));
 	import->set_disabled(true);
-	import->connect_compat("pressed", this, "_reimport_attempt");
+	import->connect("pressed", callable_mp(this, &ImportDock::_reimport_attempt));
 	hb->add_spacer();
 	hb->add_child(import);
 	hb->add_spacer();
@@ -564,7 +559,7 @@ ImportDock::ImportDock() {
 	reimport_confirm = memnew(ConfirmationDialog);
 	reimport_confirm->get_ok()->set_text(TTR("Save scenes, re-import and restart"));
 	add_child(reimport_confirm);
-	reimport_confirm->connect_compat("confirmed", this, "_reimport_and_restart");
+	reimport_confirm->connect("confirmed", callable_mp(this, &ImportDock::_reimport_and_restart));
 
 	VBoxContainer *vbc_confirm = memnew(VBoxContainer());
 	vbc_confirm->add_child(memnew(Label(TTR("Changing the type of an imported file requires editor restart."))));

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -343,27 +343,16 @@ void InspectorDock::_notification(int p_what) {
 }
 
 void InspectorDock::_bind_methods() {
-	ClassDB::bind_method("_menu_option", &InspectorDock::_menu_option);
 
 	ClassDB::bind_method("update_keying", &InspectorDock::update_keying);
-	ClassDB::bind_method("_property_keyed", &InspectorDock::_property_keyed);
 	ClassDB::bind_method("_transform_keyed", &InspectorDock::_transform_keyed);
 
-	ClassDB::bind_method("_resource_file_selected", &InspectorDock::_resource_file_selected);
-	ClassDB::bind_method("_open_resource_selector", &InspectorDock::_open_resource_selector);
 	ClassDB::bind_method("_unref_resource", &InspectorDock::_unref_resource);
 	ClassDB::bind_method("_paste_resource", &InspectorDock::_paste_resource);
 	ClassDB::bind_method("_copy_resource", &InspectorDock::_copy_resource);
 
-	ClassDB::bind_method("_select_history", &InspectorDock::_select_history);
-	ClassDB::bind_method("_prepare_history", &InspectorDock::_prepare_history);
-	ClassDB::bind_method("_resource_created", &InspectorDock::_resource_created);
-	ClassDB::bind_method("_resource_selected", &InspectorDock::_resource_selected, DEFVAL(""));
 	ClassDB::bind_method("_menu_collapseall", &InspectorDock::_menu_collapseall);
 	ClassDB::bind_method("_menu_expandall", &InspectorDock::_menu_expandall);
-	ClassDB::bind_method("_warning_pressed", &InspectorDock::_warning_pressed);
-	ClassDB::bind_method("_edit_forward", &InspectorDock::_edit_forward);
-	ClassDB::bind_method("_edit_back", &InspectorDock::_edit_back);
 
 	ADD_SIGNAL(MethodInfo("request_help"));
 }
@@ -517,7 +506,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	resource_load_button->set_tooltip(TTR("Load an existing resource from disk and edit it."));
 	resource_load_button->set_icon(get_icon("Load", "EditorIcons"));
 	general_options_hb->add_child(resource_load_button);
-	resource_load_button->connect_compat("pressed", this, "_open_resource_selector");
+	resource_load_button->connect("pressed", callable_mp(this, &InspectorDock::_open_resource_selector));
 	resource_load_button->set_focus_mode(Control::FOCUS_NONE);
 
 	resource_save_button = memnew(MenuButton);
@@ -526,7 +515,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	general_options_hb->add_child(resource_save_button);
 	resource_save_button->get_popup()->add_item(TTR("Save"), RESOURCE_SAVE);
 	resource_save_button->get_popup()->add_item(TTR("Save As..."), RESOURCE_SAVE_AS);
-	resource_save_button->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	resource_save_button->get_popup()->connect("id_pressed", callable_mp(this, &InspectorDock::_menu_option));
 	resource_save_button->set_focus_mode(Control::FOCUS_NONE);
 	resource_save_button->set_disabled(true);
 
@@ -538,7 +527,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	backward_button->set_flat(true);
 	backward_button->set_tooltip(TTR("Go to the previous edited object in history."));
 	backward_button->set_disabled(true);
-	backward_button->connect_compat("pressed", this, "_edit_back");
+	backward_button->connect("pressed", callable_mp(this, &InspectorDock::_edit_back));
 
 	forward_button = memnew(ToolButton);
 	general_options_hb->add_child(forward_button);
@@ -546,14 +535,14 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	forward_button->set_flat(true);
 	forward_button->set_tooltip(TTR("Go to the next edited object in history."));
 	forward_button->set_disabled(true);
-	forward_button->connect_compat("pressed", this, "_edit_forward");
+	forward_button->connect("pressed", callable_mp(this, &InspectorDock::_edit_forward));
 
 	history_menu = memnew(MenuButton);
 	history_menu->set_tooltip(TTR("History of recently edited objects."));
 	history_menu->set_icon(get_icon("History", "EditorIcons"));
 	general_options_hb->add_child(history_menu);
-	history_menu->connect_compat("about_to_show", this, "_prepare_history");
-	history_menu->get_popup()->connect_compat("id_pressed", this, "_select_history");
+	history_menu->connect("about_to_show", callable_mp(this, &InspectorDock::_prepare_history));
+	history_menu->get_popup()->connect("id_pressed", callable_mp(this, &InspectorDock::_select_history));
 
 	HBoxContainer *node_info_hb = memnew(HBoxContainer);
 	add_child(node_info_hb);
@@ -566,12 +555,12 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	object_menu->set_icon(get_icon("Tools", "EditorIcons"));
 	node_info_hb->add_child(object_menu);
 	object_menu->set_tooltip(TTR("Object properties."));
-	object_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	object_menu->get_popup()->connect("id_pressed", callable_mp(this, &InspectorDock::_menu_option));
 
 	new_resource_dialog = memnew(CreateDialog);
 	editor->get_gui_base()->add_child(new_resource_dialog);
 	new_resource_dialog->set_base_type("Resource");
-	new_resource_dialog->connect_compat("create", this, "_resource_created");
+	new_resource_dialog->connect("create", callable_mp(this, &InspectorDock::_resource_created));
 
 	search = memnew(LineEdit);
 	search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -587,7 +576,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	warning->add_color_override("font_color", get_color("warning_color", "Editor"));
 	warning->set_clip_text(true);
 	warning->hide();
-	warning->connect_compat("pressed", this, "_warning_pressed");
+	warning->connect("pressed", callable_mp(this, &InspectorDock::_warning_pressed));
 
 	warning_dialog = memnew(AcceptDialog);
 	editor->get_gui_base()->add_child(warning_dialog);
@@ -595,7 +584,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	load_resource_dialog = memnew(EditorFileDialog);
 	add_child(load_resource_dialog);
 	load_resource_dialog->set_current_dir("res://");
-	load_resource_dialog->connect_compat("file_selected", this, "_resource_file_selected");
+	load_resource_dialog->connect("file_selected", callable_mp(this, &InspectorDock::_resource_file_selected));
 
 	inspector = memnew(EditorInspector);
 	add_child(inspector);
@@ -611,8 +600,8 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 
 	inspector->set_use_filter(true); // TODO: check me
 
-	inspector->connect_compat("resource_selected", this, "_resource_selected");
-	inspector->connect_compat("property_keyed", this, "_property_keyed");
+	inspector->connect("resource_selected", callable_mp(this, &InspectorDock::_resource_selected));
+	inspector->connect("property_keyed", callable_mp(this, &InspectorDock::_property_keyed));
 }
 
 InspectorDock::~InspectorDock() {

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -345,7 +345,7 @@ void InspectorDock::_notification(int p_what) {
 void InspectorDock::_bind_methods() {
 
 	ClassDB::bind_method("update_keying", &InspectorDock::update_keying);
-	ClassDB::bind_method("_transform_keyed", &InspectorDock::_transform_keyed);
+	ClassDB::bind_method("_transform_keyed", &InspectorDock::_transform_keyed); // Still used by some connect_compat.
 
 	ClassDB::bind_method("_unref_resource", &InspectorDock::_unref_resource);
 	ClassDB::bind_method("_paste_resource", &InspectorDock::_paste_resource);

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -50,9 +50,6 @@ void NodeDock::show_connections() {
 }
 
 void NodeDock::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("show_groups"), &NodeDock::show_groups);
-	ClassDB::bind_method(D_METHOD("show_connections"), &NodeDock::show_connections);
 }
 
 void NodeDock::_notification(int p_what) {
@@ -107,7 +104,7 @@ NodeDock::NodeDock() {
 	connections_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	connections_button->set_clip_text(true);
 	mode_hb->add_child(connections_button);
-	connections_button->connect_compat("pressed", this, "show_connections");
+	connections_button->connect("pressed", callable_mp(this, &NodeDock::show_connections));
 
 	groups_button = memnew(ToolButton);
 	groups_button->set_text(TTR("Groups"));
@@ -116,7 +113,7 @@ NodeDock::NodeDock() {
 	groups_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	groups_button->set_clip_text(true);
 	mode_hb->add_child(groups_button);
-	groups_button->connect_compat("pressed", this, "show_groups");
+	groups_button->connect("pressed", callable_mp(this, &NodeDock::show_groups));
 
 	connections = memnew(ConnectionsDock(EditorNode::get_singleton()));
 	connections->set_undoredo(EditorNode::get_undo_redo());

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -132,8 +132,8 @@ void PluginConfigDialog::_on_required_text_changed(const String &) {
 void PluginConfigDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			connect_compat("confirmed", this, "_on_confirmed");
-			get_cancel()->connect_compat("pressed", this, "_on_cancelled");
+			connect("confirmed", callable_mp(this, &PluginConfigDialog::_on_confirmed));
+			get_cancel()->connect("pressed", callable_mp(this, &PluginConfigDialog::_on_cancelled));
 		} break;
 
 		case NOTIFICATION_POST_POPUP: {
@@ -175,9 +175,6 @@ void PluginConfigDialog::config(const String &p_config_path) {
 }
 
 void PluginConfigDialog::_bind_methods() {
-	ClassDB::bind_method("_on_required_text_changed", &PluginConfigDialog::_on_required_text_changed);
-	ClassDB::bind_method("_on_confirmed", &PluginConfigDialog::_on_confirmed);
-	ClassDB::bind_method("_on_cancelled", &PluginConfigDialog::_on_cancelled);
 	ADD_SIGNAL(MethodInfo("plugin_ready", PropertyInfo(Variant::STRING, "script_path", PROPERTY_HINT_NONE, ""), PropertyInfo(Variant::STRING, "activate_name")));
 }
 
@@ -194,7 +191,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	grid->add_child(name_lb);
 
 	name_edit = memnew(LineEdit);
-	name_edit->connect_compat("text_changed", this, "_on_required_text_changed");
+	name_edit->connect("text_changed", callable_mp(this, &PluginConfigDialog::_on_required_text_changed));
 	name_edit->set_placeholder("MyPlugin");
 	grid->add_child(name_edit);
 
@@ -253,7 +250,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	grid->add_child(script_lb);
 
 	script_edit = memnew(LineEdit);
-	script_edit->connect_compat("text_changed", this, "_on_required_text_changed");
+	script_edit->connect("text_changed", callable_mp(this, &PluginConfigDialog::_on_required_text_changed));
 	script_edit->set_placeholder("\"plugin.gd\" -> res://addons/my_plugin/plugin.gd");
 	grid->add_child(script_edit);
 

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -209,8 +209,8 @@ void AbstractPolygon2DEditor::_notification(int p_what) {
 			button_delete->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveDelete", "EditorIcons"));
 			button_edit->set_pressed(true);
 
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
-			create_resource->connect_compat("confirmed", this, "_create_resource");
+			get_tree()->connect("node_removed", callable_mp(this, &AbstractPolygon2DEditor::_node_removed));
+			create_resource->connect("confirmed", callable_mp(this, &AbstractPolygon2DEditor::_create_resource));
 		} break;
 	}
 }
@@ -695,10 +695,6 @@ void AbstractPolygon2DEditor::edit(Node *p_polygon) {
 }
 
 void AbstractPolygon2DEditor::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_node_removed"), &AbstractPolygon2DEditor::_node_removed);
-	ClassDB::bind_method(D_METHOD("_menu_option"), &AbstractPolygon2DEditor::_menu_option);
-	ClassDB::bind_method(D_METHOD("_create_resource"), &AbstractPolygon2DEditor::_create_resource);
 }
 
 void AbstractPolygon2DEditor::remove_point(const Vertex &p_vertex) {
@@ -820,17 +816,17 @@ AbstractPolygon2DEditor::AbstractPolygon2DEditor(EditorNode *p_editor, bool p_wi
 	add_child(memnew(VSeparator));
 	button_create = memnew(ToolButton);
 	add_child(button_create);
-	button_create->connect_compat("pressed", this, "_menu_option", varray(MODE_CREATE));
+	button_create->connect("pressed", callable_mp(this, &AbstractPolygon2DEditor::_menu_option), varray(MODE_CREATE));
 	button_create->set_toggle_mode(true);
 
 	button_edit = memnew(ToolButton);
 	add_child(button_edit);
-	button_edit->connect_compat("pressed", this, "_menu_option", varray(MODE_EDIT));
+	button_edit->connect("pressed", callable_mp(this, &AbstractPolygon2DEditor::_menu_option), varray(MODE_EDIT));
 	button_edit->set_toggle_mode(true);
 
 	button_delete = memnew(ToolButton);
 	add_child(button_delete);
-	button_delete->connect_compat("pressed", this, "_menu_option", varray(MODE_DELETE));
+	button_delete->connect("pressed", callable_mp(this, &AbstractPolygon2DEditor::_menu_option), varray(MODE_DELETE));
 	button_delete->set_toggle_mode(true);
 
 	create_resource = memnew(ConfirmationDialog);

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -568,25 +568,10 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 }
 
 void AnimationNodeBlendSpace1DEditor::_bind_methods() {
-	ClassDB::bind_method("_blend_space_gui_input", &AnimationNodeBlendSpace1DEditor::_blend_space_gui_input);
-	ClassDB::bind_method("_blend_space_draw", &AnimationNodeBlendSpace1DEditor::_blend_space_draw);
-	ClassDB::bind_method("_config_changed", &AnimationNodeBlendSpace1DEditor::_config_changed);
-	ClassDB::bind_method("_labels_changed", &AnimationNodeBlendSpace1DEditor::_labels_changed);
 	ClassDB::bind_method("_update_space", &AnimationNodeBlendSpace1DEditor::_update_space);
-	ClassDB::bind_method("_snap_toggled", &AnimationNodeBlendSpace1DEditor::_snap_toggled);
-	ClassDB::bind_method("_tool_switch", &AnimationNodeBlendSpace1DEditor::_tool_switch);
-	ClassDB::bind_method("_erase_selected", &AnimationNodeBlendSpace1DEditor::_erase_selected);
 	ClassDB::bind_method("_update_tool_erase", &AnimationNodeBlendSpace1DEditor::_update_tool_erase);
-	ClassDB::bind_method("_edit_point_pos", &AnimationNodeBlendSpace1DEditor::_edit_point_pos);
-
-	ClassDB::bind_method("_add_menu_type", &AnimationNodeBlendSpace1DEditor::_add_menu_type);
-	ClassDB::bind_method("_add_animation_type", &AnimationNodeBlendSpace1DEditor::_add_animation_type);
 
 	ClassDB::bind_method("_update_edited_point_pos", &AnimationNodeBlendSpace1DEditor::_update_edited_point_pos);
-
-	ClassDB::bind_method("_open_editor", &AnimationNodeBlendSpace1DEditor::_open_editor);
-
-	ClassDB::bind_method("_file_opened", &AnimationNodeBlendSpace1DEditor::_file_opened);
 }
 
 bool AnimationNodeBlendSpace1DEditor::can_edit(const Ref<AnimationNode> &p_node) {
@@ -622,28 +607,28 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	top_hb->add_child(tool_blend);
 	tool_blend->set_pressed(true);
 	tool_blend->set_tooltip(TTR("Set the blending position within the space"));
-	tool_blend->connect_compat("pressed", this, "_tool_switch", varray(3));
+	tool_blend->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch), varray(3));
 
 	tool_select = memnew(ToolButton);
 	tool_select->set_toggle_mode(true);
 	tool_select->set_button_group(bg);
 	top_hb->add_child(tool_select);
 	tool_select->set_tooltip(TTR("Select and move points, create points with RMB."));
-	tool_select->connect_compat("pressed", this, "_tool_switch", varray(0));
+	tool_select->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch), varray(0));
 
 	tool_create = memnew(ToolButton);
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	top_hb->add_child(tool_create);
 	tool_create->set_tooltip(TTR("Create points."));
-	tool_create->connect_compat("pressed", this, "_tool_switch", varray(1));
+	tool_create->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch), varray(1));
 
 	tool_erase_sep = memnew(VSeparator);
 	top_hb->add_child(tool_erase_sep);
 	tool_erase = memnew(ToolButton);
 	top_hb->add_child(tool_erase);
 	tool_erase->set_tooltip(TTR("Erase points."));
-	tool_erase->connect_compat("pressed", this, "_erase_selected");
+	tool_erase->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_erase_selected));
 
 	top_hb->add_child(memnew(VSeparator));
 
@@ -652,7 +637,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	top_hb->add_child(snap);
 	snap->set_pressed(true);
 	snap->set_tooltip(TTR("Enable snap and show grid."));
-	snap->connect_compat("pressed", this, "_snap_toggled");
+	snap->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_snap_toggled));
 
 	snap_value = memnew(SpinBox);
 	top_hb->add_child(snap_value);
@@ -670,12 +655,12 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	edit_value->set_min(-1000);
 	edit_value->set_max(1000);
 	edit_value->set_step(0.01);
-	edit_value->connect_compat("value_changed", this, "_edit_point_pos");
+	edit_value->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_edit_point_pos));
 
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
 	open_editor->set_text(TTR("Open Editor"));
-	open_editor->connect_compat("pressed", this, "_open_editor", varray(), CONNECT_DEFERRED);
+	open_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_open_editor), varray(), CONNECT_DEFERRED);
 
 	edit_hb->hide();
 	open_editor->hide();
@@ -691,8 +676,8 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	panel->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	blend_space_draw = memnew(Control);
-	blend_space_draw->connect_compat("gui_input", this, "_blend_space_gui_input");
-	blend_space_draw->connect_compat("draw", this, "_blend_space_draw");
+	blend_space_draw->connect("gui_input", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_blend_space_gui_input));
+	blend_space_draw->connect("draw", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_blend_space_draw));
 	blend_space_draw->set_focus_mode(FOCUS_ALL);
 
 	panel->add_child(blend_space_draw);
@@ -724,10 +709,10 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 		bottom_hb->add_child(max_value);
 	}
 
-	snap_value->connect_compat("value_changed", this, "_config_changed");
-	min_value->connect_compat("value_changed", this, "_config_changed");
-	max_value->connect_compat("value_changed", this, "_config_changed");
-	label_value->connect_compat("text_changed", this, "_labels_changed");
+	snap_value->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
+	min_value->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
+	max_value->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
+	label_value->connect("text_changed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_labels_changed));
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
@@ -740,18 +725,18 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_add_menu_type");
+	menu->connect("id_pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_add_menu_type));
 
 	animations_menu = memnew(PopupMenu);
 	menu->add_child(animations_menu);
 	animations_menu->set_name("animations");
-	animations_menu->connect_compat("index_pressed", this, "_add_animation_type");
+	animations_menu->connect("index_pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_add_animation_type));
 
 	open_file = memnew(EditorFileDialog);
 	add_child(open_file);
 	open_file->set_title(TTR("Open Animation Node"));
 	open_file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	open_file->connect_compat("file_selected", this, "_file_opened");
+	open_file->connect("file_selected", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_file_opened));
 	undo_redo = EditorNode::get_undo_redo();
 
 	selected_point = -1;

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -55,12 +55,12 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_changed() {
 void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 
 	if (blend_space.is_valid()) {
-		blend_space->disconnect_compat("triangles_updated", this, "_blend_space_changed");
+		blend_space->disconnect("triangles_updated", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_changed));
 	}
 	blend_space = p_node;
 
 	if (!blend_space.is_null()) {
-		blend_space->connect_compat("triangles_updated", this, "_blend_space_changed");
+		blend_space->connect("triangles_updated", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_changed));
 		_update_space();
 	}
 }
@@ -825,30 +825,12 @@ void AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled() {
 
 void AnimationNodeBlendSpace2DEditor::_bind_methods() {
 
-	ClassDB::bind_method("_blend_space_gui_input", &AnimationNodeBlendSpace2DEditor::_blend_space_gui_input);
-	ClassDB::bind_method("_blend_space_draw", &AnimationNodeBlendSpace2DEditor::_blend_space_draw);
-	ClassDB::bind_method("_config_changed", &AnimationNodeBlendSpace2DEditor::_config_changed);
-	ClassDB::bind_method("_labels_changed", &AnimationNodeBlendSpace2DEditor::_labels_changed);
 	ClassDB::bind_method("_update_space", &AnimationNodeBlendSpace2DEditor::_update_space);
-	ClassDB::bind_method("_snap_toggled", &AnimationNodeBlendSpace2DEditor::_snap_toggled);
-	ClassDB::bind_method("_tool_switch", &AnimationNodeBlendSpace2DEditor::_tool_switch);
-	ClassDB::bind_method("_erase_selected", &AnimationNodeBlendSpace2DEditor::_erase_selected);
 	ClassDB::bind_method("_update_tool_erase", &AnimationNodeBlendSpace2DEditor::_update_tool_erase);
-	ClassDB::bind_method("_edit_point_pos", &AnimationNodeBlendSpace2DEditor::_edit_point_pos);
-
-	ClassDB::bind_method("_add_menu_type", &AnimationNodeBlendSpace2DEditor::_add_menu_type);
-	ClassDB::bind_method("_add_animation_type", &AnimationNodeBlendSpace2DEditor::_add_animation_type);
 
 	ClassDB::bind_method("_update_edited_point_pos", &AnimationNodeBlendSpace2DEditor::_update_edited_point_pos);
 
-	ClassDB::bind_method("_open_editor", &AnimationNodeBlendSpace2DEditor::_open_editor);
-
 	ClassDB::bind_method("_removed_from_graph", &AnimationNodeBlendSpace2DEditor::_removed_from_graph);
-
-	ClassDB::bind_method("_auto_triangles_toggled", &AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled);
-	ClassDB::bind_method("_blend_space_changed", &AnimationNodeBlendSpace2DEditor::_blend_space_changed);
-
-	ClassDB::bind_method("_file_opened", &AnimationNodeBlendSpace2DEditor::_file_opened);
 }
 
 AnimationNodeBlendSpace2DEditor *AnimationNodeBlendSpace2DEditor::singleton = NULL;
@@ -870,42 +852,42 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hb->add_child(tool_blend);
 	tool_blend->set_pressed(true);
 	tool_blend->set_tooltip(TTR("Set the blending position within the space"));
-	tool_blend->connect_compat("pressed", this, "_tool_switch", varray(3));
+	tool_blend->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(3));
 
 	tool_select = memnew(ToolButton);
 	tool_select->set_toggle_mode(true);
 	tool_select->set_button_group(bg);
 	top_hb->add_child(tool_select);
 	tool_select->set_tooltip(TTR("Select and move points, create points with RMB."));
-	tool_select->connect_compat("pressed", this, "_tool_switch", varray(0));
+	tool_select->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(0));
 
 	tool_create = memnew(ToolButton);
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	top_hb->add_child(tool_create);
 	tool_create->set_tooltip(TTR("Create points."));
-	tool_create->connect_compat("pressed", this, "_tool_switch", varray(1));
+	tool_create->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(1));
 
 	tool_triangle = memnew(ToolButton);
 	tool_triangle->set_toggle_mode(true);
 	tool_triangle->set_button_group(bg);
 	top_hb->add_child(tool_triangle);
 	tool_triangle->set_tooltip(TTR("Create triangles by connecting points."));
-	tool_triangle->connect_compat("pressed", this, "_tool_switch", varray(2));
+	tool_triangle->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(2));
 
 	tool_erase_sep = memnew(VSeparator);
 	top_hb->add_child(tool_erase_sep);
 	tool_erase = memnew(ToolButton);
 	top_hb->add_child(tool_erase);
 	tool_erase->set_tooltip(TTR("Erase points and triangles."));
-	tool_erase->connect_compat("pressed", this, "_erase_selected");
+	tool_erase->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_erase_selected));
 	tool_erase->set_disabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
 
 	auto_triangles = memnew(ToolButton);
 	top_hb->add_child(auto_triangles);
-	auto_triangles->connect_compat("pressed", this, "_auto_triangles_toggled");
+	auto_triangles->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled));
 	auto_triangles->set_toggle_mode(true);
 	auto_triangles->set_tooltip(TTR("Generate blend triangles automatically (instead of manually)"));
 
@@ -916,7 +898,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hb->add_child(snap);
 	snap->set_pressed(true);
 	snap->set_tooltip(TTR("Enable snap and show grid."));
-	snap->connect_compat("pressed", this, "_snap_toggled");
+	snap->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_snap_toggled));
 
 	snap_x = memnew(SpinBox);
 	top_hb->add_child(snap_x);
@@ -937,7 +919,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hb->add_child(memnew(Label(TTR("Blend:"))));
 	interpolation = memnew(OptionButton);
 	top_hb->add_child(interpolation);
-	interpolation->connect_compat("item_selected", this, "_config_changed");
+	interpolation->connect("item_selected", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
 
 	edit_hb = memnew(HBoxContainer);
 	top_hb->add_child(edit_hb);
@@ -948,17 +930,17 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	edit_x->set_min(-1000);
 	edit_x->set_step(0.01);
 	edit_x->set_max(1000);
-	edit_x->connect_compat("value_changed", this, "_edit_point_pos");
+	edit_x->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 	edit_y = memnew(SpinBox);
 	edit_hb->add_child(edit_y);
 	edit_y->set_min(-1000);
 	edit_y->set_step(0.01);
 	edit_y->set_max(1000);
-	edit_y->connect_compat("value_changed", this, "_edit_point_pos");
+	edit_y->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
 	open_editor->set_text(TTR("Open Editor"));
-	open_editor->connect_compat("pressed", this, "_open_editor", varray(), CONNECT_DEFERRED);
+	open_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_open_editor), varray(), CONNECT_DEFERRED);
 	edit_hb->hide();
 	open_editor->hide();
 
@@ -999,8 +981,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	panel->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	blend_space_draw = memnew(Control);
-	blend_space_draw->connect_compat("gui_input", this, "_blend_space_gui_input");
-	blend_space_draw->connect_compat("draw", this, "_blend_space_draw");
+	blend_space_draw->connect("gui_input", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_gui_input));
+	blend_space_draw->connect("draw", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_draw));
 	blend_space_draw->set_focus_mode(FOCUS_ALL);
 
 	panel->add_child(blend_space_draw);
@@ -1029,14 +1011,14 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 		min_x_value->set_step(0.01);
 	}
 
-	snap_x->connect_compat("value_changed", this, "_config_changed");
-	snap_y->connect_compat("value_changed", this, "_config_changed");
-	max_x_value->connect_compat("value_changed", this, "_config_changed");
-	min_x_value->connect_compat("value_changed", this, "_config_changed");
-	max_y_value->connect_compat("value_changed", this, "_config_changed");
-	min_y_value->connect_compat("value_changed", this, "_config_changed");
-	label_x->connect_compat("text_changed", this, "_labels_changed");
-	label_y->connect_compat("text_changed", this, "_labels_changed");
+	snap_x->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
+	snap_y->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
+	max_x_value->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
+	min_x_value->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
+	max_y_value->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
+	min_y_value->connect("value_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
+	label_x->connect("text_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_labels_changed));
+	label_y->connect("text_changed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_labels_changed));
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
@@ -1050,18 +1032,18 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_add_menu_type");
+	menu->connect("id_pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_add_menu_type));
 
 	animations_menu = memnew(PopupMenu);
 	menu->add_child(animations_menu);
 	animations_menu->set_name("animations");
-	animations_menu->connect_compat("index_pressed", this, "_add_animation_type");
+	animations_menu->connect("index_pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_add_animation_type));
 
 	open_file = memnew(EditorFileDialog);
 	add_child(open_file);
 	open_file->set_title(TTR("Open Animation Node"));
 	open_file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	open_file->connect_compat("file_selected", this, "_file_opened");
+	open_file->connect("file_selected", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_file_opened));
 	undo_redo = EditorNode::get_undo_redo();
 
 	selected_point = -1;

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -146,11 +146,11 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			name->set_expand_to_text_length(true);
 			node->add_child(name);
 			node->set_slot(0, false, 0, Color(), true, 0, get_color("font_color", "Label"));
-			name->connect_compat("text_entered", this, "_node_renamed", varray(agnode));
-			name->connect_compat("focus_exited", this, "_node_renamed_focus_out", varray(name, agnode), CONNECT_DEFERRED);
+			name->connect("text_entered", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed), varray(agnode));
+			name->connect("focus_exited", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed_focus_out), varray(name, agnode), CONNECT_DEFERRED);
 			base = 1;
 			node->set_show_close_button(true);
-			node->connect_compat("close_request", this, "_delete_request", varray(E->get()), CONNECT_DEFERRED);
+			node->connect("close_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_delete_request), varray(E->get()), CONNECT_DEFERRED);
 		}
 
 		for (int i = 0; i < agnode->get_input_count(); i++) {
@@ -173,13 +173,13 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 				prop->set_object_and_property(AnimationTreeEditor::get_singleton()->get_tree(), base_path);
 				prop->update_property();
 				prop->set_name_split_ratio(0);
-				prop->connect_compat("property_changed", this, "_property_changed");
+				prop->connect("property_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_property_changed));
 				node->add_child(prop);
 				visible_properties.push_back(prop);
 			}
 		}
 
-		node->connect_compat("dragged", this, "_node_dragged", varray(E->get()));
+		node->connect("dragged", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_dragged), varray(E->get()));
 
 		if (AnimationTreeEditor::get_singleton()->can_edit(agnode)) {
 			node->add_child(memnew(HSeparator));
@@ -187,7 +187,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			open_in_editor->set_text(TTR("Open Editor"));
 			open_in_editor->set_icon(get_icon("Edit", "EditorIcons"));
 			node->add_child(open_in_editor);
-			open_in_editor->connect_compat("pressed", this, "_open_in_editor", varray(E->get()), CONNECT_DEFERRED);
+			open_in_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_open_in_editor), varray(E->get()), CONNECT_DEFERRED);
 			open_in_editor->set_h_size_flags(SIZE_SHRINK_CENTER);
 		}
 
@@ -198,7 +198,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			edit_filters->set_text(TTR("Edit Filters"));
 			edit_filters->set_icon(get_icon("AnimationFilter", "EditorIcons"));
 			node->add_child(edit_filters);
-			edit_filters->connect_compat("pressed", this, "_edit_filters", varray(E->get()), CONNECT_DEFERRED);
+			edit_filters->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_edit_filters), varray(E->get()), CONNECT_DEFERRED);
 			edit_filters->set_h_size_flags(SIZE_SHRINK_CENTER);
 		}
 
@@ -238,7 +238,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			animations[E->get()] = pb;
 			node->add_child(pb);
 
-			mb->get_popup()->connect_compat("index_pressed", this, "_anim_selected", varray(options, E->get()), CONNECT_DEFERRED);
+			mb->get_popup()->connect("index_pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_anim_selected), varray(options, E->get()), CONNECT_DEFERRED);
 		}
 
 		if (EditorSettings::get_singleton()->get("interface/theme/use_graph_node_headers")) {
@@ -799,28 +799,7 @@ void AnimationNodeBlendTreeEditor::_scroll_changed(const Vector2 &p_scroll) {
 void AnimationNodeBlendTreeEditor::_bind_methods() {
 
 	ClassDB::bind_method("_update_graph", &AnimationNodeBlendTreeEditor::_update_graph);
-	ClassDB::bind_method("_add_node", &AnimationNodeBlendTreeEditor::_add_node);
-	ClassDB::bind_method("_node_dragged", &AnimationNodeBlendTreeEditor::_node_dragged);
-	ClassDB::bind_method("_node_renamed", &AnimationNodeBlendTreeEditor::_node_renamed);
-	ClassDB::bind_method("_node_renamed_focus_out", &AnimationNodeBlendTreeEditor::_node_renamed_focus_out);
-	ClassDB::bind_method("_connection_request", &AnimationNodeBlendTreeEditor::_connection_request);
-	ClassDB::bind_method("_disconnection_request", &AnimationNodeBlendTreeEditor::_disconnection_request);
-	ClassDB::bind_method("_node_selected", &AnimationNodeBlendTreeEditor::_node_selected);
-	ClassDB::bind_method("_open_in_editor", &AnimationNodeBlendTreeEditor::_open_in_editor);
-	ClassDB::bind_method("_scroll_changed", &AnimationNodeBlendTreeEditor::_scroll_changed);
-	ClassDB::bind_method("_delete_request", &AnimationNodeBlendTreeEditor::_delete_request);
-	ClassDB::bind_method("_delete_nodes_request", &AnimationNodeBlendTreeEditor::_delete_nodes_request);
-	ClassDB::bind_method("_popup_request", &AnimationNodeBlendTreeEditor::_popup_request);
-	ClassDB::bind_method("_edit_filters", &AnimationNodeBlendTreeEditor::_edit_filters);
 	ClassDB::bind_method("_update_filters", &AnimationNodeBlendTreeEditor::_update_filters);
-	ClassDB::bind_method("_filter_edited", &AnimationNodeBlendTreeEditor::_filter_edited);
-	ClassDB::bind_method("_filter_toggled", &AnimationNodeBlendTreeEditor::_filter_toggled);
-	ClassDB::bind_method("_removed_from_graph", &AnimationNodeBlendTreeEditor::_removed_from_graph);
-	ClassDB::bind_method("_property_changed", &AnimationNodeBlendTreeEditor::_property_changed);
-	ClassDB::bind_method("_file_opened", &AnimationNodeBlendTreeEditor::_file_opened);
-	ClassDB::bind_method("_update_options_menu", &AnimationNodeBlendTreeEditor::_update_options_menu);
-
-	ClassDB::bind_method("_anim_selected", &AnimationNodeBlendTreeEditor::_anim_selected);
 }
 
 AnimationNodeBlendTreeEditor *AnimationNodeBlendTreeEditor::singleton = NULL;
@@ -911,7 +890,7 @@ bool AnimationNodeBlendTreeEditor::can_edit(const Ref<AnimationNode> &p_node) {
 void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 
 	if (blend_tree.is_valid()) {
-		blend_tree->disconnect_compat("removed_from_graph", this, "_removed_from_graph");
+		blend_tree->disconnect("removed_from_graph", callable_mp(this, &AnimationNodeBlendTreeEditor::_removed_from_graph));
 	}
 
 	blend_tree = p_node;
@@ -919,7 +898,7 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 	if (blend_tree.is_null()) {
 		hide();
 	} else {
-		blend_tree->connect_compat("removed_from_graph", this, "_removed_from_graph");
+		blend_tree->connect("removed_from_graph", callable_mp(this, &AnimationNodeBlendTreeEditor::_removed_from_graph));
 
 		_update_graph();
 	}
@@ -936,12 +915,12 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	graph->add_valid_right_disconnect_type(0);
 	graph->add_valid_left_disconnect_type(0);
 	graph->set_v_size_flags(SIZE_EXPAND_FILL);
-	graph->connect_compat("connection_request", this, "_connection_request", varray(), CONNECT_DEFERRED);
-	graph->connect_compat("disconnection_request", this, "_disconnection_request", varray(), CONNECT_DEFERRED);
-	graph->connect_compat("node_selected", this, "_node_selected");
-	graph->connect_compat("scroll_offset_changed", this, "_scroll_changed");
-	graph->connect_compat("delete_nodes_request", this, "_delete_nodes_request");
-	graph->connect_compat("popup_request", this, "_popup_request");
+	graph->connect("connection_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_connection_request), varray(), CONNECT_DEFERRED);
+	graph->connect("disconnection_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_disconnection_request), varray(), CONNECT_DEFERRED);
+	graph->connect("node_selected", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_selected));
+	graph->connect("scroll_offset_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_scroll_changed));
+	graph->connect("delete_nodes_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_delete_nodes_request));
+	graph->connect("popup_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_popup_request));
 
 	VSeparator *vs = memnew(VSeparator);
 	graph->get_zoom_hbox()->add_child(vs);
@@ -951,8 +930,8 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	graph->get_zoom_hbox()->add_child(add_node);
 	add_node->set_text(TTR("Add Node..."));
 	graph->get_zoom_hbox()->move_child(add_node, 0);
-	add_node->get_popup()->connect_compat("id_pressed", this, "_add_node");
-	add_node->connect_compat("about_to_show", this, "_update_options_menu");
+	add_node->get_popup()->connect("id_pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_add_node));
+	add_node->connect("about_to_show", callable_mp(this, &AnimationNodeBlendTreeEditor::_update_options_menu));
 
 	add_options.push_back(AddOption("Animation", "AnimationNodeAnimation"));
 	add_options.push_back(AddOption("OneShot", "AnimationNodeOneShot"));
@@ -984,19 +963,19 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 
 	filter_enabled = memnew(CheckBox);
 	filter_enabled->set_text(TTR("Enable Filtering"));
-	filter_enabled->connect_compat("pressed", this, "_filter_toggled");
+	filter_enabled->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_filter_toggled));
 	filter_vbox->add_child(filter_enabled);
 
 	filters = memnew(Tree);
 	filter_vbox->add_child(filters);
 	filters->set_v_size_flags(SIZE_EXPAND_FILL);
 	filters->set_hide_root(true);
-	filters->connect_compat("item_edited", this, "_filter_edited");
+	filters->connect("item_edited", callable_mp(this, &AnimationNodeBlendTreeEditor::_filter_edited));
 
 	open_file = memnew(EditorFileDialog);
 	add_child(open_file);
 	open_file->set_title(TTR("Open Animation Node"));
 	open_file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	open_file->connect_compat("file_selected", this, "_file_opened");
+	open_file->connect("file_selected", callable_mp(this, &AnimationNodeBlendTreeEditor::_file_opened));
 	undo_redo = EditorNode::get_undo_redo();
 }

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -97,13 +97,13 @@ void AnimationPlayerEditor::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 
-			tool_anim->get_popup()->connect_compat("id_pressed", this, "_animation_tool_menu");
+			tool_anim->get_popup()->connect("id_pressed", callable_mp(this, &AnimationPlayerEditor::_animation_tool_menu));
 
-			onion_skinning->get_popup()->connect_compat("id_pressed", this, "_onion_skinning_menu");
+			onion_skinning->get_popup()->connect("id_pressed", callable_mp(this, &AnimationPlayerEditor::_onion_skinning_menu));
 
-			blend_editor.next->connect_compat("item_selected", this, "_blend_editor_next_changed");
+			blend_editor.next->connect("item_selected", callable_mp(this, &AnimationPlayerEditor::_blend_editor_next_changed));
 
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
+			get_tree()->connect("node_removed", callable_mp(this, &AnimationPlayerEditor::_node_removed));
 
 			add_style_override("panel", editor->get_gui_base()->get_stylebox("panel", "Panel"));
 		} break;
@@ -1527,44 +1527,22 @@ void AnimationPlayerEditor::_pin_pressed() {
 
 void AnimationPlayerEditor::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_node_removed"), &AnimationPlayerEditor::_node_removed);
-	ClassDB::bind_method(D_METHOD("_play_pressed"), &AnimationPlayerEditor::_play_pressed);
-	ClassDB::bind_method(D_METHOD("_play_from_pressed"), &AnimationPlayerEditor::_play_from_pressed);
-	ClassDB::bind_method(D_METHOD("_play_bw_pressed"), &AnimationPlayerEditor::_play_bw_pressed);
-	ClassDB::bind_method(D_METHOD("_play_bw_from_pressed"), &AnimationPlayerEditor::_play_bw_from_pressed);
-	ClassDB::bind_method(D_METHOD("_stop_pressed"), &AnimationPlayerEditor::_stop_pressed);
-	ClassDB::bind_method(D_METHOD("_autoplay_pressed"), &AnimationPlayerEditor::_autoplay_pressed);
-	ClassDB::bind_method(D_METHOD("_animation_selected"), &AnimationPlayerEditor::_animation_selected);
-	ClassDB::bind_method(D_METHOD("_animation_name_edited"), &AnimationPlayerEditor::_animation_name_edited);
 	ClassDB::bind_method(D_METHOD("_animation_new"), &AnimationPlayerEditor::_animation_new);
 	ClassDB::bind_method(D_METHOD("_animation_rename"), &AnimationPlayerEditor::_animation_rename);
 	ClassDB::bind_method(D_METHOD("_animation_load"), &AnimationPlayerEditor::_animation_load);
 	ClassDB::bind_method(D_METHOD("_animation_remove"), &AnimationPlayerEditor::_animation_remove);
-	ClassDB::bind_method(D_METHOD("_animation_remove_confirmed"), &AnimationPlayerEditor::_animation_remove_confirmed);
 	ClassDB::bind_method(D_METHOD("_animation_blend"), &AnimationPlayerEditor::_animation_blend);
 	ClassDB::bind_method(D_METHOD("_animation_edit"), &AnimationPlayerEditor::_animation_edit);
 	ClassDB::bind_method(D_METHOD("_animation_resource_edit"), &AnimationPlayerEditor::_animation_resource_edit);
-	ClassDB::bind_method(D_METHOD("_dialog_action"), &AnimationPlayerEditor::_dialog_action);
-	ClassDB::bind_method(D_METHOD("_seek_value_changed"), &AnimationPlayerEditor::_seek_value_changed, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("_animation_player_changed"), &AnimationPlayerEditor::_animation_player_changed);
-	ClassDB::bind_method(D_METHOD("_blend_edited"), &AnimationPlayerEditor::_blend_edited);
-	ClassDB::bind_method(D_METHOD("_scale_changed"), &AnimationPlayerEditor::_scale_changed);
 	ClassDB::bind_method(D_METHOD("_list_changed"), &AnimationPlayerEditor::_list_changed);
-	ClassDB::bind_method(D_METHOD("_animation_key_editor_seek"), &AnimationPlayerEditor::_animation_key_editor_seek);
-	ClassDB::bind_method(D_METHOD("_animation_key_editor_anim_len_changed"), &AnimationPlayerEditor::_animation_key_editor_anim_len_changed);
 	ClassDB::bind_method(D_METHOD("_animation_duplicate"), &AnimationPlayerEditor::_animation_duplicate);
-	ClassDB::bind_method(D_METHOD("_blend_editor_next_changed"), &AnimationPlayerEditor::_blend_editor_next_changed);
 	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &AnimationPlayerEditor::_unhandled_key_input);
-	ClassDB::bind_method(D_METHOD("_animation_tool_menu"), &AnimationPlayerEditor::_animation_tool_menu);
 
-	ClassDB::bind_method(D_METHOD("_onion_skinning_menu"), &AnimationPlayerEditor::_onion_skinning_menu);
-	ClassDB::bind_method(D_METHOD("_editor_visibility_changed"), &AnimationPlayerEditor::_editor_visibility_changed);
 	ClassDB::bind_method(D_METHOD("_prepare_onion_layers_1"), &AnimationPlayerEditor::_prepare_onion_layers_1);
 	ClassDB::bind_method(D_METHOD("_prepare_onion_layers_2"), &AnimationPlayerEditor::_prepare_onion_layers_2);
 	ClassDB::bind_method(D_METHOD("_start_onion_skinning"), &AnimationPlayerEditor::_start_onion_skinning);
 	ClassDB::bind_method(D_METHOD("_stop_onion_skinning"), &AnimationPlayerEditor::_stop_onion_skinning);
-
-	ClassDB::bind_method(D_METHOD("_pin_pressed"), &AnimationPlayerEditor::_pin_pressed);
 }
 
 AnimationPlayerEditor *AnimationPlayerEditor::singleton = NULL;
@@ -1627,7 +1605,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	delete_dialog = memnew(ConfirmationDialog);
 	add_child(delete_dialog);
-	delete_dialog->connect_compat("confirmed", this, "_animation_remove_confirmed");
+	delete_dialog->connect("confirmed", callable_mp(this, &AnimationPlayerEditor::_animation_remove_confirmed));
 
 	tool_anim = memnew(MenuButton);
 	tool_anim->set_flat(false);
@@ -1672,7 +1650,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	onion_toggle = memnew(ToolButton);
 	onion_toggle->set_toggle_mode(true);
 	onion_toggle->set_tooltip(TTR("Enable Onion Skinning"));
-	onion_toggle->connect_compat("pressed", this, "_onion_skinning_menu", varray(ONION_SKINNING_ENABLE));
+	onion_toggle->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_onion_skinning_menu), varray(ONION_SKINNING_ENABLE));
 	hb->add_child(onion_toggle);
 
 	onion_skinning = memnew(MenuButton);
@@ -1698,7 +1676,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	pin->set_toggle_mode(true);
 	pin->set_tooltip(TTR("Pin AnimationPlayer"));
 	hb->add_child(pin);
-	pin->connect_compat("pressed", this, "_pin_pressed");
+	pin->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_pin_pressed));
 
 	file = memnew(EditorFileDialog);
 	add_child(file);
@@ -1722,7 +1700,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	error_dialog->set_title(TTR("Error!"));
 	add_child(error_dialog);
 
-	name_dialog->connect_compat("confirmed", this, "_animation_name_edited");
+	name_dialog->connect("confirmed", callable_mp(this, &AnimationPlayerEditor::_animation_name_edited));
 
 	blend_editor.dialog = memnew(AcceptDialog);
 	add_child(blend_editor.dialog);
@@ -1738,21 +1716,21 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	blend_editor.dialog->set_title(TTR("Cross-Animation Blend Times"));
 	updating_blends = false;
 
-	blend_editor.tree->connect_compat("item_edited", this, "_blend_edited");
+	blend_editor.tree->connect("item_edited", callable_mp(this, &AnimationPlayerEditor::_blend_edited));
 
-	autoplay->connect_compat("pressed", this, "_autoplay_pressed");
+	autoplay->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_autoplay_pressed));
 	autoplay->set_toggle_mode(true);
-	play->connect_compat("pressed", this, "_play_pressed");
-	play_from->connect_compat("pressed", this, "_play_from_pressed");
-	play_bw->connect_compat("pressed", this, "_play_bw_pressed");
-	play_bw_from->connect_compat("pressed", this, "_play_bw_from_pressed");
-	stop->connect_compat("pressed", this, "_stop_pressed");
+	play->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_play_pressed));
+	play_from->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_play_from_pressed));
+	play_bw->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_play_bw_pressed));
+	play_bw_from->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_play_bw_from_pressed));
+	stop->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_stop_pressed));
 
-	animation->connect_compat("item_selected", this, "_animation_selected", Vector<Variant>(), true);
+	animation->connect("item_selected", callable_mp(this, &AnimationPlayerEditor::_animation_selected), Vector<Variant>(), true);
 
-	file->connect_compat("file_selected", this, "_dialog_action");
-	frame->connect_compat("value_changed", this, "_seek_value_changed", Vector<Variant>(), true);
-	scale->connect_compat("text_entered", this, "_scale_changed", Vector<Variant>(), true);
+	file->connect("file_selected", callable_mp(this, &AnimationPlayerEditor::_dialog_action));
+	frame->connect("value_changed", callable_mp(this, &AnimationPlayerEditor::_seek_value_changed), Vector<Variant>(), true);
+	scale->connect("text_entered", callable_mp(this, &AnimationPlayerEditor::_scale_changed), Vector<Variant>(), true);
 
 	renaming = false;
 	last_active = false;
@@ -1762,14 +1740,14 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	add_child(track_editor);
 	track_editor->set_v_size_flags(SIZE_EXPAND_FILL);
-	track_editor->connect_compat("timeline_changed", this, "_animation_key_editor_seek");
-	track_editor->connect_compat("animation_len_changed", this, "_animation_key_editor_anim_len_changed");
+	track_editor->connect("timeline_changed", callable_mp(this, &AnimationPlayerEditor::_animation_key_editor_seek));
+	track_editor->connect("animation_len_changed", callable_mp(this, &AnimationPlayerEditor::_animation_key_editor_anim_len_changed));
 
 	_update_player();
 
 	// Onion skinning.
 
-	track_editor->connect_compat("visibility_changed", this, "_editor_visibility_changed");
+	track_editor->connect("visibility_changed", callable_mp(this, &AnimationPlayerEditor::_editor_visibility_changed));
 
 	onion.enabled = false;
 	onion.past = true;

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1501,16 +1501,16 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 void AnimationPlayerEditor::_start_onion_skinning() {
 
 	// FIXME: Using "idle_frame" makes onion layers update one frame behind the current.
-	if (!get_tree()->is_connected_compat("idle_frame", this, "call_deferred")) {
-		get_tree()->connect_compat("idle_frame", this, "call_deferred", varray("_prepare_onion_layers_1"));
+	if (!get_tree()->is_connected("idle_frame", callable_mp((Object *)this, &Object::call_deferred))) {
+		get_tree()->connect("idle_frame", callable_mp((Object *)this, &Object::call_deferred), varray("_prepare_onion_layers_1"));
 	}
 }
 
 void AnimationPlayerEditor::_stop_onion_skinning() {
 
-	if (get_tree()->is_connected_compat("idle_frame", this, "call_deferred")) {
+	if (get_tree()->is_connected("idle_frame", callable_mp((Object *)this, &Object::call_deferred))) {
 
-		get_tree()->disconnect_compat("idle_frame", this, "call_deferred");
+		get_tree()->disconnect("idle_frame", callable_mp((Object *)this, &Object::call_deferred));
 
 		_free_onion_layers();
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1234,27 +1234,11 @@ void AnimationNodeStateMachineEditor::_update_mode() {
 
 void AnimationNodeStateMachineEditor::_bind_methods() {
 
-	ClassDB::bind_method("_state_machine_gui_input", &AnimationNodeStateMachineEditor::_state_machine_gui_input);
-	ClassDB::bind_method("_state_machine_draw", &AnimationNodeStateMachineEditor::_state_machine_draw);
-	ClassDB::bind_method("_state_machine_pos_draw", &AnimationNodeStateMachineEditor::_state_machine_pos_draw);
 	ClassDB::bind_method("_update_graph", &AnimationNodeStateMachineEditor::_update_graph);
-
-	ClassDB::bind_method("_add_menu_type", &AnimationNodeStateMachineEditor::_add_menu_type);
-	ClassDB::bind_method("_add_animation_type", &AnimationNodeStateMachineEditor::_add_animation_type);
-
-	ClassDB::bind_method("_name_edited", &AnimationNodeStateMachineEditor::_name_edited);
-	ClassDB::bind_method("_name_edited_focus_out", &AnimationNodeStateMachineEditor::_name_edited_focus_out);
 
 	ClassDB::bind_method("_removed_from_graph", &AnimationNodeStateMachineEditor::_removed_from_graph);
 
 	ClassDB::bind_method("_open_editor", &AnimationNodeStateMachineEditor::_open_editor);
-	ClassDB::bind_method("_scroll_changed", &AnimationNodeStateMachineEditor::_scroll_changed);
-
-	ClassDB::bind_method("_erase_selected", &AnimationNodeStateMachineEditor::_erase_selected);
-	ClassDB::bind_method("_autoplay_selected", &AnimationNodeStateMachineEditor::_autoplay_selected);
-	ClassDB::bind_method("_end_selected", &AnimationNodeStateMachineEditor::_end_selected);
-	ClassDB::bind_method("_update_mode", &AnimationNodeStateMachineEditor::_update_mode);
-	ClassDB::bind_method("_file_opened", &AnimationNodeStateMachineEditor::_file_opened);
 }
 
 AnimationNodeStateMachineEditor *AnimationNodeStateMachineEditor::singleton = NULL;
@@ -1276,21 +1260,21 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_select->set_button_group(bg);
 	tool_select->set_pressed(true);
 	tool_select->set_tooltip(TTR("Select and move nodes.\nRMB to add new nodes.\nShift+LMB to create connections."));
-	tool_select->connect_compat("pressed", this, "_update_mode", varray(), CONNECT_DEFERRED);
+	tool_select->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
 
 	tool_create = memnew(ToolButton);
 	top_hb->add_child(tool_create);
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	tool_create->set_tooltip(TTR("Create new nodes."));
-	tool_create->connect_compat("pressed", this, "_update_mode", varray(), CONNECT_DEFERRED);
+	tool_create->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
 
 	tool_connect = memnew(ToolButton);
 	top_hb->add_child(tool_connect);
 	tool_connect->set_toggle_mode(true);
 	tool_connect->set_button_group(bg);
 	tool_connect->set_tooltip(TTR("Connect nodes."));
-	tool_connect->connect_compat("pressed", this, "_update_mode", varray(), CONNECT_DEFERRED);
+	tool_connect->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
 
 	tool_erase_hb = memnew(HBoxContainer);
 	top_hb->add_child(tool_erase_hb);
@@ -1298,7 +1282,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_erase = memnew(ToolButton);
 	tool_erase->set_tooltip(TTR("Remove selected node or transition."));
 	tool_erase_hb->add_child(tool_erase);
-	tool_erase->connect_compat("pressed", this, "_erase_selected");
+	tool_erase->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_erase_selected));
 	tool_erase->set_disabled(true);
 
 	tool_erase_hb->add_child(memnew(VSeparator));
@@ -1306,13 +1290,13 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_autoplay = memnew(ToolButton);
 	tool_autoplay->set_tooltip(TTR("Toggle autoplay this animation on start, restart or seek to zero."));
 	tool_erase_hb->add_child(tool_autoplay);
-	tool_autoplay->connect_compat("pressed", this, "_autoplay_selected");
+	tool_autoplay->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_autoplay_selected));
 	tool_autoplay->set_disabled(true);
 
 	tool_end = memnew(ToolButton);
 	tool_end->set_tooltip(TTR("Set the end animation. This is useful for sub-transitions."));
 	tool_erase_hb->add_child(tool_end);
-	tool_end->connect_compat("pressed", this, "_end_selected");
+	tool_end->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_end_selected));
 	tool_end->set_disabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
@@ -1333,26 +1317,26 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	state_machine_draw = memnew(Control);
 	panel->add_child(state_machine_draw);
-	state_machine_draw->connect_compat("gui_input", this, "_state_machine_gui_input");
-	state_machine_draw->connect_compat("draw", this, "_state_machine_draw");
+	state_machine_draw->connect("gui_input", callable_mp(this, &AnimationNodeStateMachineEditor::_state_machine_gui_input));
+	state_machine_draw->connect("draw", callable_mp(this, &AnimationNodeStateMachineEditor::_state_machine_draw));
 	state_machine_draw->set_focus_mode(FOCUS_ALL);
 
 	state_machine_play_pos = memnew(Control);
 	state_machine_draw->add_child(state_machine_play_pos);
 	state_machine_play_pos->set_mouse_filter(MOUSE_FILTER_PASS); //pass all to parent
 	state_machine_play_pos->set_anchors_and_margins_preset(PRESET_WIDE);
-	state_machine_play_pos->connect_compat("draw", this, "_state_machine_pos_draw");
+	state_machine_play_pos->connect("draw", callable_mp(this, &AnimationNodeStateMachineEditor::_state_machine_pos_draw));
 
 	v_scroll = memnew(VScrollBar);
 	state_machine_draw->add_child(v_scroll);
 	v_scroll->set_anchors_and_margins_preset(PRESET_RIGHT_WIDE);
-	v_scroll->connect_compat("value_changed", this, "_scroll_changed");
+	v_scroll->connect("value_changed", callable_mp(this, &AnimationNodeStateMachineEditor::_scroll_changed));
 
 	h_scroll = memnew(HScrollBar);
 	state_machine_draw->add_child(h_scroll);
 	h_scroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
 	h_scroll->set_margin(MARGIN_RIGHT, -v_scroll->get_size().x * EDSCALE);
-	h_scroll->connect_compat("value_changed", this, "_scroll_changed");
+	h_scroll->connect("value_changed", callable_mp(this, &AnimationNodeStateMachineEditor::_scroll_changed));
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
@@ -1366,25 +1350,25 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_add_menu_type");
+	menu->connect("id_pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_add_menu_type));
 
 	animations_menu = memnew(PopupMenu);
 	menu->add_child(animations_menu);
 	animations_menu->set_name("animations");
-	animations_menu->connect_compat("index_pressed", this, "_add_animation_type");
+	animations_menu->connect("index_pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_add_animation_type));
 
 	name_edit = memnew(LineEdit);
 	state_machine_draw->add_child(name_edit);
 	name_edit->hide();
-	name_edit->connect_compat("text_entered", this, "_name_edited");
-	name_edit->connect_compat("focus_exited", this, "_name_edited_focus_out");
+	name_edit->connect("text_entered", callable_mp(this, &AnimationNodeStateMachineEditor::_name_edited));
+	name_edit->connect("focus_exited", callable_mp(this, &AnimationNodeStateMachineEditor::_name_edited_focus_out));
 	name_edit->set_as_toplevel(true);
 
 	open_file = memnew(EditorFileDialog);
 	add_child(open_file);
 	open_file->set_title(TTR("Open Animation Node"));
 	open_file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	open_file->connect_compat("file_selected", this, "_file_opened");
+	open_file->connect("file_selected", callable_mp(this, &AnimationNodeStateMachineEditor::_file_opened));
 	undo_redo = EditorNode::get_undo_redo();
 
 	over_text = false;

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -85,7 +85,7 @@ void AnimationTreeEditor::_update_path() {
 	b->set_button_group(group);
 	b->set_pressed(true);
 	b->set_focus_mode(FOCUS_NONE);
-	b->connect_compat("pressed", this, "_path_button_pressed", varray(-1));
+	b->connect("pressed", callable_mp(this, &AnimationTreeEditor::_path_button_pressed), varray(-1));
 	path_hb->add_child(b);
 	for (int i = 0; i < button_path.size(); i++) {
 		b = memnew(Button);
@@ -95,7 +95,7 @@ void AnimationTreeEditor::_update_path() {
 		path_hb->add_child(b);
 		b->set_pressed(true);
 		b->set_focus_mode(FOCUS_NONE);
-		b->connect_compat("pressed", this, "_path_button_pressed", varray(i));
+		b->connect("pressed", callable_mp(this, &AnimationTreeEditor::_path_button_pressed), varray(i));
 	}
 }
 
@@ -167,7 +167,6 @@ void AnimationTreeEditor::_notification(int p_what) {
 }
 
 void AnimationTreeEditor::_bind_methods() {
-	ClassDB::bind_method("_path_button_pressed", &AnimationTreeEditor::_path_button_pressed);
 }
 
 AnimationTreeEditor *AnimationTreeEditor::singleton = NULL;

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -86,9 +86,6 @@ void EditorAssetLibraryItem::_author_clicked() {
 void EditorAssetLibraryItem::_bind_methods() {
 
 	ClassDB::bind_method("set_image", &EditorAssetLibraryItem::set_image);
-	ClassDB::bind_method("_asset_clicked", &EditorAssetLibraryItem::_asset_clicked);
-	ClassDB::bind_method("_category_clicked", &EditorAssetLibraryItem::_category_clicked);
-	ClassDB::bind_method("_author_clicked", &EditorAssetLibraryItem::_author_clicked);
 	ADD_SIGNAL(MethodInfo("asset_selected"));
 	ADD_SIGNAL(MethodInfo("category_selected"));
 	ADD_SIGNAL(MethodInfo("author_selected"));
@@ -112,7 +109,7 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 	icon = memnew(TextureButton);
 	icon->set_custom_minimum_size(Size2(64, 64) * EDSCALE);
 	icon->set_default_cursor_shape(CURSOR_POINTING_HAND);
-	icon->connect_compat("pressed", this, "_asset_clicked");
+	icon->connect("pressed", callable_mp(this, &EditorAssetLibraryItem::_asset_clicked));
 
 	hb->add_child(icon);
 
@@ -123,17 +120,17 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 
 	title = memnew(LinkButton);
 	title->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	title->connect_compat("pressed", this, "_asset_clicked");
+	title->connect("pressed", callable_mp(this, &EditorAssetLibraryItem::_asset_clicked));
 	vb->add_child(title);
 
 	category = memnew(LinkButton);
 	category->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	category->connect_compat("pressed", this, "_category_clicked");
+	category->connect("pressed", callable_mp(this, &EditorAssetLibraryItem::_category_clicked));
 	vb->add_child(category);
 
 	author = memnew(LinkButton);
 	author->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	author->connect_compat("pressed", this, "_author_clicked");
+	author->connect("pressed", callable_mp(this, &EditorAssetLibraryItem::_author_clicked));
 	vb->add_child(author);
 
 	price = memnew(Label);
@@ -208,8 +205,6 @@ void EditorAssetLibraryItemDescription::_notification(int p_what) {
 
 void EditorAssetLibraryItemDescription::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_image"), &EditorAssetLibraryItemDescription::set_image);
-	ClassDB::bind_method(D_METHOD("_link_click"), &EditorAssetLibraryItemDescription::_link_click);
-	ClassDB::bind_method(D_METHOD("_preview_click"), &EditorAssetLibraryItemDescription::_preview_click);
 }
 
 void EditorAssetLibraryItemDescription::_link_click(const String &p_url) {
@@ -263,7 +258,7 @@ void EditorAssetLibraryItemDescription::add_preview(int p_id, bool p_video, cons
 	preview.button->set_flat(true);
 	preview.button->set_icon(get_icon("ThumbnailWait", "EditorIcons"));
 	preview.button->set_toggle_mode(true);
-	preview.button->connect_compat("pressed", this, "_preview_click", varray(p_id));
+	preview.button->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDescription::_preview_click), varray(p_id));
 	preview_hb->add_child(preview.button);
 	if (!p_video) {
 		preview.image = get_icon("ThumbnailWait", "EditorIcons");
@@ -290,7 +285,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	description = memnew(RichTextLabel);
 	desc_vbox->add_child(description);
 	description->set_v_size_flags(SIZE_EXPAND_FILL);
-	description->connect_compat("meta_clicked", this, "_link_click");
+	description->connect("meta_clicked", callable_mp(this, &EditorAssetLibraryItemDescription::_link_click));
 	description->add_constant_override("line_separation", Math::round(5 * EDSCALE));
 
 	VBoxContainer *previews_vbox = memnew(VBoxContainer);
@@ -500,11 +495,6 @@ void EditorAssetLibraryItemDownload::_make_request() {
 
 void EditorAssetLibraryItemDownload::_bind_methods() {
 
-	ClassDB::bind_method("_http_download_completed", &EditorAssetLibraryItemDownload::_http_download_completed);
-	ClassDB::bind_method("_install", &EditorAssetLibraryItemDownload::_install);
-	ClassDB::bind_method("_close", &EditorAssetLibraryItemDownload::_close);
-	ClassDB::bind_method("_make_request", &EditorAssetLibraryItemDownload::_make_request);
-
 	ADD_SIGNAL(MethodInfo("install_asset", PropertyInfo(Variant::STRING, "zip_path"), PropertyInfo(Variant::STRING, "name")));
 }
 
@@ -526,7 +516,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	title->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	dismiss = memnew(TextureButton);
-	dismiss->connect_compat("pressed", this, "_close");
+	dismiss->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDownload::_close));
 	title_hb->add_child(dismiss);
 
 	title->set_clip_text(true);
@@ -546,11 +536,11 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	install = memnew(Button);
 	install->set_text(TTR("Install..."));
 	install->set_disabled(true);
-	install->connect_compat("pressed", this, "_install");
+	install->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDownload::_install));
 
 	retry = memnew(Button);
 	retry->set_text(TTR("Retry"));
-	retry->connect_compat("pressed", this, "_make_request");
+	retry->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDownload::_make_request));
 
 	hb2->add_child(retry);
 	hb2->add_child(install);
@@ -558,7 +548,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 
 	download = memnew(HTTPRequest);
 	add_child(download);
-	download->connect_compat("request_completed", this, "_http_download_completed");
+	download->connect("request_completed", callable_mp(this, &EditorAssetLibraryItemDownload::_http_download_completed));
 	download->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
 
 	download_error = memnew(AcceptDialog);
@@ -567,7 +557,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 
 	asset_installer = memnew(EditorAssetInstaller);
 	add_child(asset_installer);
-	asset_installer->connect_compat("confirmed", this, "_close");
+	asset_installer->connect("confirmed", callable_mp(this, &EditorAssetLibraryItemDownload::_close));
 
 	prev_status = -1;
 
@@ -657,7 +647,7 @@ void EditorAssetLibrary::_install_asset() {
 
 	if (templates_only) {
 		download->set_external_install(true);
-		download->connect_compat("install_asset", this, "_install_external_asset");
+		download->connect("install_asset", callable_mp(this, &EditorAssetLibrary::_install_external_asset));
 	}
 }
 
@@ -892,7 +882,7 @@ void EditorAssetLibrary::_request_image(ObjectID p_for, String p_image_url, Imag
 	iq.queue_id = ++last_queue_id;
 	iq.active = false;
 
-	iq.request->connect_compat("request_completed", this, "_image_request_completed", varray(iq.queue_id));
+	iq.request->connect("request_completed", callable_mp(this, &EditorAssetLibrary::_image_request_completed), varray(iq.queue_id));
 
 	image_queue[iq.queue_id] = iq;
 
@@ -991,7 +981,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *first = memnew(Button);
 	first->set_text(TTR("First"));
 	if (p_page != 0) {
-		first->connect_compat("pressed", this, "_search", varray(0));
+		first->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(0));
 	} else {
 		first->set_disabled(true);
 		first->set_focus_mode(Control::FOCUS_NONE);
@@ -1001,7 +991,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *prev = memnew(Button);
 	prev->set_text(TTR("Previous"));
 	if (p_page > 0) {
-		prev->connect_compat("pressed", this, "_search", varray(p_page - 1));
+		prev->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(p_page - 1));
 	} else {
 		prev->set_disabled(true);
 		prev->set_focus_mode(Control::FOCUS_NONE);
@@ -1023,7 +1013,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 
 			Button *current = memnew(Button);
 			current->set_text(itos(i + 1));
-			current->connect_compat("pressed", this, "_search", varray(i));
+			current->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(i));
 
 			hbc->add_child(current);
 		}
@@ -1032,7 +1022,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *next = memnew(Button);
 	next->set_text(TTR("Next"));
 	if (p_page < p_page_count - 1) {
-		next->connect_compat("pressed", this, "_search", varray(p_page + 1));
+		next->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(p_page + 1));
 	} else {
 		next->set_disabled(true);
 		next->set_focus_mode(Control::FOCUS_NONE);
@@ -1043,7 +1033,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *last = memnew(Button);
 	last->set_text(TTR("Last"));
 	if (p_page != p_page_count - 1) {
-		last->connect_compat("pressed", this, "_search", varray(p_page_count - 1));
+		last->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(p_page_count - 1));
 	} else {
 		last->set_disabled(true);
 		last->set_focus_mode(Control::FOCUS_NONE);
@@ -1229,9 +1219,9 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				EditorAssetLibraryItem *item = memnew(EditorAssetLibraryItem);
 				asset_items->add_child(item);
 				item->configure(r["title"], r["asset_id"], category_map[r["category_id"]], r["category_id"], r["author"], r["author_id"], r["cost"]);
-				item->connect_compat("asset_selected", this, "_select_asset");
-				item->connect_compat("author_selected", this, "_select_author");
-				item->connect_compat("category_selected", this, "_select_category");
+				item->connect("asset_selected", callable_mp(this, &EditorAssetLibrary::_select_asset));
+				item->connect("author_selected", callable_mp(this, &EditorAssetLibrary::_select_author));
+				item->connect("category_selected", callable_mp(this, &EditorAssetLibrary::_select_category));
 
 				if (r.has("icon_url") && r["icon_url"] != "") {
 					_request_image(item->get_instance_id(), r["icon_url"], IMAGE_QUEUE_ICON, 0);
@@ -1262,7 +1252,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 			description = memnew(EditorAssetLibraryItemDescription);
 			add_child(description);
 			description->popup_centered_minsize();
-			description->connect_compat("confirmed", this, "_install_asset");
+			description->connect("confirmed", callable_mp(this, &EditorAssetLibrary::_install_asset));
 
 			description->configure(r["title"], r["asset_id"], category_map[r["category_id"]], r["category_id"], r["author"], r["author_id"], r["cost"], r["version"], r["version_string"], r["description"], r["download_url"], r["browse_url"], r["download_hash"]);
 
@@ -1337,21 +1327,6 @@ void EditorAssetLibrary::disable_community_support() {
 void EditorAssetLibrary::_bind_methods() {
 
 	ClassDB::bind_method("_unhandled_input", &EditorAssetLibrary::_unhandled_input);
-	ClassDB::bind_method("_http_request_completed", &EditorAssetLibrary::_http_request_completed);
-	ClassDB::bind_method("_select_asset", &EditorAssetLibrary::_select_asset);
-	ClassDB::bind_method("_select_author", &EditorAssetLibrary::_select_author);
-	ClassDB::bind_method("_select_category", &EditorAssetLibrary::_select_category);
-	ClassDB::bind_method("_image_request_completed", &EditorAssetLibrary::_image_request_completed);
-	ClassDB::bind_method("_search", &EditorAssetLibrary::_search, DEFVAL(0));
-	ClassDB::bind_method("_search_text_entered", &EditorAssetLibrary::_search_text_entered);
-	ClassDB::bind_method("_install_asset", &EditorAssetLibrary::_install_asset);
-	ClassDB::bind_method("_manage_plugins", &EditorAssetLibrary::_manage_plugins);
-	ClassDB::bind_method("_asset_open", &EditorAssetLibrary::_asset_open);
-	ClassDB::bind_method("_asset_file_selected", &EditorAssetLibrary::_asset_file_selected);
-	ClassDB::bind_method("_repository_changed", &EditorAssetLibrary::_repository_changed);
-	ClassDB::bind_method("_support_toggled", &EditorAssetLibrary::_support_toggled);
-	ClassDB::bind_method("_rerun_search", &EditorAssetLibrary::_rerun_search);
-	ClassDB::bind_method("_install_external_asset", &EditorAssetLibrary::_install_external_asset);
 
 	ADD_SIGNAL(MethodInfo("install_asset", PropertyInfo(Variant::STRING, "zip_path"), PropertyInfo(Variant::STRING, "name")));
 }
@@ -1374,9 +1349,9 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	filter = memnew(LineEdit);
 	search_hb->add_child(filter);
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
-	filter->connect_compat("text_entered", this, "_search_text_entered");
+	filter->connect("text_entered", callable_mp(this, &EditorAssetLibrary::_search_text_entered));
 	search = memnew(Button(TTR("Search")));
-	search->connect_compat("pressed", this, "_search");
+	search->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search));
 	search_hb->add_child(search);
 
 	if (!p_templates_only)
@@ -1385,12 +1360,12 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	Button *open_asset = memnew(Button);
 	open_asset->set_text(TTR("Import..."));
 	search_hb->add_child(open_asset);
-	open_asset->connect_compat("pressed", this, "_asset_open");
+	open_asset->connect("pressed", callable_mp(this, &EditorAssetLibrary::_asset_open));
 
 	Button *plugins = memnew(Button);
 	plugins->set_text(TTR("Plugins..."));
 	search_hb->add_child(plugins);
-	plugins->connect_compat("pressed", this, "_manage_plugins");
+	plugins->connect("pressed", callable_mp(this, &EditorAssetLibrary::_manage_plugins));
 
 	if (p_templates_only) {
 		open_asset->hide();
@@ -1409,7 +1384,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	search_hb2->add_child(sort);
 
 	sort->set_h_size_flags(SIZE_EXPAND_FILL);
-	sort->connect_compat("item_selected", this, "_rerun_search");
+	sort->connect("item_selected", callable_mp(this, &EditorAssetLibrary::_rerun_search));
 
 	search_hb2->add_child(memnew(VSeparator));
 
@@ -1418,7 +1393,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	categories->add_item(TTR("All"));
 	search_hb2->add_child(categories);
 	categories->set_h_size_flags(SIZE_EXPAND_FILL);
-	categories->connect_compat("item_selected", this, "_rerun_search");
+	categories->connect("item_selected", callable_mp(this, &EditorAssetLibrary::_rerun_search));
 
 	search_hb2->add_child(memnew(VSeparator));
 
@@ -1430,7 +1405,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	repository->add_item("localhost");
 	repository->set_item_metadata(1, "http://127.0.0.1/asset-library/api");
 
-	repository->connect_compat("item_selected", this, "_repository_changed");
+	repository->connect("item_selected", callable_mp(this, &EditorAssetLibrary::_repository_changed));
 
 	search_hb2->add_child(repository);
 	repository->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1445,7 +1420,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	support->get_popup()->add_check_item(TTR("Testing"), SUPPORT_TESTING);
 	support->get_popup()->set_item_checked(SUPPORT_OFFICIAL, true);
 	support->get_popup()->set_item_checked(SUPPORT_COMMUNITY, true);
-	support->get_popup()->connect_compat("id_pressed", this, "_support_toggled");
+	support->get_popup()->connect("id_pressed", callable_mp(this, &EditorAssetLibrary::_support_toggled));
 
 	/////////
 
@@ -1501,7 +1476,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	request = memnew(HTTPRequest);
 	add_child(request);
 	request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
-	request->connect_compat("request_completed", this, "_http_request_completed");
+	request->connect("request_completed", callable_mp(this, &EditorAssetLibrary::_http_request_completed));
 
 	last_queue_id = 0;
 
@@ -1534,7 +1509,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	asset_open->add_filter("*.zip ; " + TTR("Assets ZIP File"));
 	asset_open->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	add_child(asset_open);
-	asset_open->connect_compat("file_selected", this, "_asset_file_selected");
+	asset_open->connect("file_selected", callable_mp(this, &EditorAssetLibrary::_asset_file_selected));
 
 	asset_installer = NULL;
 }

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -39,7 +39,7 @@
 void AudioStreamEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_READY) {
-		AudioStreamPreviewGenerator::get_singleton()->connect_compat("preview_updated", this, "_preview_changed");
+		AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AudioStreamEditor::_preview_changed));
 	}
 
 	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
@@ -197,14 +197,6 @@ void AudioStreamEditor::edit(Ref<AudioStream> p_stream) {
 }
 
 void AudioStreamEditor::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_preview_changed"), &AudioStreamEditor::_preview_changed);
-	ClassDB::bind_method(D_METHOD("_play"), &AudioStreamEditor::_play);
-	ClassDB::bind_method(D_METHOD("_stop"), &AudioStreamEditor::_stop);
-	ClassDB::bind_method(D_METHOD("_on_finished"), &AudioStreamEditor::_on_finished);
-	ClassDB::bind_method(D_METHOD("_draw_preview"), &AudioStreamEditor::_draw_preview);
-	ClassDB::bind_method(D_METHOD("_draw_indicator"), &AudioStreamEditor::_draw_indicator);
-	ClassDB::bind_method(D_METHOD("_on_input_indicator"), &AudioStreamEditor::_on_input_indicator);
 }
 
 AudioStreamEditor::AudioStreamEditor() {
@@ -214,7 +206,7 @@ AudioStreamEditor::AudioStreamEditor() {
 	_dragging = false;
 
 	_player = memnew(AudioStreamPlayer);
-	_player->connect_compat("finished", this, "_on_finished");
+	_player->connect("finished", callable_mp(this, &AudioStreamEditor::_on_finished));
 	add_child(_player);
 
 	VBoxContainer *vbox = memnew(VBoxContainer);
@@ -223,13 +215,13 @@ AudioStreamEditor::AudioStreamEditor() {
 
 	_preview = memnew(ColorRect);
 	_preview->set_v_size_flags(SIZE_EXPAND_FILL);
-	_preview->connect_compat("draw", this, "_draw_preview");
+	_preview->connect("draw", callable_mp(this, &AudioStreamEditor::_draw_preview));
 	vbox->add_child(_preview);
 
 	_indicator = memnew(Control);
 	_indicator->set_anchors_and_margins_preset(PRESET_WIDE);
-	_indicator->connect_compat("draw", this, "_draw_indicator");
-	_indicator->connect_compat("gui_input", this, "_on_input_indicator");
+	_indicator->connect("draw", callable_mp(this, &AudioStreamEditor::_draw_indicator));
+	_indicator->connect("gui_input", callable_mp(this, &AudioStreamEditor::_on_input_indicator));
 	_preview->add_child(_indicator);
 
 	HBoxContainer *hbox = memnew(HBoxContainer);
@@ -239,12 +231,12 @@ AudioStreamEditor::AudioStreamEditor() {
 	_play_button = memnew(ToolButton);
 	hbox->add_child(_play_button);
 	_play_button->set_focus_mode(Control::FOCUS_NONE);
-	_play_button->connect_compat("pressed", this, "_play");
+	_play_button->connect("pressed", callable_mp(this, &AudioStreamEditor::_play));
 
 	_stop_button = memnew(ToolButton);
 	hbox->add_child(_stop_button);
 	_stop_button->set_focus_mode(Control::FOCUS_NONE);
-	_stop_button->connect_compat("pressed", this, "_stop");
+	_stop_button->connect("pressed", callable_mp(this, &AudioStreamEditor::_stop));
 
 	_current_label = memnew(Label);
 	_current_label->set_align(Label::ALIGN_RIGHT);

--- a/editor/plugins/camera_editor_plugin.cpp
+++ b/editor/plugins/camera_editor_plugin.cpp
@@ -48,8 +48,6 @@ void CameraEditor::_pressed() {
 }
 
 void CameraEditor::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_pressed"), &CameraEditor::_pressed);
 }
 
 void CameraEditor::edit(Node *p_camera) {
@@ -81,7 +79,7 @@ CameraEditor::CameraEditor() {
 	preview->set_margin(MARGIN_RIGHT, 0);
 	preview->set_margin(MARGIN_TOP, 0);
 	preview->set_margin(MARGIN_BOTTOM, 10);
-	preview->connect_compat("pressed", this, "_pressed");
+	preview->connect("pressed", callable_mp(this, &CameraEditor::_pressed));
 }
 
 void CameraEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3891,10 +3891,10 @@ void CanvasItemEditor::_notification(int p_what) {
 			select_sb->set_default_margin(Margin(i), 4);
 		}
 
-		AnimationPlayerEditor::singleton->get_track_editor()->connect_compat("visibility_changed", this, "_keying_changed");
+		AnimationPlayerEditor::singleton->get_track_editor()->connect("visibility_changed", callable_mp(this, &CanvasItemEditor::_keying_changed));
 		_keying_changed();
-		get_tree()->connect_compat("node_added", this, "_tree_changed", varray());
-		get_tree()->connect_compat("node_removed", this, "_tree_changed", varray());
+		get_tree()->connect("node_added", callable_mp(this, &CanvasItemEditor::_tree_changed), varray());
+		get_tree()->connect("node_removed", callable_mp(this, &CanvasItemEditor::_tree_changed), varray());
 
 	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
 
@@ -3902,8 +3902,8 @@ void CanvasItemEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
-		get_tree()->disconnect_compat("node_added", this, "_tree_changed");
-		get_tree()->disconnect_compat("node_removed", this, "_tree_changed");
+		get_tree()->disconnect("node_added", callable_mp(this, &CanvasItemEditor::_tree_changed));
+		get_tree()->disconnect("node_removed", callable_mp(this, &CanvasItemEditor::_tree_changed));
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
@@ -4181,7 +4181,7 @@ void CanvasItemEditor::_popup_warning_temporarily(Control *p_control, const floa
 	Timer *timer;
 	if (!popup_temporarily_timers.has(p_control)) {
 		timer = memnew(Timer);
-		timer->connect_compat("timeout", this, "_popup_warning_depop", varray(p_control));
+		timer->connect("timeout", callable_mp(this, &CanvasItemEditor::_popup_warning_depop), varray(p_control));
 		timer->set_one_shot(true);
 		add_child(timer);
 
@@ -5060,31 +5060,11 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 
 void CanvasItemEditor::_bind_methods() {
 
-	ClassDB::bind_method("_button_zoom_minus", &CanvasItemEditor::_button_zoom_minus);
-	ClassDB::bind_method("_button_zoom_reset", &CanvasItemEditor::_button_zoom_reset);
-	ClassDB::bind_method("_button_zoom_plus", &CanvasItemEditor::_button_zoom_plus);
-	ClassDB::bind_method("_button_toggle_smart_snap", &CanvasItemEditor::_button_toggle_smart_snap);
-	ClassDB::bind_method("_button_toggle_grid_snap", &CanvasItemEditor::_button_toggle_grid_snap);
-	ClassDB::bind_method(D_METHOD("_button_override_camera", "pressed"), &CanvasItemEditor::_button_override_camera);
 	ClassDB::bind_method(D_METHOD("_update_override_camera_button", "game_running"), &CanvasItemEditor::_update_override_camera_button);
-	ClassDB::bind_method("_button_toggle_anchor_mode", &CanvasItemEditor::_button_toggle_anchor_mode);
-	ClassDB::bind_method("_update_scroll", &CanvasItemEditor::_update_scroll);
-	ClassDB::bind_method("_update_scrollbars", &CanvasItemEditor::_update_scrollbars);
-	ClassDB::bind_method("_popup_callback", &CanvasItemEditor::_popup_callback);
 	ClassDB::bind_method("_get_editor_data", &CanvasItemEditor::_get_editor_data);
-	ClassDB::bind_method("_button_tool_select", &CanvasItemEditor::_button_tool_select);
-	ClassDB::bind_method("_keying_changed", &CanvasItemEditor::_keying_changed);
 	ClassDB::bind_method("_unhandled_key_input", &CanvasItemEditor::_unhandled_key_input);
-	ClassDB::bind_method("_draw_viewport", &CanvasItemEditor::_draw_viewport);
-	ClassDB::bind_method("_gui_input_viewport", &CanvasItemEditor::_gui_input_viewport);
-	ClassDB::bind_method("_snap_changed", &CanvasItemEditor::_snap_changed);
 	ClassDB::bind_method("_queue_update_bone_list", &CanvasItemEditor::_update_bone_list);
 	ClassDB::bind_method("_update_bone_list", &CanvasItemEditor::_update_bone_list);
-	ClassDB::bind_method("_tree_changed", &CanvasItemEditor::_tree_changed);
-	ClassDB::bind_method("_selection_changed", &CanvasItemEditor::_selection_changed);
-	ClassDB::bind_method("_popup_warning_depop", &CanvasItemEditor::_popup_warning_depop);
-	ClassDB::bind_method(D_METHOD("_selection_result_pressed"), &CanvasItemEditor::_selection_result_pressed);
-	ClassDB::bind_method(D_METHOD("_selection_menu_hide"), &CanvasItemEditor::_selection_menu_hide);
 	ClassDB::bind_method(D_METHOD("set_state"), &CanvasItemEditor::set_state);
 	ClassDB::bind_method(D_METHOD("update_viewport"), &CanvasItemEditor::update_viewport);
 
@@ -5411,7 +5391,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	editor_selection = p_editor->get_editor_selection();
 	editor_selection->add_editor_plugin(this);
 	editor_selection->connect_compat("selection_changed", this, "update");
-	editor_selection->connect_compat("selection_changed", this, "_selection_changed");
+	editor_selection->connect("selection_changed", callable_mp(this, &CanvasItemEditor::_selection_changed));
 
 	editor->call_deferred("connect", make_binds("play_pressed", Callable(this, "_update_override_camera_button"), true));
 	editor->call_deferred("connect", make_binds("stop_pressed", Callable(this, "_update_override_camera_button"), false));
@@ -5434,7 +5414,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	viewport_scrollable->set_clip_contents(true);
 	viewport_scrollable->set_v_size_flags(SIZE_EXPAND_FILL);
 	viewport_scrollable->set_h_size_flags(SIZE_EXPAND_FILL);
-	viewport_scrollable->connect_compat("draw", this, "_update_scrollbars");
+	viewport_scrollable->connect("draw", callable_mp(this, &CanvasItemEditor::_update_scrollbars));
 
 	ViewportContainer *scene_tree = memnew(ViewportContainer);
 	viewport_scrollable->add_child(scene_tree);
@@ -5456,8 +5436,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	viewport->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	viewport->set_clip_contents(true);
 	viewport->set_focus_mode(FOCUS_ALL);
-	viewport->connect_compat("draw", this, "_draw_viewport");
-	viewport->connect_compat("gui_input", this, "_gui_input_viewport");
+	viewport->connect("draw", callable_mp(this, &CanvasItemEditor::_draw_viewport));
+	viewport->connect("gui_input", callable_mp(this, &CanvasItemEditor::_gui_input_viewport));
 
 	info_overlay = memnew(VBoxContainer);
 	info_overlay->set_anchors_and_margins_preset(Control::PRESET_BOTTOM_LEFT);
@@ -5485,25 +5465,25 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	h_scroll = memnew(HScrollBar);
 	viewport->add_child(h_scroll);
-	h_scroll->connect_compat("value_changed", this, "_update_scroll");
+	h_scroll->connect("value_changed", callable_mp(this, &CanvasItemEditor::_update_scroll));
 	h_scroll->hide();
 
 	v_scroll = memnew(VScrollBar);
 	viewport->add_child(v_scroll);
-	v_scroll->connect_compat("value_changed", this, "_update_scroll");
+	v_scroll->connect("value_changed", callable_mp(this, &CanvasItemEditor::_update_scroll));
 	v_scroll->hide();
 
 	viewport->add_child(controls_vb);
 
 	zoom_minus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_minus);
-	zoom_minus->connect_compat("pressed", this, "_button_zoom_minus");
+	zoom_minus->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_zoom_minus));
 	zoom_minus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_minus", TTR("Zoom Out"), KEY_MASK_CMD | KEY_MINUS));
 	zoom_minus->set_focus_mode(FOCUS_NONE);
 
 	zoom_reset = memnew(ToolButton);
 	zoom_hb->add_child(zoom_reset);
-	zoom_reset->connect_compat("pressed", this, "_button_zoom_reset");
+	zoom_reset->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_zoom_reset));
 	zoom_reset->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_reset", TTR("Zoom Reset"), KEY_MASK_CMD | KEY_0));
 	zoom_reset->set_focus_mode(FOCUS_NONE);
 	zoom_reset->set_text_align(Button::TextAlign::ALIGN_CENTER);
@@ -5512,7 +5492,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	zoom_plus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_plus);
-	zoom_plus->connect_compat("pressed", this, "_button_zoom_plus");
+	zoom_plus->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_zoom_plus));
 	zoom_plus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_plus", TTR("Zoom In"), KEY_MASK_CMD | KEY_EQUAL)); // Usually direct access key for PLUS
 	zoom_plus->set_focus_mode(FOCUS_NONE);
 
@@ -5521,7 +5501,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	select_button = memnew(ToolButton);
 	hb->add_child(select_button);
 	select_button->set_toggle_mode(true);
-	select_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_SELECT));
+	select_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_SELECT));
 	select_button->set_pressed(true);
 	select_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/select_mode", TTR("Select Mode"), KEY_Q));
 	select_button->set_tooltip(keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate") + "\n" + TTR("Alt+Drag: Move") + "\n" + TTR("Press 'v' to Change Pivot, 'Shift+v' to Drag Pivot (while moving).") + "\n" + TTR("Alt+RMB: Depth list selection"));
@@ -5531,21 +5511,21 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	move_button = memnew(ToolButton);
 	hb->add_child(move_button);
 	move_button->set_toggle_mode(true);
-	move_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_MOVE));
+	move_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_MOVE));
 	move_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/move_mode", TTR("Move Mode"), KEY_W));
 	move_button->set_tooltip(TTR("Move Mode"));
 
 	rotate_button = memnew(ToolButton);
 	hb->add_child(rotate_button);
 	rotate_button->set_toggle_mode(true);
-	rotate_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_ROTATE));
+	rotate_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_ROTATE));
 	rotate_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/rotate_mode", TTR("Rotate Mode"), KEY_E));
 	rotate_button->set_tooltip(TTR("Rotate Mode"));
 
 	scale_button = memnew(ToolButton);
 	hb->add_child(scale_button);
 	scale_button->set_toggle_mode(true);
-	scale_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_SCALE));
+	scale_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_SCALE));
 	scale_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/scale_mode", TTR("Scale Mode"), KEY_S));
 	scale_button->set_tooltip(TTR("Scale Mode"));
 
@@ -5554,25 +5534,25 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	list_select_button = memnew(ToolButton);
 	hb->add_child(list_select_button);
 	list_select_button->set_toggle_mode(true);
-	list_select_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_LIST_SELECT));
+	list_select_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_LIST_SELECT));
 	list_select_button->set_tooltip(TTR("Show a list of all objects at the position clicked\n(same as Alt+RMB in select mode)."));
 
 	pivot_button = memnew(ToolButton);
 	hb->add_child(pivot_button);
 	pivot_button->set_toggle_mode(true);
-	pivot_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_EDIT_PIVOT));
+	pivot_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_EDIT_PIVOT));
 	pivot_button->set_tooltip(TTR("Click to change object's rotation pivot."));
 
 	pan_button = memnew(ToolButton);
 	hb->add_child(pan_button);
 	pan_button->set_toggle_mode(true);
-	pan_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_PAN));
+	pan_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_PAN));
 	pan_button->set_tooltip(TTR("Pan Mode"));
 
 	ruler_button = memnew(ToolButton);
 	hb->add_child(ruler_button);
 	ruler_button->set_toggle_mode(true);
-	ruler_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_RULER));
+	ruler_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_RULER));
 	ruler_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/ruler_mode", TTR("Ruler Mode"), KEY_R));
 	ruler_button->set_tooltip(TTR("Ruler Mode"));
 
@@ -5581,14 +5561,14 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	smart_snap_button = memnew(ToolButton);
 	hb->add_child(smart_snap_button);
 	smart_snap_button->set_toggle_mode(true);
-	smart_snap_button->connect_compat("toggled", this, "_button_toggle_smart_snap");
+	smart_snap_button->connect("toggled", callable_mp(this, &CanvasItemEditor::_button_toggle_smart_snap));
 	smart_snap_button->set_tooltip(TTR("Toggle smart snapping."));
 	smart_snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_smart_snap", TTR("Use Smart Snap"), KEY_MASK_SHIFT | KEY_S));
 
 	grid_snap_button = memnew(ToolButton);
 	hb->add_child(grid_snap_button);
 	grid_snap_button->set_toggle_mode(true);
-	grid_snap_button->connect_compat("toggled", this, "_button_toggle_grid_snap");
+	grid_snap_button->connect("toggled", callable_mp(this, &CanvasItemEditor::_button_toggle_grid_snap));
 	grid_snap_button->set_tooltip(TTR("Toggle grid snapping."));
 	grid_snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_grid_snap", TTR("Use Grid Snap"), KEY_MASK_SHIFT | KEY_G));
 
@@ -5599,7 +5579,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	snap_config_menu->set_switch_on_hover(true);
 
 	PopupMenu *p = snap_config_menu->get_popup();
-	p->connect_compat("id_pressed", this, "_popup_callback");
+	p->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_popup_callback));
 	p->set_hide_on_checkable_item_selection(false);
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/use_rotation_snap", TTR("Use Rotation Snap")), SNAP_USE_ROTATION);
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/use_scale_snap", TTR("Use Scale Snap")), SNAP_USE_SCALE);
@@ -5613,7 +5593,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	smartsnap_config_popup = memnew(PopupMenu);
 	p->add_child(smartsnap_config_popup);
 	smartsnap_config_popup->set_name("SmartSnapping");
-	smartsnap_config_popup->connect_compat("id_pressed", this, "_popup_callback");
+	smartsnap_config_popup->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_popup_callback));
 	smartsnap_config_popup->set_hide_on_checkable_item_selection(false);
 	smartsnap_config_popup->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/snap_node_parent", TTR("Snap to Parent")), SNAP_USE_NODE_PARENT);
 	smartsnap_config_popup->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/snap_node_anchors", TTR("Snap to Node Anchor")), SNAP_USE_NODE_ANCHORS);
@@ -5627,22 +5607,22 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	lock_button = memnew(ToolButton);
 	hb->add_child(lock_button);
 
-	lock_button->connect_compat("pressed", this, "_popup_callback", varray(LOCK_SELECTED));
+	lock_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(LOCK_SELECTED));
 	lock_button->set_tooltip(TTR("Lock the selected object in place (can't be moved)."));
 
 	unlock_button = memnew(ToolButton);
 	hb->add_child(unlock_button);
-	unlock_button->connect_compat("pressed", this, "_popup_callback", varray(UNLOCK_SELECTED));
+	unlock_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(UNLOCK_SELECTED));
 	unlock_button->set_tooltip(TTR("Unlock the selected object (can be moved)."));
 
 	group_button = memnew(ToolButton);
 	hb->add_child(group_button);
-	group_button->connect_compat("pressed", this, "_popup_callback", varray(GROUP_SELECTED));
+	group_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(GROUP_SELECTED));
 	group_button->set_tooltip(TTR("Makes sure the object's children are not selectable."));
 
 	ungroup_button = memnew(ToolButton);
 	hb->add_child(ungroup_button);
-	ungroup_button->connect_compat("pressed", this, "_popup_callback", varray(UNGROUP_SELECTED));
+	ungroup_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(UNGROUP_SELECTED));
 	ungroup_button->set_tooltip(TTR("Restores the object's children's ability to be selected."));
 
 	hb->add_child(memnew(VSeparator));
@@ -5661,13 +5641,13 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/skeleton_make_bones", TTR("Make Custom Bone(s) from Node(s)"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_B), SKELETON_MAKE_BONES);
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/skeleton_clear_bones", TTR("Clear Custom Bones")), SKELETON_CLEAR_BONES);
-	p->connect_compat("id_pressed", this, "_popup_callback");
+	p->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_popup_callback));
 
 	hb->add_child(memnew(VSeparator));
 
 	override_camera_button = memnew(ToolButton);
 	hb->add_child(override_camera_button);
-	override_camera_button->connect_compat("toggled", this, "_button_override_camera");
+	override_camera_button->connect("toggled", callable_mp(this, &CanvasItemEditor::_button_override_camera));
 	override_camera_button->set_toggle_mode(true);
 	override_camera_button->set_disabled(true);
 	_update_override_camera_button(false);
@@ -5677,7 +5657,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	view_menu = memnew(MenuButton);
 	view_menu->set_text(TTR("View"));
 	hb->add_child(view_menu);
-	view_menu->get_popup()->connect_compat("id_pressed", this, "_popup_callback");
+	view_menu->get_popup()->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_popup_callback));
 	view_menu->set_switch_on_hover(true);
 
 	p = view_menu->get_popup();
@@ -5705,18 +5685,18 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	presets_menu->set_switch_on_hover(true);
 
 	p = presets_menu->get_popup();
-	p->connect_compat("id_pressed", this, "_popup_callback");
+	p->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_popup_callback));
 
 	anchors_popup = memnew(PopupMenu);
 	p->add_child(anchors_popup);
 	anchors_popup->set_name("Anchors");
-	anchors_popup->connect_compat("id_pressed", this, "_popup_callback");
+	anchors_popup->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_popup_callback));
 
 	anchor_mode_button = memnew(ToolButton);
 	hb->add_child(anchor_mode_button);
 	anchor_mode_button->set_toggle_mode(true);
 	anchor_mode_button->hide();
-	anchor_mode_button->connect_compat("toggled", this, "_button_toggle_anchor_mode");
+	anchor_mode_button->connect("toggled", callable_mp(this, &CanvasItemEditor::_button_toggle_anchor_mode));
 
 	animation_hb = memnew(HBoxContainer);
 	hb->add_child(animation_hb);
@@ -5728,7 +5708,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	key_loc_button->set_flat(true);
 	key_loc_button->set_pressed(true);
 	key_loc_button->set_focus_mode(FOCUS_NONE);
-	key_loc_button->connect_compat("pressed", this, "_popup_callback", varray(ANIM_INSERT_POS));
+	key_loc_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_POS));
 	key_loc_button->set_tooltip(TTR("Translation mask for inserting keys."));
 	animation_hb->add_child(key_loc_button);
 	key_rot_button = memnew(Button);
@@ -5736,20 +5716,20 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	key_rot_button->set_flat(true);
 	key_rot_button->set_pressed(true);
 	key_rot_button->set_focus_mode(FOCUS_NONE);
-	key_rot_button->connect_compat("pressed", this, "_popup_callback", varray(ANIM_INSERT_ROT));
+	key_rot_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_ROT));
 	key_rot_button->set_tooltip(TTR("Rotation mask for inserting keys."));
 	animation_hb->add_child(key_rot_button);
 	key_scale_button = memnew(Button);
 	key_scale_button->set_toggle_mode(true);
 	key_scale_button->set_flat(true);
 	key_scale_button->set_focus_mode(FOCUS_NONE);
-	key_scale_button->connect_compat("pressed", this, "_popup_callback", varray(ANIM_INSERT_SCALE));
+	key_scale_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_SCALE));
 	key_scale_button->set_tooltip(TTR("Scale mask for inserting keys."));
 	animation_hb->add_child(key_scale_button);
 	key_insert_button = memnew(Button);
 	key_insert_button->set_flat(true);
 	key_insert_button->set_focus_mode(FOCUS_NONE);
-	key_insert_button->connect_compat("pressed", this, "_popup_callback", varray(ANIM_INSERT_KEY));
+	key_insert_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_KEY));
 	key_insert_button->set_tooltip(TTR("Insert keys (based on mask)."));
 	key_insert_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/anim_insert_key", TTR("Insert Key"), KEY_INSERT));
 	animation_hb->add_child(key_insert_button);
@@ -5765,7 +5745,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	animation_menu = memnew(MenuButton);
 	animation_menu->set_tooltip(TTR("Animation Key and Pose Options"));
 	animation_hb->add_child(animation_menu);
-	animation_menu->get_popup()->connect_compat("id_pressed", this, "_popup_callback");
+	animation_menu->get_popup()->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_popup_callback));
 	animation_menu->set_switch_on_hover(true);
 
 	p = animation_menu->get_popup();
@@ -5778,7 +5758,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/anim_clear_pose", TTR("Clear Pose"), KEY_MASK_SHIFT | KEY_K), ANIM_CLEAR_POSE);
 
 	snap_dialog = memnew(SnapDialog);
-	snap_dialog->connect_compat("confirmed", this, "_snap_changed");
+	snap_dialog->connect("confirmed", callable_mp(this, &CanvasItemEditor::_snap_changed));
 	add_child(snap_dialog);
 
 	select_sb = Ref<StyleBoxTexture>(memnew(StyleBoxTexture));
@@ -5786,8 +5766,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	selection_menu = memnew(PopupMenu);
 	add_child(selection_menu);
 	selection_menu->set_custom_minimum_size(Vector2(100, 0));
-	selection_menu->connect_compat("id_pressed", this, "_selection_result_pressed");
-	selection_menu->connect_compat("popup_hide", this, "_selection_menu_hide");
+	selection_menu->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_selection_result_pressed));
+	selection_menu->connect("popup_hide", callable_mp(this, &CanvasItemEditor::_selection_menu_hide));
 
 	multiply_grid_step_shortcut = ED_SHORTCUT("canvas_item_editor/multiply_grid_step", TTR("Multiply grid step by 2"), KEY_KP_MULTIPLY);
 	divide_grid_step_shortcut = ED_SHORTCUT("canvas_item_editor/divide_grid_step", TTR("Divide grid step by 2"), KEY_KP_DIVIDE);
@@ -6234,11 +6214,11 @@ void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p
 void CanvasItemEditorViewport::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("mouse_exited", this, "_on_mouse_exit");
+			connect("mouse_exited", callable_mp(this, &CanvasItemEditorViewport::_on_mouse_exit));
 			label->add_color_override("font_color", get_color("warning_color", "Editor"));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("mouse_exited", this, "_on_mouse_exit");
+			disconnect("mouse_exited", callable_mp(this, &CanvasItemEditorViewport::_on_mouse_exit));
 		} break;
 
 		default: break;
@@ -6246,10 +6226,6 @@ void CanvasItemEditorViewport::_notification(int p_what) {
 }
 
 void CanvasItemEditorViewport::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_on_select_type"), &CanvasItemEditorViewport::_on_select_type);
-	ClassDB::bind_method(D_METHOD("_on_change_type_confirmed"), &CanvasItemEditorViewport::_on_change_type_confirmed);
-	ClassDB::bind_method(D_METHOD("_on_change_type_closed"), &CanvasItemEditorViewport::_on_change_type_closed);
-	ClassDB::bind_method(D_METHOD("_on_mouse_exit"), &CanvasItemEditorViewport::_on_mouse_exit);
 }
 
 CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasItemEditor *p_canvas_item_editor) {
@@ -6276,8 +6252,8 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 	selector = memnew(AcceptDialog);
 	editor->get_gui_base()->add_child(selector);
 	selector->set_title(TTR("Change Default Type"));
-	selector->connect_compat("confirmed", this, "_on_change_type_confirmed");
-	selector->connect_compat("popup_hide", this, "_on_change_type_closed");
+	selector->connect("confirmed", callable_mp(this, &CanvasItemEditorViewport::_on_change_type_confirmed));
+	selector->connect("popup_hide", callable_mp(this, &CanvasItemEditorViewport::_on_change_type_closed));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	selector->add_child(vbc);
@@ -6294,7 +6270,7 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 		CheckBox *check = memnew(CheckBox);
 		btn_group->add_child(check);
 		check->set_text(types[i]);
-		check->connect_compat("button_down", this, "_on_select_type", varray(check));
+		check->connect("button_down", callable_mp(this, &CanvasItemEditorViewport::_on_select_type), varray(check));
 		check->set_button_group(button_group);
 	}
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5390,7 +5390,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	editor = p_editor;
 	editor_selection = p_editor->get_editor_selection();
 	editor_selection->add_editor_plugin(this);
-	editor_selection->connect_compat("selection_changed", this, "update");
+	editor_selection->connect("selection_changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
 	editor_selection->connect("selection_changed", callable_mp(this, &CanvasItemEditor::_selection_changed));
 
 	editor->call_deferred("connect", make_binds("play_pressed", Callable(this, "_update_override_camera_button"), true));

--- a/editor/plugins/collision_polygon_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_editor_plugin.cpp
@@ -47,7 +47,7 @@ void Polygon3DEditor::_notification(int p_what) {
 			button_create->set_icon(get_icon("Edit", "EditorIcons"));
 			button_edit->set_icon(get_icon("MovePoint", "EditorIcons"));
 			button_edit->set_pressed(true);
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
+			get_tree()->connect("node_removed", callable_mp(this, &Polygon3DEditor::_node_removed));
 
 		} break;
 		case NOTIFICATION_PROCESS: {
@@ -518,9 +518,7 @@ void Polygon3DEditor::edit(Node *p_collision_polygon) {
 
 void Polygon3DEditor::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_menu_option"), &Polygon3DEditor::_menu_option);
 	ClassDB::bind_method(D_METHOD("_polygon_draw"), &Polygon3DEditor::_polygon_draw);
-	ClassDB::bind_method(D_METHOD("_node_removed"), &Polygon3DEditor::_node_removed);
 }
 
 Polygon3DEditor::Polygon3DEditor(EditorNode *p_editor) {
@@ -532,12 +530,12 @@ Polygon3DEditor::Polygon3DEditor(EditorNode *p_editor) {
 	add_child(memnew(VSeparator));
 	button_create = memnew(ToolButton);
 	add_child(button_create);
-	button_create->connect_compat("pressed", this, "_menu_option", varray(MODE_CREATE));
+	button_create->connect("pressed", callable_mp(this, &Polygon3DEditor::_menu_option), varray(MODE_CREATE));
 	button_create->set_toggle_mode(true);
 
 	button_edit = memnew(ToolButton);
 	add_child(button_edit);
-	button_edit->connect_compat("pressed", this, "_menu_option", varray(MODE_EDIT));
+	button_edit->connect("pressed", callable_mp(this, &Polygon3DEditor::_menu_option), varray(MODE_EDIT));
 	button_edit->set_toggle_mode(true);
 
 	mode = MODE_EDIT;

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -240,17 +240,13 @@ void CPUParticles2DEditorPlugin::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		menu->get_popup()->connect_compat("id_pressed", this, "_menu_callback");
+		menu->get_popup()->connect("id_pressed", callable_mp(this, &CPUParticles2DEditorPlugin::_menu_callback));
 		menu->set_icon(menu->get_popup()->get_icon("Particles2D", "EditorIcons"));
-		file->connect_compat("file_selected", this, "_file_selected");
+		file->connect("file_selected", callable_mp(this, &CPUParticles2DEditorPlugin::_file_selected));
 	}
 }
 
 void CPUParticles2DEditorPlugin::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_menu_callback"), &CPUParticles2DEditorPlugin::_menu_callback);
-	ClassDB::bind_method(D_METHOD("_file_selected"), &CPUParticles2DEditorPlugin::_file_selected);
-	ClassDB::bind_method(D_METHOD("_generate_emission_mask"), &CPUParticles2DEditorPlugin::_generate_emission_mask);
 }
 
 CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin(EditorNode *p_node) {
@@ -305,7 +301,7 @@ CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin(EditorNode *p_node) {
 
 	toolbar->add_child(emission_mask);
 
-	emission_mask->connect_compat("confirmed", this, "_generate_emission_mask");
+	emission_mask->connect("confirmed", callable_mp(this, &CPUParticles2DEditorPlugin::_generate_emission_mask));
 }
 
 CPUParticles2DEditorPlugin::~CPUParticles2DEditorPlugin() {

--- a/editor/plugins/cpu_particles_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_editor_plugin.cpp
@@ -92,8 +92,6 @@ void CPUParticlesEditor::_generate_emission_points() {
 }
 
 void CPUParticlesEditor::_bind_methods() {
-
-	ClassDB::bind_method("_menu_option", &CPUParticlesEditor::_menu_option);
 }
 
 CPUParticlesEditor::CPUParticlesEditor() {
@@ -109,7 +107,7 @@ CPUParticlesEditor::CPUParticlesEditor() {
 	options->get_popup()->add_item(TTR("Create Emission Points From Node"), MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_NODE);
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Restart"), MENU_OPTION_RESTART);
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", callable_mp(this, &CPUParticlesEditor::_menu_option));
 }
 
 void CPUParticlesEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -49,7 +49,7 @@ CurveEditor::CurveEditor() {
 	set_clip_contents(true);
 
 	_context_menu = memnew(PopupMenu);
-	_context_menu->connect_compat("id_pressed", this, "_on_context_menu_item_selected");
+	_context_menu->connect("id_pressed", callable_mp(this, &CurveEditor::on_context_menu_item_selected));
 	add_child(_context_menu);
 
 	_presets_menu = memnew(PopupMenu);
@@ -60,7 +60,7 @@ CurveEditor::CurveEditor() {
 	_presets_menu->add_item(TTR("Ease In"), PRESET_EASE_IN);
 	_presets_menu->add_item(TTR("Ease Out"), PRESET_EASE_OUT);
 	_presets_menu->add_item(TTR("Smoothstep"), PRESET_SMOOTHSTEP);
-	_presets_menu->connect_compat("id_pressed", this, "_on_preset_item_selected");
+	_presets_menu->connect("id_pressed", callable_mp(this, &CurveEditor::on_preset_item_selected));
 	_context_menu->add_child(_presets_menu);
 }
 
@@ -749,9 +749,7 @@ void CurveEditor::_draw() {
 
 void CurveEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_gui_input"), &CurveEditor::on_gui_input);
-	ClassDB::bind_method(D_METHOD("_on_preset_item_selected"), &CurveEditor::on_preset_item_selected);
 	ClassDB::bind_method(D_METHOD("_curve_changed"), &CurveEditor::_curve_changed);
-	ClassDB::bind_method(D_METHOD("_on_context_menu_item_selected"), &CurveEditor::on_context_menu_item_selected);
 }
 
 //---------------

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -70,15 +70,15 @@ void CurveEditor::set_curve(Ref<Curve> curve) {
 		return;
 
 	if (_curve_ref.is_valid()) {
-		_curve_ref->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_curve_changed");
-		_curve_ref->disconnect_compat(Curve::SIGNAL_RANGE_CHANGED, this, "_curve_changed");
+		_curve_ref->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveEditor::_curve_changed));
+		_curve_ref->disconnect(Curve::SIGNAL_RANGE_CHANGED, callable_mp(this, &CurveEditor::_curve_changed));
 	}
 
 	_curve_ref = curve;
 
 	if (_curve_ref.is_valid()) {
-		_curve_ref->connect_compat(CoreStringNames::get_singleton()->changed, this, "_curve_changed");
-		_curve_ref->connect_compat(Curve::SIGNAL_RANGE_CHANGED, this, "_curve_changed");
+		_curve_ref->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveEditor::_curve_changed));
+		_curve_ref->connect(Curve::SIGNAL_RANGE_CHANGED, callable_mp(this, &CurveEditor::_curve_changed));
 	}
 
 	_selected_point = -1;
@@ -749,7 +749,6 @@ void CurveEditor::_draw() {
 
 void CurveEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_gui_input"), &CurveEditor::on_gui_input);
-	ClassDB::bind_method(D_METHOD("_curve_changed"), &CurveEditor::_curve_changed);
 }
 
 //---------------

--- a/editor/plugins/gi_probe_editor_plugin.cpp
+++ b/editor/plugins/gi_probe_editor_plugin.cpp
@@ -133,9 +133,6 @@ void GIProbeEditorPlugin::_giprobe_save_path_and_bake(const String &p_path) {
 }
 
 void GIProbeEditorPlugin::_bind_methods() {
-
-	ClassDB::bind_method("_bake", &GIProbeEditorPlugin::_bake);
-	ClassDB::bind_method("_giprobe_save_path_and_bake", &GIProbeEditorPlugin::_giprobe_save_path_and_bake);
 }
 
 GIProbeEditorPlugin::GIProbeEditorPlugin(EditorNode *p_node) {
@@ -147,7 +144,7 @@ GIProbeEditorPlugin::GIProbeEditorPlugin(EditorNode *p_node) {
 	bake = memnew(ToolButton);
 	bake->set_icon(editor->get_gui_base()->get_icon("Bake", "EditorIcons"));
 	bake->set_text(TTR("Bake GI Probe"));
-	bake->connect_compat("pressed", this, "_bake");
+	bake->connect("pressed", callable_mp(this, &GIProbeEditorPlugin::_bake));
 	bake_hb->add_child(bake);
 	bake_info = memnew(Label);
 	bake_info->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -159,7 +156,7 @@ GIProbeEditorPlugin::GIProbeEditorPlugin(EditorNode *p_node) {
 	probe_file = memnew(EditorFileDialog);
 	probe_file->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	probe_file->add_filter("*.res");
-	probe_file->connect_compat("file_selected", this, "_giprobe_save_path_and_bake");
+	probe_file->connect("file_selected", callable_mp(this, &GIProbeEditorPlugin::_giprobe_save_path_and_bake));
 	get_editor_interface()->get_base_control()->add_child(probe_file);
 	probe_file->set_title(TTR("Select path for GIProbe Data File"));
 

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -62,15 +62,12 @@ void GradientEditor::_ramp_changed() {
 }
 
 void GradientEditor::_bind_methods() {
-
-	ClassDB::bind_method("_gradient_changed", &GradientEditor::_gradient_changed);
-	ClassDB::bind_method("_ramp_changed", &GradientEditor::_ramp_changed);
 }
 
 void GradientEditor::set_gradient(const Ref<Gradient> &p_gradient) {
 	gradient = p_gradient;
-	connect_compat("ramp_changed", this, "_ramp_changed");
-	gradient->connect_compat("changed", this, "_gradient_changed");
+	connect("ramp_changed", callable_mp(this, &GradientEditor::_ramp_changed));
+	gradient->connect("changed", callable_mp(this, &GradientEditor::_gradient_changed));
 	set_points(gradient->get_points());
 }
 

--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -268,7 +268,7 @@ void ItemListEditor::_notification(int p_notification) {
 		del_button->set_icon(get_icon("Remove", "EditorIcons"));
 	} else if (p_notification == NOTIFICATION_READY) {
 
-		get_tree()->connect_compat("node_removed", this, "_node_removed");
+		get_tree()->connect("node_removed", callable_mp(this, &ItemListEditor::_node_removed));
 	}
 }
 
@@ -344,11 +344,6 @@ bool ItemListEditor::handles(Object *p_object) const {
 }
 
 void ItemListEditor::_bind_methods() {
-
-	ClassDB::bind_method("_node_removed", &ItemListEditor::_node_removed);
-	ClassDB::bind_method("_edit_items", &ItemListEditor::_edit_items);
-	ClassDB::bind_method("_add_button", &ItemListEditor::_add_pressed);
-	ClassDB::bind_method("_delete_button", &ItemListEditor::_delete_pressed);
 }
 
 ItemListEditor::ItemListEditor() {
@@ -359,7 +354,7 @@ ItemListEditor::ItemListEditor() {
 	toolbar_button = memnew(ToolButton);
 	toolbar_button->set_text(TTR("Items"));
 	add_child(toolbar_button);
-	toolbar_button->connect_compat("pressed", this, "_edit_items");
+	toolbar_button->connect("pressed", callable_mp(this, &ItemListEditor::_edit_items));
 
 	dialog = memnew(AcceptDialog);
 	dialog->set_title(TTR("Item List Editor"));
@@ -376,14 +371,14 @@ ItemListEditor::ItemListEditor() {
 	add_button = memnew(Button);
 	add_button->set_text(TTR("Add"));
 	hbc->add_child(add_button);
-	add_button->connect_compat("pressed", this, "_add_button");
+	add_button->connect("pressed", callable_mp(this, &ItemListEditor::_add_pressed));
 
 	hbc->add_spacer();
 
 	del_button = memnew(Button);
 	del_button->set_text(TTR("Delete"));
 	hbc->add_child(del_button);
-	del_button->connect_compat("pressed", this, "_delete_button");
+	del_button->connect("pressed", callable_mp(this, &ItemListEditor::_delete_pressed));
 
 	property_editor = memnew(EditorInspector);
 	vbc->add_child(property_editor);

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -105,8 +105,6 @@ void MaterialEditor::_button_pressed(Node *p_button) {
 }
 
 void MaterialEditor::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_button_pressed"), &MaterialEditor::_button_pressed);
 }
 
 MaterialEditor::MaterialEditor() {
@@ -171,13 +169,13 @@ MaterialEditor::MaterialEditor() {
 	sphere_switch->set_toggle_mode(true);
 	sphere_switch->set_pressed(true);
 	vb_shape->add_child(sphere_switch);
-	sphere_switch->connect_compat("pressed", this, "_button_pressed", varray(sphere_switch));
+	sphere_switch->connect("pressed", callable_mp(this, &MaterialEditor::_button_pressed), varray(sphere_switch));
 
 	box_switch = memnew(TextureButton);
 	box_switch->set_toggle_mode(true);
 	box_switch->set_pressed(false);
 	vb_shape->add_child(box_switch);
-	box_switch->connect_compat("pressed", this, "_button_pressed", varray(box_switch));
+	box_switch->connect("pressed", callable_mp(this, &MaterialEditor::_button_pressed), varray(box_switch));
 
 	hb->add_spacer();
 
@@ -187,12 +185,12 @@ MaterialEditor::MaterialEditor() {
 	light_1_switch = memnew(TextureButton);
 	light_1_switch->set_toggle_mode(true);
 	vb_light->add_child(light_1_switch);
-	light_1_switch->connect_compat("pressed", this, "_button_pressed", varray(light_1_switch));
+	light_1_switch->connect("pressed", callable_mp(this, &MaterialEditor::_button_pressed), varray(light_1_switch));
 
 	light_2_switch = memnew(TextureButton);
 	light_2_switch->set_toggle_mode(true);
 	vb_light->add_child(light_2_switch);
-	light_2_switch->connect_compat("pressed", this, "_button_pressed", varray(light_2_switch));
+	light_2_switch->connect("pressed", callable_mp(this, &MaterialEditor::_button_pressed), varray(light_2_switch));
 
 	first_enter = true;
 }

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -111,7 +111,6 @@ void MeshEditor::_button_pressed(Node *p_button) {
 void MeshEditor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &MeshEditor::_gui_input);
-	ClassDB::bind_method(D_METHOD("_button_pressed"), &MeshEditor::_button_pressed);
 }
 
 MeshEditor::MeshEditor() {
@@ -157,12 +156,12 @@ MeshEditor::MeshEditor() {
 	light_1_switch = memnew(TextureButton);
 	light_1_switch->set_toggle_mode(true);
 	vb_light->add_child(light_1_switch);
-	light_1_switch->connect_compat("pressed", this, "_button_pressed", varray(light_1_switch));
+	light_1_switch->connect("pressed", callable_mp(this, &MeshEditor::_button_pressed), varray(light_1_switch));
 
 	light_2_switch = memnew(TextureButton);
 	light_2_switch->set_toggle_mode(true);
 	vb_light->add_child(light_2_switch);
-	light_2_switch->connect_compat("pressed", this, "_button_pressed", varray(light_2_switch));
+	light_2_switch->connect("pressed", callable_mp(this, &MeshEditor::_button_pressed), varray(light_2_switch));
 
 	first_enter = true;
 

--- a/editor/plugins/mesh_instance_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_editor_plugin.cpp
@@ -435,10 +435,6 @@ void MeshInstanceEditor::_create_outline_mesh() {
 }
 
 void MeshInstanceEditor::_bind_methods() {
-
-	ClassDB::bind_method("_menu_option", &MeshInstanceEditor::_menu_option);
-	ClassDB::bind_method("_create_outline_mesh", &MeshInstanceEditor::_create_outline_mesh);
-	ClassDB::bind_method("_debug_uv_draw", &MeshInstanceEditor::_debug_uv_draw);
 }
 
 MeshInstanceEditor::MeshInstanceEditor() {
@@ -469,7 +465,7 @@ MeshInstanceEditor::MeshInstanceEditor() {
 	options->get_popup()->add_item(TTR("View UV2"), MENU_OPTION_DEBUG_UV2);
 	options->get_popup()->add_item(TTR("Unwrap UV2 for Lightmap/AO"), MENU_OPTION_CREATE_UV2);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", callable_mp(this, &MeshInstanceEditor::_menu_option));
 
 	outline_dialog = memnew(ConfirmationDialog);
 	outline_dialog->set_title(TTR("Create Outline Mesh"));
@@ -487,7 +483,7 @@ MeshInstanceEditor::MeshInstanceEditor() {
 	outline_dialog_vbc->add_margin_child(TTR("Outline Size:"), outline_size);
 
 	add_child(outline_dialog);
-	outline_dialog->connect_compat("confirmed", this, "_create_outline_mesh");
+	outline_dialog->connect("confirmed", callable_mp(this, &MeshInstanceEditor::_create_outline_mesh));
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
@@ -497,7 +493,7 @@ MeshInstanceEditor::MeshInstanceEditor() {
 	add_child(debug_uv_dialog);
 	debug_uv = memnew(Control);
 	debug_uv->set_custom_minimum_size(Size2(600, 600) * EDSCALE);
-	debug_uv->connect_compat("draw", this, "_debug_uv_draw");
+	debug_uv->connect("draw", callable_mp(this, &MeshInstanceEditor::_debug_uv_draw));
 	debug_uv_dialog->add_child(debug_uv);
 }
 

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -248,10 +248,6 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 }
 
 void MeshLibraryEditor::_bind_methods() {
-
-	ClassDB::bind_method("_menu_cbk", &MeshLibraryEditor::_menu_cbk);
-	ClassDB::bind_method("_menu_confirm", &MeshLibraryEditor::_menu_confirm);
-	ClassDB::bind_method("_import_scene_cbk", &MeshLibraryEditor::_import_scene_cbk);
 }
 
 MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
@@ -268,7 +264,7 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 		file->add_filter("*." + extensions[i] + " ; " + extensions[i].to_upper());
 	}
 	add_child(file);
-	file->connect_compat("file_selected", this, "_import_scene_cbk");
+	file->connect("file_selected", callable_mp(this, &MeshLibraryEditor::_import_scene_cbk));
 
 	menu = memnew(MenuButton);
 	SpatialEditor::get_singleton()->add_control_to_menu_panel(menu);
@@ -281,13 +277,13 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 	menu->get_popup()->add_item(TTR("Import from Scene"), MENU_OPTION_IMPORT_FROM_SCENE);
 	menu->get_popup()->add_item(TTR("Update from Scene"), MENU_OPTION_UPDATE_FROM_SCENE);
 	menu->get_popup()->set_item_disabled(menu->get_popup()->get_item_index(MENU_OPTION_UPDATE_FROM_SCENE), true);
-	menu->get_popup()->connect_compat("id_pressed", this, "_menu_cbk");
+	menu->get_popup()->connect("id_pressed", callable_mp(this, &MeshLibraryEditor::_menu_cbk));
 	menu->hide();
 
 	editor = p_editor;
 	cd = memnew(ConfirmationDialog);
 	add_child(cd);
-	cd->get_ok()->connect_compat("pressed", this, "_menu_confirm");
+	cd->get_ok()->connect("pressed", callable_mp(this, &MeshLibraryEditor::_menu_confirm));
 }
 
 void MeshLibraryEditorPlugin::edit(Object *p_node) {

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -278,11 +278,6 @@ void MultiMeshEditor::_browse(bool p_source) {
 }
 
 void MultiMeshEditor::_bind_methods() {
-
-	ClassDB::bind_method("_menu_option", &MultiMeshEditor::_menu_option);
-	ClassDB::bind_method("_populate", &MultiMeshEditor::_populate);
-	ClassDB::bind_method("_browsed", &MultiMeshEditor::_browsed);
-	ClassDB::bind_method("_browse", &MultiMeshEditor::_browse);
 }
 
 MultiMeshEditor::MultiMeshEditor() {
@@ -295,7 +290,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("MultiMeshInstance", "EditorIcons"));
 
 	options->get_popup()->add_item(TTR("Populate Surface"));
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", callable_mp(this, &MultiMeshEditor::_menu_option));
 
 	populate_dialog = memnew(ConfirmationDialog);
 	populate_dialog->set_title(TTR("Populate MultiMesh"));
@@ -313,7 +308,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	Button *b = memnew(Button);
 	hbc->add_child(b);
 	b->set_text("..");
-	b->connect_compat("pressed", this, "_browse", make_binds(false));
+	b->connect("pressed", callable_mp(this, &MultiMeshEditor::_browse), make_binds(false));
 
 	vbc->add_margin_child(TTR("Target Surface:"), hbc);
 
@@ -325,7 +320,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	hbc->add_child(b);
 	b->set_text("..");
 	vbc->add_margin_child(TTR("Source Mesh:"), hbc);
-	b->connect_compat("pressed", this, "_browse", make_binds(true));
+	b->connect("pressed", callable_mp(this, &MultiMeshEditor::_browse), make_binds(true));
 
 	populate_axis = memnew(OptionButton);
 	populate_axis->add_item(TTR("X-Axis"));
@@ -371,10 +366,10 @@ MultiMeshEditor::MultiMeshEditor() {
 
 	populate_dialog->get_ok()->set_text(TTR("Populate"));
 
-	populate_dialog->get_ok()->connect_compat("pressed", this, "_populate");
+	populate_dialog->get_ok()->connect("pressed", callable_mp(this, &MultiMeshEditor::_populate));
 	std = memnew(SceneTreeDialog);
 	populate_dialog->add_child(std);
-	std->connect_compat("selected", this, "_browsed");
+	std->connect("selected", callable_mp(this, &MultiMeshEditor::_browsed));
 
 	_last_pp_node = NULL;
 

--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -349,18 +349,13 @@ void Particles2DEditorPlugin::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		menu->get_popup()->connect_compat("id_pressed", this, "_menu_callback");
+		menu->get_popup()->connect("id_pressed", callable_mp(this, &Particles2DEditorPlugin::_menu_callback));
 		menu->set_icon(menu->get_popup()->get_icon("Particles2D", "EditorIcons"));
-		file->connect_compat("file_selected", this, "_file_selected");
+		file->connect("file_selected", callable_mp(this, &Particles2DEditorPlugin::_file_selected));
 	}
 }
 
 void Particles2DEditorPlugin::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_menu_callback"), &Particles2DEditorPlugin::_menu_callback);
-	ClassDB::bind_method(D_METHOD("_file_selected"), &Particles2DEditorPlugin::_file_selected);
-	ClassDB::bind_method(D_METHOD("_generate_visibility_rect"), &Particles2DEditorPlugin::_generate_visibility_rect);
-	ClassDB::bind_method(D_METHOD("_generate_emission_mask"), &Particles2DEditorPlugin::_generate_emission_mask);
 }
 
 Particles2DEditorPlugin::Particles2DEditorPlugin(EditorNode *p_node) {
@@ -416,7 +411,7 @@ Particles2DEditorPlugin::Particles2DEditorPlugin(EditorNode *p_node) {
 
 	toolbar->add_child(generate_visibility_rect);
 
-	generate_visibility_rect->connect_compat("confirmed", this, "_generate_visibility_rect");
+	generate_visibility_rect->connect("confirmed", callable_mp(this, &Particles2DEditorPlugin::_generate_visibility_rect));
 
 	emission_mask = memnew(ConfirmationDialog);
 	emission_mask->set_title(TTR("Load Emission Mask"));
@@ -433,7 +428,7 @@ Particles2DEditorPlugin::Particles2DEditorPlugin(EditorNode *p_node) {
 
 	toolbar->add_child(emission_mask);
 
-	emission_mask->connect_compat("confirmed", this, "_generate_emission_mask");
+	emission_mask->connect("confirmed", callable_mp(this, &Particles2DEditorPlugin::_generate_emission_mask));
 }
 
 Particles2DEditorPlugin::~Particles2DEditorPlugin() {

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -203,9 +203,6 @@ void ParticlesEditorBase::_node_selected(const NodePath &p_path) {
 }
 
 void ParticlesEditorBase::_bind_methods() {
-
-	ClassDB::bind_method("_node_selected", &ParticlesEditorBase::_node_selected);
-	ClassDB::bind_method("_generate_emission_points", &ParticlesEditorBase::_generate_emission_points);
 }
 
 ParticlesEditorBase::ParticlesEditorBase() {
@@ -229,11 +226,11 @@ ParticlesEditorBase::ParticlesEditorBase() {
 	emd_vb->add_margin_child(TTR("Emission Source: "), emission_fill);
 
 	emission_dialog->get_ok()->set_text(TTR("Create"));
-	emission_dialog->connect_compat("confirmed", this, "_generate_emission_points");
+	emission_dialog->connect("confirmed", callable_mp(this, &ParticlesEditorBase::_generate_emission_points));
 
 	emission_tree_dialog = memnew(SceneTreeDialog);
 	add_child(emission_tree_dialog);
-	emission_tree_dialog->connect_compat("selected", this, "_node_selected");
+	emission_tree_dialog->connect("selected", callable_mp(this, &ParticlesEditorBase::_node_selected));
 }
 
 void ParticlesEditor::_node_removed(Node *p_node) {
@@ -248,7 +245,7 @@ void ParticlesEditor::_notification(int p_notification) {
 
 	if (p_notification == NOTIFICATION_ENTER_TREE) {
 		options->set_icon(options->get_popup()->get_icon("Particles", "EditorIcons"));
-		get_tree()->connect_compat("node_removed", this, "_node_removed");
+		get_tree()->connect("node_removed", callable_mp(this, &ParticlesEditor::_node_removed));
 	}
 }
 
@@ -423,10 +420,6 @@ void ParticlesEditor::_generate_emission_points() {
 }
 
 void ParticlesEditor::_bind_methods() {
-
-	ClassDB::bind_method("_menu_option", &ParticlesEditor::_menu_option);
-	ClassDB::bind_method("_generate_aabb", &ParticlesEditor::_generate_aabb);
-	ClassDB::bind_method("_node_removed", &ParticlesEditor::_node_removed);
 }
 
 ParticlesEditor::ParticlesEditor() {
@@ -448,7 +441,7 @@ ParticlesEditor::ParticlesEditor() {
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Restart"), MENU_OPTION_RESTART);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", callable_mp(this, &ParticlesEditor::_menu_option));
 
 	generate_aabb = memnew(ConfirmationDialog);
 	generate_aabb->set_title(TTR("Generate Visibility AABB"));
@@ -462,7 +455,7 @@ ParticlesEditor::ParticlesEditor() {
 
 	add_child(generate_aabb);
 
-	generate_aabb->connect_compat("confirmed", this, "_generate_aabb");
+	generate_aabb->connect("confirmed", callable_mp(this, &ParticlesEditor::_generate_aabb));
 }
 
 void ParticlesEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -441,14 +441,14 @@ void Path2DEditor::edit(Node *p_path2d) {
 	if (p_path2d) {
 
 		node = Object::cast_to<Path2D>(p_path2d);
-		if (!node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-			node->connect_compat("visibility_changed", this, "_node_visibility_changed");
+		if (!node->is_connected("visibility_changed", callable_mp(this, &Path2DEditor::_node_visibility_changed)))
+			node->connect("visibility_changed", callable_mp(this, &Path2DEditor::_node_visibility_changed));
 
 	} else {
 
 		// node may have been deleted at this point
-		if (node && node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-			node->disconnect_compat("visibility_changed", this, "_node_visibility_changed");
+		if (node && node->is_connected("visibility_changed", callable_mp(this, &Path2DEditor::_node_visibility_changed)))
+			node->disconnect("visibility_changed", callable_mp(this, &Path2DEditor::_node_visibility_changed));
 		node = NULL;
 	}
 }
@@ -456,9 +456,6 @@ void Path2DEditor::edit(Node *p_path2d) {
 void Path2DEditor::_bind_methods() {
 
 	//ClassDB::bind_method(D_METHOD("_menu_option"),&Path2DEditor::_menu_option);
-	ClassDB::bind_method(D_METHOD("_node_visibility_changed"), &Path2DEditor::_node_visibility_changed);
-	ClassDB::bind_method(D_METHOD("_mode_selected"), &Path2DEditor::_mode_selected);
-	ClassDB::bind_method(D_METHOD("_handle_option_pressed"), &Path2DEditor::_handle_option_pressed);
 }
 
 void Path2DEditor::_mode_selected(int p_mode) {
@@ -555,34 +552,34 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	curve_edit->set_toggle_mode(true);
 	curve_edit->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit->set_tooltip(TTR("Select Points") + "\n" + TTR("Shift+Drag: Select Control Points") + "\n" + keycode_get_string(KEY_MASK_CMD) + TTR("Click: Add Point") + "\n" + TTR("Left Click: Split Segment (in curve)") + "\n" + TTR("Right Click: Delete Point"));
-	curve_edit->connect_compat("pressed", this, "_mode_selected", varray(MODE_EDIT));
+	curve_edit->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_EDIT));
 	base_hb->add_child(curve_edit);
 	curve_edit_curve = memnew(ToolButton);
 	curve_edit_curve->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveCurve", "EditorIcons"));
 	curve_edit_curve->set_toggle_mode(true);
 	curve_edit_curve->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit_curve->set_tooltip(TTR("Select Control Points (Shift+Drag)"));
-	curve_edit_curve->connect_compat("pressed", this, "_mode_selected", varray(MODE_EDIT_CURVE));
+	curve_edit_curve->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_EDIT_CURVE));
 	base_hb->add_child(curve_edit_curve);
 	curve_create = memnew(ToolButton);
 	curve_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveCreate", "EditorIcons"));
 	curve_create->set_toggle_mode(true);
 	curve_create->set_focus_mode(Control::FOCUS_NONE);
 	curve_create->set_tooltip(TTR("Add Point (in empty space)"));
-	curve_create->connect_compat("pressed", this, "_mode_selected", varray(MODE_CREATE));
+	curve_create->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_CREATE));
 	base_hb->add_child(curve_create);
 	curve_del = memnew(ToolButton);
 	curve_del->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveDelete", "EditorIcons"));
 	curve_del->set_toggle_mode(true);
 	curve_del->set_focus_mode(Control::FOCUS_NONE);
 	curve_del->set_tooltip(TTR("Delete Point"));
-	curve_del->connect_compat("pressed", this, "_mode_selected", varray(MODE_DELETE));
+	curve_del->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_DELETE));
 	base_hb->add_child(curve_del);
 	curve_close = memnew(ToolButton);
 	curve_close->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveClose", "EditorIcons"));
 	curve_close->set_focus_mode(Control::FOCUS_NONE);
 	curve_close->set_tooltip(TTR("Close Curve"));
-	curve_close->connect_compat("pressed", this, "_mode_selected", varray(ACTION_CLOSE));
+	curve_close->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(ACTION_CLOSE));
 	base_hb->add_child(curve_close);
 
 	PopupMenu *menu;
@@ -596,7 +593,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	menu->set_item_checked(HANDLE_OPTION_ANGLE, mirror_handle_angle);
 	menu->add_check_item(TTR("Mirror Handle Lengths"));
 	menu->set_item_checked(HANDLE_OPTION_LENGTH, mirror_handle_length);
-	menu->connect_compat("id_pressed", this, "_handle_option_pressed");
+	menu->connect("id_pressed", callable_mp(this, &Path2DEditor::_handle_option_pressed));
 
 	base_hb->hide();
 

--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -543,18 +543,14 @@ void PathEditorPlugin::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		curve_create->connect_compat("pressed", this, "_mode_changed", make_binds(0));
-		curve_edit->connect_compat("pressed", this, "_mode_changed", make_binds(1));
-		curve_del->connect_compat("pressed", this, "_mode_changed", make_binds(2));
-		curve_close->connect_compat("pressed", this, "_close_curve");
+		curve_create->connect("pressed", callable_mp(this, &PathEditorPlugin::_mode_changed), make_binds(0));
+		curve_edit->connect("pressed", callable_mp(this, &PathEditorPlugin::_mode_changed), make_binds(1));
+		curve_del->connect("pressed", callable_mp(this, &PathEditorPlugin::_mode_changed), make_binds(2));
+		curve_close->connect("pressed", callable_mp(this, &PathEditorPlugin::_close_curve));
 	}
 }
 
 void PathEditorPlugin::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_mode_changed"), &PathEditorPlugin::_mode_changed);
-	ClassDB::bind_method(D_METHOD("_close_curve"), &PathEditorPlugin::_close_curve);
-	ClassDB::bind_method(D_METHOD("_handle_option_pressed"), &PathEditorPlugin::_handle_option_pressed);
 }
 
 PathEditorPlugin *PathEditorPlugin::singleton = NULL;
@@ -614,7 +610,7 @@ PathEditorPlugin::PathEditorPlugin(EditorNode *p_node) {
 	menu->set_item_checked(HANDLE_OPTION_ANGLE, mirror_handle_angle);
 	menu->add_check_item(TTR("Mirror Handle Lengths"));
 	menu->set_item_checked(HANDLE_OPTION_LENGTH, mirror_handle_length);
-	menu->connect_compat("id_pressed", this, "_handle_option_pressed");
+	menu->connect("id_pressed", callable_mp(this, &PathEditorPlugin::_handle_option_pressed));
 
 	curve_edit->set_pressed(true);
 	/*

--- a/editor/plugins/physical_bone_plugin.cpp
+++ b/editor/plugins/physical_bone_plugin.cpp
@@ -33,7 +33,6 @@
 #include "scene/3d/physics_body.h"
 
 void PhysicalBoneEditor::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_on_toggle_button_transform_joint", "is_pressed"), &PhysicalBoneEditor::_on_toggle_button_transform_joint);
 }
 
 void PhysicalBoneEditor::_on_toggle_button_transform_joint(bool p_is_pressed) {
@@ -64,7 +63,7 @@ PhysicalBoneEditor::PhysicalBoneEditor(EditorNode *p_editor) :
 	button_transform_joint->set_text(TTR("Move Joint"));
 	button_transform_joint->set_icon(SpatialEditor::get_singleton()->get_icon("PhysicalBone", "EditorIcons"));
 	button_transform_joint->set_toggle_mode(true);
-	button_transform_joint->connect_compat("toggled", this, "_on_toggle_button_transform_joint");
+	button_transform_joint->connect("toggled", callable_mp(this, &PhysicalBoneEditor::_on_toggle_button_transform_joint));
 
 	hide();
 }

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1259,7 +1259,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	button_uv = memnew(ToolButton);
 	add_child(button_uv);
 	button_uv->set_tooltip(TTR("Open Polygon 2D UV editor."));
-	button_uv->connect_compat("pressed", this, "_menu_option", varray(MODE_EDIT_UV));
+	button_uv->connect("pressed", callable_mp(this, &Polygon2DEditor::_menu_option), varray(MODE_EDIT_UV));
 
 	uv_mode = UV_MODE_EDIT_POINT;
 	uv_edit = memnew(AcceptDialog);
@@ -1374,7 +1374,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_menu->get_popup()->add_item(TTR("Clear UV"), UVEDIT_UV_CLEAR);
 	uv_menu->get_popup()->add_separator();
 	uv_menu->get_popup()->add_item(TTR("Grid Settings"), UVEDIT_GRID_SETTINGS);
-	uv_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	uv_menu->get_popup()->connect("id_pressed", callable_mp(this, &Polygon2DEditor::_menu_option));
 
 	uv_mode_hb->add_child(memnew(VSeparator));
 

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -192,7 +192,7 @@ void Polygon2DEditor::_update_bone_list() {
 		if (np == selected || bone_scroll_vb->get_child_count() < 2)
 			cb->set_pressed(true);
 
-		cb->connect_compat("pressed", this, "_bone_paint_selected", varray(i));
+		cb->connect("pressed", callable_mp(this, &Polygon2DEditor::_bone_paint_selected), varray(i));
 	}
 
 	uv_edit_draw->update();
@@ -1234,22 +1234,8 @@ void Polygon2DEditor::_uv_draw() {
 
 void Polygon2DEditor::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_uv_mode"), &Polygon2DEditor::_uv_mode);
-	ClassDB::bind_method(D_METHOD("_uv_draw"), &Polygon2DEditor::_uv_draw);
-	ClassDB::bind_method(D_METHOD("_uv_input"), &Polygon2DEditor::_uv_input);
-	ClassDB::bind_method(D_METHOD("_uv_scroll_changed"), &Polygon2DEditor::_uv_scroll_changed);
-	ClassDB::bind_method(D_METHOD("_set_use_snap"), &Polygon2DEditor::_set_use_snap);
-	ClassDB::bind_method(D_METHOD("_set_show_grid"), &Polygon2DEditor::_set_show_grid);
-	ClassDB::bind_method(D_METHOD("_set_snap_off_x"), &Polygon2DEditor::_set_snap_off_x);
-	ClassDB::bind_method(D_METHOD("_set_snap_off_y"), &Polygon2DEditor::_set_snap_off_y);
-	ClassDB::bind_method(D_METHOD("_set_snap_step_x"), &Polygon2DEditor::_set_snap_step_x);
-	ClassDB::bind_method(D_METHOD("_set_snap_step_y"), &Polygon2DEditor::_set_snap_step_y);
-	ClassDB::bind_method(D_METHOD("_uv_edit_mode_select"), &Polygon2DEditor::_uv_edit_mode_select);
-	ClassDB::bind_method(D_METHOD("_uv_edit_popup_hide"), &Polygon2DEditor::_uv_edit_popup_hide);
-	ClassDB::bind_method(D_METHOD("_sync_bones"), &Polygon2DEditor::_sync_bones);
 	ClassDB::bind_method(D_METHOD("_update_bone_list"), &Polygon2DEditor::_update_bone_list);
 	ClassDB::bind_method(D_METHOD("_update_polygon_editing_state"), &Polygon2DEditor::_update_polygon_editing_state);
-	ClassDB::bind_method(D_METHOD("_bone_paint_selected"), &Polygon2DEditor::_bone_paint_selected);
 }
 
 Vector2 Polygon2DEditor::snap_point(Vector2 p_target) const {
@@ -1280,7 +1266,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	add_child(uv_edit);
 	uv_edit->set_title(TTR("Polygon 2D UV Editor"));
 	uv_edit->set_resizable(true);
-	uv_edit->connect_compat("popup_hide", this, "_uv_edit_popup_hide");
+	uv_edit->connect("popup_hide", callable_mp(this, &Polygon2DEditor::_uv_edit_popup_hide));
 
 	VBoxContainer *uv_main_vb = memnew(VBoxContainer);
 	uv_edit->add_child(uv_main_vb);
@@ -1312,10 +1298,10 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_edit_mode[2]->set_button_group(uv_edit_group);
 	uv_edit_mode[3]->set_button_group(uv_edit_group);
 
-	uv_edit_mode[0]->connect_compat("pressed", this, "_uv_edit_mode_select", varray(0));
-	uv_edit_mode[1]->connect_compat("pressed", this, "_uv_edit_mode_select", varray(1));
-	uv_edit_mode[2]->connect_compat("pressed", this, "_uv_edit_mode_select", varray(2));
-	uv_edit_mode[3]->connect_compat("pressed", this, "_uv_edit_mode_select", varray(3));
+	uv_edit_mode[0]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(0));
+	uv_edit_mode[1]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(1));
+	uv_edit_mode[2]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(2));
+	uv_edit_mode[3]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(3));
 
 	uv_mode_hb->add_child(memnew(VSeparator));
 
@@ -1325,7 +1311,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 		uv_button[i] = memnew(ToolButton);
 		uv_button[i]->set_toggle_mode(true);
 		uv_mode_hb->add_child(uv_button[i]);
-		uv_button[i]->connect_compat("pressed", this, "_uv_mode", varray(i));
+		uv_button[i]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_mode), varray(i));
 		uv_button[i]->set_focus_mode(FOCUS_NONE);
 	}
 
@@ -1399,7 +1385,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	b_snap_enable->set_toggle_mode(true);
 	b_snap_enable->set_pressed(use_snap);
 	b_snap_enable->set_tooltip(TTR("Enable Snap"));
-	b_snap_enable->connect_compat("toggled", this, "_set_use_snap");
+	b_snap_enable->connect("toggled", callable_mp(this, &Polygon2DEditor::_set_use_snap));
 
 	b_snap_grid = memnew(ToolButton);
 	uv_mode_hb->add_child(b_snap_grid);
@@ -1408,7 +1394,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	b_snap_grid->set_toggle_mode(true);
 	b_snap_grid->set_pressed(snap_show_grid);
 	b_snap_grid->set_tooltip(TTR("Show Grid"));
-	b_snap_grid->connect_compat("toggled", this, "_set_show_grid");
+	b_snap_grid->connect("toggled", callable_mp(this, &Polygon2DEditor::_set_show_grid));
 
 	grid_settings = memnew(AcceptDialog);
 	grid_settings->set_title(TTR("Configure Grid:"));
@@ -1422,7 +1408,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sb_off_x->set_step(1);
 	sb_off_x->set_value(snap_offset.x);
 	sb_off_x->set_suffix("px");
-	sb_off_x->connect_compat("value_changed", this, "_set_snap_off_x");
+	sb_off_x->connect("value_changed", callable_mp(this, &Polygon2DEditor::_set_snap_off_x));
 	grid_settings_vb->add_margin_child(TTR("Grid Offset X:"), sb_off_x);
 
 	SpinBox *sb_off_y = memnew(SpinBox);
@@ -1431,7 +1417,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sb_off_y->set_step(1);
 	sb_off_y->set_value(snap_offset.y);
 	sb_off_y->set_suffix("px");
-	sb_off_y->connect_compat("value_changed", this, "_set_snap_off_y");
+	sb_off_y->connect("value_changed", callable_mp(this, &Polygon2DEditor::_set_snap_off_y));
 	grid_settings_vb->add_margin_child(TTR("Grid Offset Y:"), sb_off_y);
 
 	SpinBox *sb_step_x = memnew(SpinBox);
@@ -1440,7 +1426,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sb_step_x->set_step(1);
 	sb_step_x->set_value(snap_step.x);
 	sb_step_x->set_suffix("px");
-	sb_step_x->connect_compat("value_changed", this, "_set_snap_step_x");
+	sb_step_x->connect("value_changed", callable_mp(this, &Polygon2DEditor::_set_snap_step_x));
 	grid_settings_vb->add_margin_child(TTR("Grid Step X:"), sb_step_x);
 
 	SpinBox *sb_step_y = memnew(SpinBox);
@@ -1449,7 +1435,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sb_step_y->set_step(1);
 	sb_step_y->set_value(snap_step.y);
 	sb_step_y->set_suffix("px");
-	sb_step_y->connect_compat("value_changed", this, "_set_snap_step_y");
+	sb_step_y->connect("value_changed", callable_mp(this, &Polygon2DEditor::_set_snap_step_y));
 	grid_settings_vb->add_margin_child(TTR("Grid Step Y:"), sb_step_y);
 
 	uv_mode_hb->add_child(memnew(VSeparator));
@@ -1469,16 +1455,16 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_zoom->share(uv_zoom_value);
 	uv_zoom_value->set_custom_minimum_size(Size2(50, 0));
 	uv_mode_hb->add_child(uv_zoom_value);
-	uv_zoom->connect_compat("value_changed", this, "_uv_scroll_changed");
+	uv_zoom->connect("value_changed", callable_mp(this, &Polygon2DEditor::_uv_scroll_changed));
 
 	uv_vscroll = memnew(VScrollBar);
 	uv_vscroll->set_step(0.001);
 	uv_edit_draw->add_child(uv_vscroll);
-	uv_vscroll->connect_compat("value_changed", this, "_uv_scroll_changed");
+	uv_vscroll->connect("value_changed", callable_mp(this, &Polygon2DEditor::_uv_scroll_changed));
 	uv_hscroll = memnew(HScrollBar);
 	uv_hscroll->set_step(0.001);
 	uv_edit_draw->add_child(uv_hscroll);
-	uv_hscroll->connect_compat("value_changed", this, "_uv_scroll_changed");
+	uv_hscroll->connect("value_changed", callable_mp(this, &Polygon2DEditor::_uv_scroll_changed));
 
 	bone_scroll_main_vb = memnew(VBoxContainer);
 	bone_scroll_main_vb->hide();
@@ -1486,7 +1472,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sync_bones = memnew(Button(TTR("Sync Bones to Polygon")));
 	bone_scroll_main_vb->add_child(sync_bones);
 	sync_bones->set_h_size_flags(0);
-	sync_bones->connect_compat("pressed", this, "_sync_bones");
+	sync_bones->connect("pressed", callable_mp(this, &Polygon2DEditor::_sync_bones));
 	uv_main_hsc->add_child(bone_scroll_main_vb);
 	bone_scroll = memnew(ScrollContainer);
 	bone_scroll->set_v_scroll(true);
@@ -1496,8 +1482,8 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	bone_scroll_vb = memnew(VBoxContainer);
 	bone_scroll->add_child(bone_scroll_vb);
 
-	uv_edit_draw->connect_compat("draw", this, "_uv_draw");
-	uv_edit_draw->connect_compat("gui_input", this, "_uv_input");
+	uv_edit_draw->connect("draw", callable_mp(this, &Polygon2DEditor::_uv_draw));
+	uv_edit_draw->connect("gui_input", callable_mp(this, &Polygon2DEditor::_uv_input));
 	uv_draw_zoom = 1.0;
 	point_drag_index = -1;
 	uv_drag = false;

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -347,12 +347,7 @@ void ResourcePreloaderEditor::drop_data_fw(const Point2 &p_point, const Variant 
 void ResourcePreloaderEditor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &ResourcePreloaderEditor::_gui_input);
-	ClassDB::bind_method(D_METHOD("_load_pressed"), &ResourcePreloaderEditor::_load_pressed);
-	ClassDB::bind_method(D_METHOD("_item_edited"), &ResourcePreloaderEditor::_item_edited);
-	ClassDB::bind_method(D_METHOD("_paste_pressed"), &ResourcePreloaderEditor::_paste_pressed);
-	ClassDB::bind_method(D_METHOD("_files_load_request"), &ResourcePreloaderEditor::_files_load_request);
 	ClassDB::bind_method(D_METHOD("_update_library"), &ResourcePreloaderEditor::_update_library);
-	ClassDB::bind_method(D_METHOD("_cell_button_pressed"), &ResourcePreloaderEditor::_cell_button_pressed);
 	ClassDB::bind_method(D_METHOD("_remove_resource", "to_remove"), &ResourcePreloaderEditor::_remove_resource);
 
 	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &ResourcePreloaderEditor::get_drag_data_fw);
@@ -382,7 +377,7 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	add_child(file);
 
 	tree = memnew(Tree);
-	tree->connect_compat("button_pressed", this, "_cell_button_pressed");
+	tree->connect("button_pressed", callable_mp(this, &ResourcePreloaderEditor::_cell_button_pressed));
 	tree->set_columns(2);
 	tree->set_column_min_width(0, 2);
 	tree->set_column_min_width(1, 3);
@@ -396,10 +391,10 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	dialog = memnew(AcceptDialog);
 	add_child(dialog);
 
-	load->connect_compat("pressed", this, "_load_pressed");
-	paste->connect_compat("pressed", this, "_paste_pressed");
-	file->connect_compat("files_selected", this, "_files_load_request");
-	tree->connect_compat("item_edited", this, "_item_edited");
+	load->connect("pressed", callable_mp(this, &ResourcePreloaderEditor::_load_pressed));
+	paste->connect("pressed", callable_mp(this, &ResourcePreloaderEditor::_paste_pressed));
+	file->connect("files_selected", callable_mp(this, &ResourcePreloaderEditor::_files_load_request));
+	tree->connect("item_edited", callable_mp(this, &ResourcePreloaderEditor::_item_edited));
 	loading_scene = false;
 }
 

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -248,10 +248,6 @@ void EditorPropertyRootMotion::_notification(int p_what) {
 }
 
 void EditorPropertyRootMotion::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_confirmed"), &EditorPropertyRootMotion::_confirmed);
-	ClassDB::bind_method(D_METHOD("_node_assign"), &EditorPropertyRootMotion::_node_assign);
-	ClassDB::bind_method(D_METHOD("_node_clear"), &EditorPropertyRootMotion::_node_clear);
 }
 
 EditorPropertyRootMotion::EditorPropertyRootMotion() {
@@ -262,24 +258,24 @@ EditorPropertyRootMotion::EditorPropertyRootMotion() {
 	assign->set_flat(true);
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
-	assign->connect_compat("pressed", this, "_node_assign");
+	assign->connect("pressed", callable_mp(this, &EditorPropertyRootMotion::_node_assign));
 	hbc->add_child(assign);
 
 	clear = memnew(Button);
 	clear->set_flat(true);
-	clear->connect_compat("pressed", this, "_node_clear");
+	clear->connect("pressed", callable_mp(this, &EditorPropertyRootMotion::_node_clear));
 	hbc->add_child(clear);
 
 	filter_dialog = memnew(ConfirmationDialog);
 	add_child(filter_dialog);
 	filter_dialog->set_title(TTR("Edit Filtered Tracks:"));
-	filter_dialog->connect_compat("confirmed", this, "_confirmed");
+	filter_dialog->connect("confirmed", callable_mp(this, &EditorPropertyRootMotion::_confirmed));
 
 	filters = memnew(Tree);
 	filter_dialog->add_child(filters);
 	filters->set_v_size_flags(SIZE_EXPAND_FILL);
 	filters->set_hide_root(true);
-	filters->connect_compat("item_activated", this, "_confirmed");
+	filters->connect("item_activated", callable_mp(this, &EditorPropertyRootMotion::_confirmed));
 	//filters->connect("item_edited", this, "_filter_edited");
 }
 //////////////////////////

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3042,16 +3042,12 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_copy_script_path", &ScriptEditor::_copy_script_path);
 
 	ClassDB::bind_method("_get_debug_tooltip", &ScriptEditor::_get_debug_tooltip);
-	ClassDB::bind_method("_update_autosave_timer", &ScriptEditor::_update_autosave_timer);
 	ClassDB::bind_method("_update_script_connections", &ScriptEditor::_update_script_connections);
 	ClassDB::bind_method("_help_class_open", &ScriptEditor::_help_class_open);
 	ClassDB::bind_method("_live_auto_reload_running_scripts", &ScriptEditor::_live_auto_reload_running_scripts);
 	ClassDB::bind_method("_unhandled_input", &ScriptEditor::_unhandled_input);
 	ClassDB::bind_method("_update_members_overview", &ScriptEditor::_update_members_overview);
 	ClassDB::bind_method("_update_recent_scripts", &ScriptEditor::_update_recent_scripts);
-	ClassDB::bind_method("_start_find_in_files", &ScriptEditor::_start_find_in_files);
-	ClassDB::bind_method("_on_find_in_files_result_selected", &ScriptEditor::_on_find_in_files_result_selected);
-	ClassDB::bind_method("_on_find_in_files_modified_files", &ScriptEditor::_on_find_in_files_modified_files);
 
 	ClassDB::bind_method(D_METHOD("get_drag_data_fw", "point", "from"), &ScriptEditor::get_drag_data_fw);
 	ClassDB::bind_method(D_METHOD("can_drop_data_fw", "point", "data", "from"), &ScriptEditor::can_drop_data_fw);
@@ -3340,7 +3336,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	autosave_timer = memnew(Timer);
 	autosave_timer->set_one_shot(false);
-	autosave_timer->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, "_update_autosave_timer");
+	autosave_timer->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &ScriptEditor::_update_autosave_timer));
 	autosave_timer->connect("timeout", callable_mp(this, &ScriptEditor::_autosave_scripts));
 	add_child(autosave_timer);
 
@@ -3351,14 +3347,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	help_search_dialog->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 
 	find_in_files_dialog = memnew(FindInFilesDialog);
-	find_in_files_dialog->connect_compat(FindInFilesDialog::SIGNAL_FIND_REQUESTED, this, "_start_find_in_files", varray(false));
-	find_in_files_dialog->connect_compat(FindInFilesDialog::SIGNAL_REPLACE_REQUESTED, this, "_start_find_in_files", varray(true));
+	find_in_files_dialog->connect(FindInFilesDialog::SIGNAL_FIND_REQUESTED, callable_mp(this, &ScriptEditor::_start_find_in_files), varray(false));
+	find_in_files_dialog->connect(FindInFilesDialog::SIGNAL_REPLACE_REQUESTED, callable_mp(this, &ScriptEditor::_start_find_in_files), varray(true));
 	add_child(find_in_files_dialog);
 	find_in_files = memnew(FindInFilesPanel);
 	find_in_files_button = editor->add_bottom_panel_item(TTR("Search Results"), find_in_files);
 	find_in_files->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
-	find_in_files->connect_compat(FindInFilesPanel::SIGNAL_RESULT_SELECTED, this, "_on_find_in_files_result_selected");
-	find_in_files->connect_compat(FindInFilesPanel::SIGNAL_FILES_MODIFIED, this, "_on_find_in_files_modified_files");
+	find_in_files->connect(FindInFilesPanel::SIGNAL_RESULT_SELECTED, callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
+	find_in_files->connect(FindInFilesPanel::SIGNAL_FILES_MODIFIED, callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));
 	find_in_files->hide();
 	find_in_files_button->hide();
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -211,7 +211,7 @@ void ScriptEditorQuickOpen::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("confirmed", this, "_confirmed");
+			connect("confirmed", callable_mp(this, &ScriptEditorQuickOpen::_confirmed));
 
 			search_box->set_clear_button_enabled(true);
 			[[fallthrough]];
@@ -220,16 +220,12 @@ void ScriptEditorQuickOpen::_notification(int p_what) {
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("confirmed", this, "_confirmed");
+			disconnect("confirmed", callable_mp(this, &ScriptEditorQuickOpen::_confirmed));
 		} break;
 	}
 }
 
 void ScriptEditorQuickOpen::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_text_changed"), &ScriptEditorQuickOpen::_text_changed);
-	ClassDB::bind_method(D_METHOD("_confirmed"), &ScriptEditorQuickOpen::_confirmed);
-	ClassDB::bind_method(D_METHOD("_sbox_input"), &ScriptEditorQuickOpen::_sbox_input);
 
 	ADD_SIGNAL(MethodInfo("goto_line", PropertyInfo(Variant::INT, "line")));
 }
@@ -240,15 +236,15 @@ ScriptEditorQuickOpen::ScriptEditorQuickOpen() {
 	add_child(vbc);
 	search_box = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", callable_mp(this, &ScriptEditorQuickOpen::_text_changed));
+	search_box->connect("gui_input", callable_mp(this, &ScriptEditorQuickOpen::_sbox_input));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_text(TTR("Open"));
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
+	search_options->connect("item_activated", callable_mp(this, &ScriptEditorQuickOpen::_confirmed));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
 	search_options->add_constant_override("draw_guides", 1);
@@ -1386,16 +1382,16 @@ void ScriptEditor::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
-			editor->connect_compat("stop_pressed", this, "_editor_stop");
-			editor->connect_compat("script_add_function_request", this, "_add_callback");
-			editor->connect_compat("resource_saved", this, "_res_saved_callback");
-			script_list->connect_compat("item_selected", this, "_script_selected");
+			editor->connect("stop_pressed", callable_mp(this, &ScriptEditor::_editor_stop));
+			editor->connect("script_add_function_request", callable_mp(this, &ScriptEditor::_add_callback));
+			editor->connect("resource_saved", callable_mp(this, &ScriptEditor::_res_saved_callback));
+			script_list->connect("item_selected", callable_mp(this, &ScriptEditor::_script_selected));
 
-			members_overview->connect_compat("item_selected", this, "_members_overview_selected");
-			help_overview->connect_compat("item_selected", this, "_help_overview_selected");
-			script_split->connect_compat("dragged", this, "_script_split_dragged");
+			members_overview->connect("item_selected", callable_mp(this, &ScriptEditor::_members_overview_selected));
+			help_overview->connect("item_selected", callable_mp(this, &ScriptEditor::_help_overview_selected));
+			script_split->connect("dragged", callable_mp(this, &ScriptEditor::_script_split_dragged));
 
-			EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_editor_settings_changed");
+			EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &ScriptEditor::_editor_settings_changed));
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
@@ -1419,14 +1415,14 @@ void ScriptEditor::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 
-			get_tree()->connect_compat("tree_changed", this, "_tree_changed");
-			editor->get_inspector_dock()->connect_compat("request_help", this, "_request_help");
-			editor->connect_compat("request_help_search", this, "_help_search");
+			get_tree()->connect("tree_changed", callable_mp(this, &ScriptEditor::_tree_changed));
+			editor->get_inspector_dock()->connect("request_help", callable_mp(this, &ScriptEditor::_help_class_open));
+			editor->connect("request_help_search", callable_mp(this, &ScriptEditor::_help_search));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
 
-			editor->disconnect_compat("stop_pressed", this, "_editor_stop");
+			editor->disconnect("stop_pressed", callable_mp(this, &ScriptEditor::_editor_stop));
 		} break;
 
 		case MainLoop::NOTIFICATION_WM_FOCUS_IN: {
@@ -2137,14 +2133,14 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 	_sort_list_on_update = true;
 	_update_script_names();
 	_save_layout();
-	se->connect_compat("name_changed", this, "_update_script_names");
-	se->connect_compat("edited_script_changed", this, "_script_changed");
-	se->connect_compat("request_help", this, "_help_search");
-	se->connect_compat("request_open_script_at_line", this, "_goto_script_line");
-	se->connect_compat("go_to_help", this, "_help_class_goto");
-	se->connect_compat("request_save_history", this, "_save_history");
-	se->connect_compat("search_in_files_requested", this, "_on_find_in_files_requested");
-	se->connect_compat("replace_in_files_requested", this, "_on_replace_in_files_requested");
+	se->connect("name_changed", callable_mp(this, &ScriptEditor::_update_script_names));
+	se->connect("edited_script_changed", callable_mp(this, &ScriptEditor::_script_changed));
+	se->connect("request_help", callable_mp(this, &ScriptEditor::_help_search));
+	se->connect("request_open_script_at_line", callable_mp(this, &ScriptEditor::_goto_script_line));
+	se->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
+	se->connect("request_save_history", callable_mp(this, &ScriptEditor::_save_history));
+	se->connect("search_in_files_requested", callable_mp(this, &ScriptEditor::_on_find_in_files_requested));
+	se->connect("replace_in_files_requested", callable_mp(this, &ScriptEditor::_on_replace_in_files_requested));
 
 	//test for modification, maybe the script was not edited but was loaded
 
@@ -2737,7 +2733,7 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 	tab_container->add_child(eh);
 	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_class(p_class, 0);
-	eh->connect_compat("go_to_help", this, "_help_class_goto");
+	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 	_add_recent_script(p_class);
 	_sort_list_on_update = true;
 	_update_script_names();
@@ -2767,7 +2763,7 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	tab_container->add_child(eh);
 	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_help(p_desc);
-	eh->connect_compat("go_to_help", this, "_help_class_goto");
+	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 	_add_recent_script(eh->get_class());
 	_sort_list_on_update = true;
 	_update_script_names();
@@ -3039,58 +3035,20 @@ void ScriptEditor::_filter_methods_text_changed(const String &p_newtext) {
 
 void ScriptEditor::_bind_methods() {
 
-	ClassDB::bind_method("_file_dialog_action", &ScriptEditor::_file_dialog_action);
-	ClassDB::bind_method("_tab_changed", &ScriptEditor::_tab_changed);
-	ClassDB::bind_method("_menu_option", &ScriptEditor::_menu_option);
-	ClassDB::bind_method("_close_current_tab", &ScriptEditor::_close_current_tab);
-	ClassDB::bind_method("_close_discard_current_tab", &ScriptEditor::_close_discard_current_tab);
 	ClassDB::bind_method("_close_docs_tab", &ScriptEditor::_close_docs_tab);
 	ClassDB::bind_method("_close_all_tabs", &ScriptEditor::_close_all_tabs);
 	ClassDB::bind_method("_close_other_tabs", &ScriptEditor::_close_other_tabs);
-	ClassDB::bind_method("_open_recent_script", &ScriptEditor::_open_recent_script);
-	ClassDB::bind_method("_theme_option", &ScriptEditor::_theme_option);
-	ClassDB::bind_method("_editor_stop", &ScriptEditor::_editor_stop);
-	ClassDB::bind_method("_add_callback", &ScriptEditor::_add_callback);
-	ClassDB::bind_method("_reload_scripts", &ScriptEditor::_reload_scripts);
-	ClassDB::bind_method("_resave_scripts", &ScriptEditor::_resave_scripts);
-	ClassDB::bind_method("_res_saved_callback", &ScriptEditor::_res_saved_callback);
-	ClassDB::bind_method("_goto_script_line", &ScriptEditor::_goto_script_line);
 	ClassDB::bind_method("_goto_script_line2", &ScriptEditor::_goto_script_line2);
-	ClassDB::bind_method("_set_execution", &ScriptEditor::_set_execution);
-	ClassDB::bind_method("_clear_execution", &ScriptEditor::_clear_execution);
-	ClassDB::bind_method("_help_search", &ScriptEditor::_help_search);
-	ClassDB::bind_method("_save_history", &ScriptEditor::_save_history);
 	ClassDB::bind_method("_copy_script_path", &ScriptEditor::_copy_script_path);
 
-	ClassDB::bind_method("_breaked", &ScriptEditor::_breaked);
 	ClassDB::bind_method("_get_debug_tooltip", &ScriptEditor::_get_debug_tooltip);
-	ClassDB::bind_method("_autosave_scripts", &ScriptEditor::_autosave_scripts);
 	ClassDB::bind_method("_update_autosave_timer", &ScriptEditor::_update_autosave_timer);
-	ClassDB::bind_method("_editor_settings_changed", &ScriptEditor::_editor_settings_changed);
-	ClassDB::bind_method("_update_script_names", &ScriptEditor::_update_script_names);
 	ClassDB::bind_method("_update_script_connections", &ScriptEditor::_update_script_connections);
-	ClassDB::bind_method("_tree_changed", &ScriptEditor::_tree_changed);
-	ClassDB::bind_method("_members_overview_selected", &ScriptEditor::_members_overview_selected);
-	ClassDB::bind_method("_help_overview_selected", &ScriptEditor::_help_overview_selected);
-	ClassDB::bind_method("_script_selected", &ScriptEditor::_script_selected);
-	ClassDB::bind_method("_script_created", &ScriptEditor::_script_created);
-	ClassDB::bind_method("_script_split_dragged", &ScriptEditor::_script_split_dragged);
 	ClassDB::bind_method("_help_class_open", &ScriptEditor::_help_class_open);
-	ClassDB::bind_method("_help_class_goto", &ScriptEditor::_help_class_goto);
-	ClassDB::bind_method("_request_help", &ScriptEditor::_help_class_open);
-	ClassDB::bind_method("_history_forward", &ScriptEditor::_history_forward);
-	ClassDB::bind_method("_history_back", &ScriptEditor::_history_back);
 	ClassDB::bind_method("_live_auto_reload_running_scripts", &ScriptEditor::_live_auto_reload_running_scripts);
 	ClassDB::bind_method("_unhandled_input", &ScriptEditor::_unhandled_input);
-	ClassDB::bind_method("_script_list_gui_input", &ScriptEditor::_script_list_gui_input);
-	ClassDB::bind_method("_toggle_members_overview_alpha_sort", &ScriptEditor::_toggle_members_overview_alpha_sort);
 	ClassDB::bind_method("_update_members_overview", &ScriptEditor::_update_members_overview);
-	ClassDB::bind_method("_script_changed", &ScriptEditor::_script_changed);
-	ClassDB::bind_method("_filter_scripts_text_changed", &ScriptEditor::_filter_scripts_text_changed);
-	ClassDB::bind_method("_filter_methods_text_changed", &ScriptEditor::_filter_methods_text_changed);
 	ClassDB::bind_method("_update_recent_scripts", &ScriptEditor::_update_recent_scripts);
-	ClassDB::bind_method("_on_find_in_files_requested", &ScriptEditor::_on_find_in_files_requested);
-	ClassDB::bind_method("_on_replace_in_files_requested", &ScriptEditor::_on_replace_in_files_requested);
 	ClassDB::bind_method("_start_find_in_files", &ScriptEditor::_start_find_in_files);
 	ClassDB::bind_method("_on_find_in_files_result_selected", &ScriptEditor::_on_find_in_files_result_selected);
 	ClassDB::bind_method("_on_find_in_files_modified_files", &ScriptEditor::_on_find_in_files_modified_files);
@@ -3142,7 +3100,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	filter_scripts = memnew(LineEdit);
 	filter_scripts->set_placeholder(TTR("Filter scripts"));
 	filter_scripts->set_clear_button_enabled(true);
-	filter_scripts->connect_compat("text_changed", this, "_filter_scripts_text_changed");
+	filter_scripts->connect("text_changed", callable_mp(this, &ScriptEditor::_filter_scripts_text_changed));
 	scripts_vbox->add_child(filter_scripts);
 
 	script_list = memnew(ItemList);
@@ -3151,13 +3109,13 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	script_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	script_split->set_split_offset(140);
 	_sort_list_on_update = true;
-	script_list->connect_compat("gui_input", this, "_script_list_gui_input", varray(), CONNECT_DEFERRED);
+	script_list->connect("gui_input", callable_mp(this, &ScriptEditor::_script_list_gui_input), varray(), CONNECT_DEFERRED);
 	script_list->set_allow_rmb_select(true);
 	script_list->set_drag_forwarding(this);
 
 	context_menu = memnew(PopupMenu);
 	add_child(context_menu);
-	context_menu->connect_compat("id_pressed", this, "_menu_option");
+	context_menu->connect("id_pressed", callable_mp(this, &ScriptEditor::_menu_option));
 	context_menu->set_hide_on_window_lose_focus(true);
 
 	overview_vbox = memnew(VBoxContainer);
@@ -3178,14 +3136,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	members_overview_alphabeta_sort_button->set_tooltip(TTR("Toggle alphabetical sorting of the method list."));
 	members_overview_alphabeta_sort_button->set_toggle_mode(true);
 	members_overview_alphabeta_sort_button->set_pressed(EditorSettings::get_singleton()->get("text_editor/tools/sort_members_outline_alphabetically"));
-	members_overview_alphabeta_sort_button->connect_compat("toggled", this, "_toggle_members_overview_alpha_sort");
+	members_overview_alphabeta_sort_button->connect("toggled", callable_mp(this, &ScriptEditor::_toggle_members_overview_alpha_sort));
 
 	buttons_hbox->add_child(members_overview_alphabeta_sort_button);
 
 	filter_methods = memnew(LineEdit);
 	filter_methods->set_placeholder(TTR("Filter methods"));
 	filter_methods->set_clear_button_enabled(true);
-	filter_methods->connect_compat("text_changed", this, "_filter_methods_text_changed");
+	filter_methods->connect("text_changed", callable_mp(this, &ScriptEditor::_filter_methods_text_changed));
 	overview_vbox->add_child(filter_methods);
 
 	members_overview = memnew(ItemList);
@@ -3229,7 +3187,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	recent_scripts = memnew(PopupMenu);
 	recent_scripts->set_name("RecentScripts");
 	file_menu->get_popup()->add_child(recent_scripts);
-	recent_scripts->connect_compat("id_pressed", this, "_open_recent_script");
+	recent_scripts->connect("id_pressed", callable_mp(this, &ScriptEditor::_open_recent_script));
 	_update_recent_scripts();
 
 	file_menu->get_popup()->add_separator();
@@ -3251,7 +3209,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	theme_submenu = memnew(PopupMenu);
 	theme_submenu->set_name("Theme");
 	file_menu->get_popup()->add_child(theme_submenu);
-	theme_submenu->connect_compat("id_pressed", this, "_theme_option");
+	theme_submenu->connect("id_pressed", callable_mp(this, &ScriptEditor::_theme_option));
 	theme_submenu->add_shortcut(ED_SHORTCUT("script_editor/import_theme", TTR("Import Theme...")), THEME_IMPORT);
 	theme_submenu->add_shortcut(ED_SHORTCUT("script_editor/reload_theme", TTR("Reload Theme")), THEME_RELOAD);
 
@@ -3270,14 +3228,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	file_menu->get_popup()->add_separator();
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/toggle_scripts_panel", TTR("Toggle Scripts Panel"), KEY_MASK_CMD | KEY_BACKSLASH), TOGGLE_SCRIPTS_PANEL);
-	file_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	file_menu->get_popup()->connect("id_pressed", callable_mp(this, &ScriptEditor::_menu_option));
 
 	script_search_menu = memnew(MenuButton);
 	menu_hb->add_child(script_search_menu);
 	script_search_menu->set_text(TTR("Search"));
 	script_search_menu->set_switch_on_hover(true);
 	script_search_menu->get_popup()->set_hide_on_window_lose_focus(true);
-	script_search_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	script_search_menu->get_popup()->connect("id_pressed", callable_mp(this, &ScriptEditor::_menu_option));
 
 	MenuButton *debug_menu = memnew(MenuButton);
 	menu_hb->add_child(debug_menu);
@@ -3285,10 +3243,10 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	EditorDebuggerNode *debugger = EditorDebuggerNode::get_singleton();
 	debugger->set_script_debug_button(debug_menu);
-	debugger->connect_compat("goto_script_line", this, "_goto_script_line");
-	debugger->connect_compat("set_execution", this, "_set_execution");
-	debugger->connect_compat("clear_execution", this, "_clear_execution");
-	debugger->connect_compat("breaked", this, "_breaked");
+	debugger->connect("goto_script_line", callable_mp(this, &ScriptEditor::_goto_script_line));
+	debugger->connect("set_execution", callable_mp(this, &ScriptEditor::_set_execution));
+	debugger->connect("clear_execution", callable_mp(this, &ScriptEditor::_clear_execution));
+	debugger->connect("breaked", callable_mp(this, &ScriptEditor::_breaked));
 
 	menu_hb->add_spacer();
 
@@ -3304,54 +3262,54 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	site_search = memnew(ToolButton);
 	site_search->set_text(TTR("Online Docs"));
-	site_search->connect_compat("pressed", this, "_menu_option", varray(SEARCH_WEBSITE));
+	site_search->connect("pressed", callable_mp(this, &ScriptEditor::_menu_option), varray(SEARCH_WEBSITE));
 	menu_hb->add_child(site_search);
 	site_search->set_tooltip(TTR("Open Godot online documentation."));
 
 	request_docs = memnew(ToolButton);
 	request_docs->set_text(TTR("Request Docs"));
-	request_docs->connect_compat("pressed", this, "_menu_option", varray(REQUEST_DOCS));
+	request_docs->connect("pressed", callable_mp(this, &ScriptEditor::_menu_option), varray(REQUEST_DOCS));
 	menu_hb->add_child(request_docs);
 	request_docs->set_tooltip(TTR("Help improve the Godot documentation by giving feedback."));
 
 	help_search = memnew(ToolButton);
 	help_search->set_text(TTR("Search Help"));
-	help_search->connect_compat("pressed", this, "_menu_option", varray(SEARCH_HELP));
+	help_search->connect("pressed", callable_mp(this, &ScriptEditor::_menu_option), varray(SEARCH_HELP));
 	menu_hb->add_child(help_search);
 	help_search->set_tooltip(TTR("Search the reference documentation."));
 
 	menu_hb->add_child(memnew(VSeparator));
 
 	script_back = memnew(ToolButton);
-	script_back->connect_compat("pressed", this, "_history_back");
+	script_back->connect("pressed", callable_mp(this, &ScriptEditor::_history_back));
 	menu_hb->add_child(script_back);
 	script_back->set_disabled(true);
 	script_back->set_tooltip(TTR("Go to previous edited document."));
 
 	script_forward = memnew(ToolButton);
-	script_forward->connect_compat("pressed", this, "_history_forward");
+	script_forward->connect("pressed", callable_mp(this, &ScriptEditor::_history_forward));
 	menu_hb->add_child(script_forward);
 	script_forward->set_disabled(true);
 	script_forward->set_tooltip(TTR("Go to next edited document."));
 
-	tab_container->connect_compat("tab_changed", this, "_tab_changed");
+	tab_container->connect("tab_changed", callable_mp(this, &ScriptEditor::_tab_changed));
 
 	erase_tab_confirm = memnew(ConfirmationDialog);
 	erase_tab_confirm->get_ok()->set_text(TTR("Save"));
 	erase_tab_confirm->add_button(TTR("Discard"), OS::get_singleton()->get_swap_ok_cancel(), "discard");
-	erase_tab_confirm->connect_compat("confirmed", this, "_close_current_tab");
-	erase_tab_confirm->connect_compat("custom_action", this, "_close_discard_current_tab");
+	erase_tab_confirm->connect("confirmed", callable_mp(this, &ScriptEditor::_close_current_tab));
+	erase_tab_confirm->connect("custom_action", callable_mp(this, &ScriptEditor::_close_discard_current_tab));
 	add_child(erase_tab_confirm);
 
 	script_create_dialog = memnew(ScriptCreateDialog);
 	script_create_dialog->set_title(TTR("Create Script"));
 	add_child(script_create_dialog);
-	script_create_dialog->connect_compat("script_created", this, "_script_created");
+	script_create_dialog->connect("script_created", callable_mp(this, &ScriptEditor::_script_created));
 
 	file_dialog_option = -1;
 	file_dialog = memnew(EditorFileDialog);
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_file_dialog_action");
+	file_dialog->connect("file_selected", callable_mp(this, &ScriptEditor::_file_dialog_action));
 
 	error_dialog = memnew(AcceptDialog);
 	add_child(error_dialog);
@@ -3369,11 +3327,11 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 		vbc->add_child(disk_changed_list);
 		disk_changed_list->set_v_size_flags(SIZE_EXPAND_FILL);
 
-		disk_changed->connect_compat("confirmed", this, "_reload_scripts");
+		disk_changed->connect("confirmed", callable_mp(this, &ScriptEditor::_reload_scripts));
 		disk_changed->get_ok()->set_text(TTR("Reload"));
 
 		disk_changed->add_button(TTR("Resave"), !OS::get_singleton()->get_swap_ok_cancel(), "resave");
-		disk_changed->connect_compat("custom_action", this, "_resave_scripts");
+		disk_changed->connect("custom_action", callable_mp(this, &ScriptEditor::_resave_scripts));
 	}
 
 	add_child(disk_changed);
@@ -3383,14 +3341,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	autosave_timer = memnew(Timer);
 	autosave_timer->set_one_shot(false);
 	autosave_timer->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, "_update_autosave_timer");
-	autosave_timer->connect_compat("timeout", this, "_autosave_scripts");
+	autosave_timer->connect("timeout", callable_mp(this, &ScriptEditor::_autosave_scripts));
 	add_child(autosave_timer);
 
 	grab_focus_block = false;
 
 	help_search_dialog = memnew(EditorHelpSearch);
 	add_child(help_search_dialog);
-	help_search_dialog->connect_compat("go_to_help", this, "_help_class_goto");
+	help_search_dialog->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 
 	find_in_files_dialog = memnew(FindInFilesDialog);
 	find_in_files_dialog->connect_compat(FindInFilesDialog::SIGNAL_FIND_REQUESTED, this, "_start_find_in_files", varray(false));

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1429,24 +1429,7 @@ void ScriptTextEditor::_change_syntax_highlighter(int p_idx) {
 
 void ScriptTextEditor::_bind_methods() {
 
-	ClassDB::bind_method("_validate_script", &ScriptTextEditor::_validate_script);
-	ClassDB::bind_method("_update_bookmark_list", &ScriptTextEditor::_update_bookmark_list);
-	ClassDB::bind_method("_bookmark_item_pressed", &ScriptTextEditor::_bookmark_item_pressed);
-	ClassDB::bind_method("_load_theme_settings", &ScriptTextEditor::_load_theme_settings);
-	ClassDB::bind_method("_update_breakpoint_list", &ScriptTextEditor::_update_breakpoint_list);
-	ClassDB::bind_method("_breakpoint_item_pressed", &ScriptTextEditor::_breakpoint_item_pressed);
-	ClassDB::bind_method("_breakpoint_toggled", &ScriptTextEditor::_breakpoint_toggled);
-	ClassDB::bind_method("_lookup_connections", &ScriptTextEditor::_lookup_connections);
 	ClassDB::bind_method("_update_connected_methods", &ScriptTextEditor::_update_connected_methods);
-	ClassDB::bind_method("_change_syntax_highlighter", &ScriptTextEditor::_change_syntax_highlighter);
-	ClassDB::bind_method("_edit_option", &ScriptTextEditor::_edit_option);
-	ClassDB::bind_method("_goto_line", &ScriptTextEditor::_goto_line);
-	ClassDB::bind_method("_lookup_symbol", &ScriptTextEditor::_lookup_symbol);
-	ClassDB::bind_method("_text_edit_gui_input", &ScriptTextEditor::_text_edit_gui_input);
-	ClassDB::bind_method("_show_warnings_panel", &ScriptTextEditor::_show_warnings_panel);
-	ClassDB::bind_method("_error_pressed", &ScriptTextEditor::_error_pressed);
-	ClassDB::bind_method("_warning_clicked", &ScriptTextEditor::_warning_clicked);
-	ClassDB::bind_method("_color_changed", &ScriptTextEditor::_color_changed);
 
 	ClassDB::bind_method("get_drag_data_fw", &ScriptTextEditor::get_drag_data_fw);
 	ClassDB::bind_method("can_drop_data_fw", &ScriptTextEditor::can_drop_data_fw);
@@ -1774,12 +1757,12 @@ ScriptTextEditor::ScriptTextEditor() {
 	editor_box->add_child(code_editor);
 	code_editor->add_constant_override("separation", 2);
 	code_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	code_editor->connect_compat("validate_script", this, "_validate_script");
-	code_editor->connect_compat("load_theme_settings", this, "_load_theme_settings");
+	code_editor->connect("validate_script", callable_mp(this, &ScriptTextEditor::_validate_script));
+	code_editor->connect("load_theme_settings", callable_mp(this, &ScriptTextEditor::_load_theme_settings));
 	code_editor->set_code_complete_func(_code_complete_scripts, this);
-	code_editor->get_text_edit()->connect_compat("breakpoint_toggled", this, "_breakpoint_toggled");
-	code_editor->get_text_edit()->connect_compat("symbol_lookup", this, "_lookup_symbol");
-	code_editor->get_text_edit()->connect_compat("info_clicked", this, "_lookup_connections");
+	code_editor->get_text_edit()->connect("breakpoint_toggled", callable_mp(this, &ScriptTextEditor::_breakpoint_toggled));
+	code_editor->get_text_edit()->connect("symbol_lookup", callable_mp(this, &ScriptTextEditor::_lookup_symbol));
+	code_editor->get_text_edit()->connect("info_clicked", callable_mp(this, &ScriptTextEditor::_lookup_connections));
 	code_editor->set_v_size_flags(SIZE_EXPAND_FILL);
 	code_editor->show_toggle_scripts_button();
 
@@ -1792,9 +1775,9 @@ ScriptTextEditor::ScriptTextEditor() {
 	warnings_panel->set_focus_mode(FOCUS_CLICK);
 	warnings_panel->hide();
 
-	code_editor->connect_compat("error_pressed", this, "_error_pressed");
-	code_editor->connect_compat("show_warnings_panel", this, "_show_warnings_panel");
-	warnings_panel->connect_compat("meta_clicked", this, "_warning_clicked");
+	code_editor->connect("error_pressed", callable_mp(this, &ScriptTextEditor::_error_pressed));
+	code_editor->connect("show_warnings_panel", callable_mp(this, &ScriptTextEditor::_show_warnings_panel));
+	warnings_panel->connect("meta_clicked", callable_mp(this, &ScriptTextEditor::_warning_clicked));
 
 	update_settings();
 
@@ -1804,11 +1787,11 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	code_editor->get_text_edit()->set_select_identifiers_on_hover(true);
 	code_editor->get_text_edit()->set_context_menu_enabled(false);
-	code_editor->get_text_edit()->connect_compat("gui_input", this, "_text_edit_gui_input");
+	code_editor->get_text_edit()->connect("gui_input", callable_mp(this, &ScriptTextEditor::_text_edit_gui_input));
 
 	context_menu = memnew(PopupMenu);
 	add_child(context_menu);
-	context_menu->connect_compat("id_pressed", this, "_edit_option");
+	context_menu->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_edit_option));
 	context_menu->set_hide_on_window_lose_focus(true);
 
 	color_panel = memnew(PopupPanel);
@@ -1816,7 +1799,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	color_picker = memnew(ColorPicker);
 	color_picker->set_deferred_mode(true);
 	color_panel->add_child(color_picker);
-	color_picker->connect_compat("color_changed", this, "_color_changed");
+	color_picker->connect("color_changed", callable_mp(this, &ScriptTextEditor::_color_changed));
 
 	// get default color picker mode from editor settings
 	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
@@ -1857,7 +1840,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_spaces"), EDIT_CONVERT_INDENT_TO_SPACES);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_tabs"), EDIT_CONVERT_INDENT_TO_TABS);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/auto_indent"), EDIT_AUTO_INDENT);
-	edit_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	edit_menu->get_popup()->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_edit_option));
 	edit_menu->get_popup()->add_separator();
 
 	PopupMenu *convert_case = memnew(PopupMenu);
@@ -1867,7 +1850,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/convert_to_uppercase", TTR("Uppercase"), KEY_MASK_SHIFT | KEY_F4), EDIT_TO_UPPERCASE);
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/convert_to_lowercase", TTR("Lowercase"), KEY_MASK_SHIFT | KEY_F5), EDIT_TO_LOWERCASE);
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/capitalize", TTR("Capitalize"), KEY_MASK_SHIFT | KEY_F6), EDIT_CAPITALIZE);
-	convert_case->connect_compat("id_pressed", this, "_edit_option");
+	convert_case->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_edit_option));
 
 	highlighters[TTR("Standard")] = NULL;
 	highlighter_menu = memnew(PopupMenu);
@@ -1875,7 +1858,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	edit_menu->get_popup()->add_child(highlighter_menu);
 	edit_menu->get_popup()->add_submenu_item(TTR("Syntax Highlighter"), "highlighter_menu");
 	highlighter_menu->add_radio_check_item(TTR("Standard"));
-	highlighter_menu->connect_compat("id_pressed", this, "_change_syntax_highlighter");
+	highlighter_menu->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_change_syntax_highlighter));
 
 	search_menu = memnew(MenuButton);
 	edit_hb->add_child(search_menu);
@@ -1891,7 +1874,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace_in_files"), REPLACE_IN_FILES);
 	search_menu->get_popup()->add_separator();
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/contextual_help"), HELP_CONTEXTUAL);
-	search_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	search_menu->get_popup()->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_edit_option));
 
 	edit_hb->add_child(edit_menu);
 
@@ -1899,7 +1882,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	edit_hb->add_child(goto_menu);
 	goto_menu->set_text(TTR("Go To"));
 	goto_menu->set_switch_on_hover(true);
-	goto_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	goto_menu->get_popup()->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_edit_option));
 
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_function"), SEARCH_LOCATE_FUNCTION);
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
@@ -1910,20 +1893,20 @@ ScriptTextEditor::ScriptTextEditor() {
 	goto_menu->get_popup()->add_child(bookmarks_menu);
 	goto_menu->get_popup()->add_submenu_item(TTR("Bookmarks"), "Bookmarks");
 	_update_bookmark_list();
-	bookmarks_menu->connect_compat("about_to_show", this, "_update_bookmark_list");
-	bookmarks_menu->connect_compat("index_pressed", this, "_bookmark_item_pressed");
+	bookmarks_menu->connect("about_to_show", callable_mp(this, &ScriptTextEditor::_update_bookmark_list));
+	bookmarks_menu->connect("index_pressed", callable_mp(this, &ScriptTextEditor::_bookmark_item_pressed));
 
 	breakpoints_menu = memnew(PopupMenu);
 	breakpoints_menu->set_name("Breakpoints");
 	goto_menu->get_popup()->add_child(breakpoints_menu);
 	goto_menu->get_popup()->add_submenu_item(TTR("Breakpoints"), "Breakpoints");
 	_update_breakpoint_list();
-	breakpoints_menu->connect_compat("about_to_show", this, "_update_breakpoint_list");
-	breakpoints_menu->connect_compat("index_pressed", this, "_breakpoint_item_pressed");
+	breakpoints_menu->connect("about_to_show", callable_mp(this, &ScriptTextEditor::_update_breakpoint_list));
+	breakpoints_menu->connect("index_pressed", callable_mp(this, &ScriptTextEditor::_breakpoint_item_pressed));
 
 	quick_open = memnew(ScriptEditorQuickOpen);
 	add_child(quick_open);
-	quick_open->connect_compat("goto_line", this, "_goto_line");
+	quick_open->connect("goto_line", callable_mp(this, &ScriptTextEditor::_goto_line));
 
 	goto_line_dialog = memnew(GotoLineDialog);
 	add_child(goto_line_dialog);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -389,17 +389,7 @@ void ShaderEditor::_editor_settings_changed() {
 
 void ShaderEditor::_bind_methods() {
 
-	ClassDB::bind_method("_reload_shader_from_disk", &ShaderEditor::_reload_shader_from_disk);
-	ClassDB::bind_method("_editor_settings_changed", &ShaderEditor::_editor_settings_changed);
-	ClassDB::bind_method("_text_edit_gui_input", &ShaderEditor::_text_edit_gui_input);
-
-	ClassDB::bind_method("_update_bookmark_list", &ShaderEditor::_update_bookmark_list);
-	ClassDB::bind_method("_bookmark_item_pressed", &ShaderEditor::_bookmark_item_pressed);
-
-	ClassDB::bind_method("_menu_option", &ShaderEditor::_menu_option);
 	ClassDB::bind_method("_params_changed", &ShaderEditor::_params_changed);
-	ClassDB::bind_method("apply_shaders", &ShaderEditor::apply_shaders);
-	ClassDB::bind_method("save_external_data", &ShaderEditor::save_external_data);
 }
 
 void ShaderEditor::ensure_select_current() {
@@ -607,8 +597,8 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	shader_editor->add_constant_override("separation", 0);
 	shader_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 
-	shader_editor->connect_compat("script_changed", this, "apply_shaders");
-	EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_editor_settings_changed");
+	shader_editor->connect("script_changed", callable_mp(this, &ShaderEditor::apply_shaders));
+	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &ShaderEditor::_editor_settings_changed));
 
 	shader_editor->get_text_edit()->set_callhint_settings(
 			EditorSettings::get_singleton()->get("text_editor/completion/put_callhint_tooltip_below_current_line"),
@@ -616,13 +606,13 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 
 	shader_editor->get_text_edit()->set_select_identifiers_on_hover(true);
 	shader_editor->get_text_edit()->set_context_menu_enabled(false);
-	shader_editor->get_text_edit()->connect_compat("gui_input", this, "_text_edit_gui_input");
+	shader_editor->get_text_edit()->connect("gui_input", callable_mp(this, &ShaderEditor::_text_edit_gui_input));
 
 	shader_editor->update_editor_settings();
 
 	context_menu = memnew(PopupMenu);
 	add_child(context_menu);
-	context_menu->connect_compat("id_pressed", this, "_menu_option");
+	context_menu->connect("id_pressed", callable_mp(this, &ShaderEditor::_menu_option));
 	context_menu->set_hide_on_window_lose_focus(true);
 
 	VBoxContainer *main_container = memnew(VBoxContainer);
@@ -650,7 +640,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/clone_down"), EDIT_CLONE_DOWN);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/complete_symbol"), EDIT_COMPLETE);
-	edit_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	edit_menu->get_popup()->connect("id_pressed", callable_mp(this, &ShaderEditor::_menu_option));
 
 	search_menu = memnew(MenuButton);
 	search_menu->set_text(TTR("Search"));
@@ -660,12 +650,12 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_previous"), SEARCH_FIND_PREV);
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace"), SEARCH_REPLACE);
-	search_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	search_menu->get_popup()->connect("id_pressed", callable_mp(this, &ShaderEditor::_menu_option));
 
 	MenuButton *goto_menu = memnew(MenuButton);
 	goto_menu->set_text(TTR("Go To"));
 	goto_menu->set_switch_on_hover(true);
-	goto_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	goto_menu->get_popup()->connect("id_pressed", callable_mp(this, &ShaderEditor::_menu_option));
 
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
 	goto_menu->get_popup()->add_separator();
@@ -675,14 +665,14 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	goto_menu->get_popup()->add_child(bookmarks_menu);
 	goto_menu->get_popup()->add_submenu_item(TTR("Bookmarks"), "Bookmarks");
 	_update_bookmark_list();
-	bookmarks_menu->connect_compat("about_to_show", this, "_update_bookmark_list");
-	bookmarks_menu->connect_compat("index_pressed", this, "_bookmark_item_pressed");
+	bookmarks_menu->connect("about_to_show", callable_mp(this, &ShaderEditor::_update_bookmark_list));
+	bookmarks_menu->connect("index_pressed", callable_mp(this, &ShaderEditor::_bookmark_item_pressed));
 
 	help_menu = memnew(MenuButton);
 	help_menu->set_text(TTR("Help"));
 	help_menu->set_switch_on_hover(true);
 	help_menu->get_popup()->add_icon_item(p_node->get_gui_base()->get_icon("Instance", "EditorIcons"), TTR("Online Docs"), HELP_DOCS);
-	help_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	help_menu->get_popup()->connect("id_pressed", callable_mp(this, &ShaderEditor::_menu_option));
 
 	add_child(main_container);
 	main_container->add_child(hbc);
@@ -705,11 +695,11 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	dl->set_text(TTR("This shader has been modified on on disk.\nWhat action should be taken?"));
 	vbc->add_child(dl);
 
-	disk_changed->connect_compat("confirmed", this, "_reload_shader_from_disk");
+	disk_changed->connect("confirmed", callable_mp(this, &ShaderEditor::_reload_shader_from_disk));
 	disk_changed->get_ok()->set_text(TTR("Reload"));
 
 	disk_changed->add_button(TTR("Resave"), !OS::get_singleton()->get_swap_ok_cancel(), "resave");
-	disk_changed->connect_compat("custom_action", this, "save_external_data");
+	disk_changed->connect("custom_action", callable_mp(this, &ShaderEditor::save_external_data));
 
 	add_child(disk_changed);
 

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -92,8 +92,6 @@ void Skeleton2DEditor::_menu_option(int p_option) {
 }
 
 void Skeleton2DEditor::_bind_methods() {
-
-	ClassDB::bind_method("_menu_option", &Skeleton2DEditor::_menu_option);
 }
 
 Skeleton2DEditor::Skeleton2DEditor() {
@@ -110,7 +108,7 @@ Skeleton2DEditor::Skeleton2DEditor() {
 	options->get_popup()->add_item(TTR("Set Bones to Rest Pose"), MENU_OPTION_SET_REST);
 	options->set_switch_on_hover(true);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", callable_mp(this, &Skeleton2DEditor::_menu_option));
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);

--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -137,7 +137,7 @@ void SkeletonEditor::edit(Skeleton *p_node) {
 
 void SkeletonEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		get_tree()->connect_compat("node_removed", this, "_node_removed");
+		get_tree()->connect("node_removed", callable_mp(this, &SkeletonEditor::_node_removed));
 	}
 }
 
@@ -150,8 +150,6 @@ void SkeletonEditor::_node_removed(Node *p_node) {
 }
 
 void SkeletonEditor::_bind_methods() {
-	ClassDB::bind_method("_on_click_option", &SkeletonEditor::_on_click_option);
-	ClassDB::bind_method("_node_removed", &SkeletonEditor::_node_removed);
 }
 
 SkeletonEditor::SkeletonEditor() {
@@ -164,7 +162,7 @@ SkeletonEditor::SkeletonEditor() {
 
 	options->get_popup()->add_item(TTR("Create physical skeleton"), MENU_OPTION_CREATE_PHYSICAL_SKELETON);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_on_click_option");
+	options->get_popup()->connect("id_pressed", callable_mp(this, &SkeletonEditor::_on_click_option));
 	options->hide();
 }
 

--- a/editor/plugins/skeleton_ik_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_editor_plugin.cpp
@@ -81,8 +81,6 @@ void SkeletonIKEditorPlugin::make_visible(bool p_visible) {
 }
 
 void SkeletonIKEditorPlugin::_bind_methods() {
-
-	ClassDB::bind_method("_play", &SkeletonIKEditorPlugin::_play);
 }
 
 SkeletonIKEditorPlugin::SkeletonIKEditorPlugin(EditorNode *p_node) {
@@ -93,7 +91,7 @@ SkeletonIKEditorPlugin::SkeletonIKEditorPlugin(EditorNode *p_node) {
 	play_btn->set_text(TTR("Play IK"));
 	play_btn->set_toggle_mode(true);
 	play_btn->hide();
-	play_btn->connect_compat("pressed", this, "_play");
+	play_btn->connect("pressed", callable_mp(this, &SkeletonIKEditorPlugin::_play));
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, play_btn);
 	skeleton_ik = NULL;
 }

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2187,10 +2187,10 @@ void SpatialEditorViewport::_notification(int p_what) {
 			if (cam != NULL && cam != previewing) {
 				//then switch the viewport's camera to the scene's viewport camera
 				if (previewing != NULL) {
-					previewing->disconnect_compat("tree_exited", this, "_preview_exited_scene");
+					previewing->disconnect("tree_exited", callable_mp(this, &SpatialEditorViewport::_preview_exited_scene));
 				}
 				previewing = cam;
-				previewing->connect_compat("tree_exited", this, "_preview_exited_scene");
+				previewing->connect("tree_exited", callable_mp(this, &SpatialEditorViewport::_preview_exited_scene));
 				VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), cam->get_camera());
 				surface->update();
 			}
@@ -2331,12 +2331,12 @@ void SpatialEditorViewport::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		surface->connect_compat("draw", this, "_draw");
-		surface->connect_compat("gui_input", this, "_sinput");
-		surface->connect_compat("mouse_entered", this, "_surface_mouse_enter");
-		surface->connect_compat("mouse_exited", this, "_surface_mouse_exit");
-		surface->connect_compat("focus_entered", this, "_surface_focus_enter");
-		surface->connect_compat("focus_exited", this, "_surface_focus_exit");
+		surface->connect("draw", callable_mp(this, &SpatialEditorViewport::_draw));
+		surface->connect("gui_input", callable_mp(this, &SpatialEditorViewport::_sinput));
+		surface->connect("mouse_entered", callable_mp(this, &SpatialEditorViewport::_surface_mouse_enter));
+		surface->connect("mouse_exited", callable_mp(this, &SpatialEditorViewport::_surface_mouse_exit));
+		surface->connect("focus_entered", callable_mp(this, &SpatialEditorViewport::_surface_focus_enter));
+		surface->connect("focus_exited", callable_mp(this, &SpatialEditorViewport::_surface_focus_exit));
 
 		_init_gizmo_instance(index);
 	}
@@ -2837,10 +2837,10 @@ void SpatialEditorViewport::_menu_option(int p_option) {
 
 void SpatialEditorViewport::_preview_exited_scene() {
 
-	preview_camera->disconnect_compat("toggled", this, "_toggle_camera_preview");
+	preview_camera->disconnect("toggled", callable_mp(this, &SpatialEditorViewport::_toggle_camera_preview));
 	preview_camera->set_pressed(false);
 	_toggle_camera_preview(false);
-	preview_camera->connect_compat("toggled", this, "_toggle_camera_preview");
+	preview_camera->connect("toggled", callable_mp(this, &SpatialEditorViewport::_toggle_camera_preview));
 	view_menu->show();
 }
 
@@ -2903,7 +2903,7 @@ void SpatialEditorViewport::_toggle_camera_preview(bool p_activate) {
 
 	if (!p_activate) {
 
-		previewing->disconnect_compat("tree_exiting", this, "_preview_exited_scene");
+		previewing->disconnect("tree_exiting", callable_mp(this, &SpatialEditorViewport::_preview_exited_scene));
 		previewing = NULL;
 		VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
 		if (!preview)
@@ -2914,7 +2914,7 @@ void SpatialEditorViewport::_toggle_camera_preview(bool p_activate) {
 	} else {
 
 		previewing = preview;
-		previewing->connect_compat("tree_exiting", this, "_preview_exited_scene");
+		previewing->connect("tree_exiting", callable_mp(this, &SpatialEditorViewport::_preview_exited_scene));
 		VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), preview->get_camera()); //replace
 		view_menu->set_disabled(true);
 		surface->update();
@@ -2925,7 +2925,7 @@ void SpatialEditorViewport::_toggle_cinema_preview(bool p_activate) {
 	previewing_cinema = p_activate;
 	if (!previewing_cinema) {
 		if (previewing != NULL)
-			previewing->disconnect_compat("tree_exited", this, "_preview_exited_scene");
+			previewing->disconnect("tree_exited", callable_mp(this, &SpatialEditorViewport::_preview_exited_scene));
 
 		previewing = NULL;
 		VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
@@ -3110,14 +3110,14 @@ void SpatialEditorViewport::set_state(const Dictionary &p_state) {
 		view_menu->get_popup()->set_item_checked(idx, previewing_cinema);
 	}
 
-	if (preview_camera->is_connected_compat("toggled", this, "_toggle_camera_preview")) {
-		preview_camera->disconnect_compat("toggled", this, "_toggle_camera_preview");
+	if (preview_camera->is_connected("toggled", callable_mp(this, &SpatialEditorViewport::_toggle_camera_preview))) {
+		preview_camera->disconnect("toggled", callable_mp(this, &SpatialEditorViewport::_toggle_camera_preview));
 	}
 	if (p_state.has("previewing")) {
 		Node *pv = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["previewing"]);
 		if (Object::cast_to<Camera>(pv)) {
 			previewing = Object::cast_to<Camera>(pv);
-			previewing->connect_compat("tree_exiting", this, "_preview_exited_scene");
+			previewing->connect("tree_exiting", callable_mp(this, &SpatialEditorViewport::_preview_exited_scene));
 			VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), previewing->get_camera()); //replace
 			view_menu->set_disabled(true);
 			surface->update();
@@ -3125,7 +3125,7 @@ void SpatialEditorViewport::set_state(const Dictionary &p_state) {
 			preview_camera->show();
 		}
 	}
-	preview_camera->connect_compat("toggled", this, "_toggle_camera_preview");
+	preview_camera->connect("toggled", callable_mp(this, &SpatialEditorViewport::_toggle_camera_preview));
 }
 
 Dictionary SpatialEditorViewport::get_state() const {
@@ -3162,19 +3162,6 @@ Dictionary SpatialEditorViewport::get_state() const {
 
 void SpatialEditorViewport::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_draw"), &SpatialEditorViewport::_draw);
-
-	ClassDB::bind_method(D_METHOD("_surface_mouse_enter"), &SpatialEditorViewport::_surface_mouse_enter);
-	ClassDB::bind_method(D_METHOD("_surface_mouse_exit"), &SpatialEditorViewport::_surface_mouse_exit);
-	ClassDB::bind_method(D_METHOD("_surface_focus_enter"), &SpatialEditorViewport::_surface_focus_enter);
-	ClassDB::bind_method(D_METHOD("_surface_focus_exit"), &SpatialEditorViewport::_surface_focus_exit);
-	ClassDB::bind_method(D_METHOD("_sinput"), &SpatialEditorViewport::_sinput);
-	ClassDB::bind_method(D_METHOD("_menu_option"), &SpatialEditorViewport::_menu_option);
-	ClassDB::bind_method(D_METHOD("_toggle_camera_preview"), &SpatialEditorViewport::_toggle_camera_preview);
-	ClassDB::bind_method(D_METHOD("_preview_exited_scene"), &SpatialEditorViewport::_preview_exited_scene);
-	ClassDB::bind_method(D_METHOD("update_transform_gizmo_view"), &SpatialEditorViewport::update_transform_gizmo_view);
-	ClassDB::bind_method(D_METHOD("_selection_result_pressed"), &SpatialEditorViewport::_selection_result_pressed);
-	ClassDB::bind_method(D_METHOD("_selection_menu_hide"), &SpatialEditorViewport::_selection_menu_hide);
 	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &SpatialEditorViewport::can_drop_data_fw);
 	ClassDB::bind_method(D_METHOD("drop_data_fw"), &SpatialEditorViewport::drop_data_fw);
 
@@ -3684,8 +3671,8 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
 	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
 	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);
-	view_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
-	display_submenu->connect_compat("id_pressed", this, "_menu_option");
+	view_menu->get_popup()->connect("id_pressed", callable_mp(this, &SpatialEditorViewport::_menu_option));
+	display_submenu->connect("id_pressed", callable_mp(this, &SpatialEditorViewport::_menu_option));
 	view_menu->set_disable_shortcuts(true);
 
 	if (OS::get_singleton()->get_current_video_driver() == OS::VIDEO_DRIVER_GLES2) {
@@ -3720,7 +3707,7 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	vbox->add_child(preview_camera);
 	preview_camera->set_h_size_flags(0);
 	preview_camera->hide();
-	preview_camera->connect_compat("toggled", this, "_toggle_camera_preview");
+	preview_camera->connect("toggled", callable_mp(this, &SpatialEditorViewport::_toggle_camera_preview));
 	previewing = NULL;
 	gizmo_scale = 1.0;
 
@@ -3773,8 +3760,8 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	selection_menu = memnew(PopupMenu);
 	add_child(selection_menu);
 	selection_menu->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
-	selection_menu->connect_compat("id_pressed", this, "_selection_result_pressed");
-	selection_menu->connect_compat("popup_hide", this, "_selection_menu_hide");
+	selection_menu->connect("id_pressed", callable_mp(this, &SpatialEditorViewport::_selection_result_pressed));
+	selection_menu->connect("popup_hide", callable_mp(this, &SpatialEditorViewport::_selection_menu_hide));
 
 	if (p_index == 0) {
 		view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_AUDIO_LISTENER), true);
@@ -3784,7 +3771,7 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	name = "";
 	_update_name();
 
-	EditorSettings::get_singleton()->connect_compat("settings_changed", this, "update_transform_gizmo_view");
+	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &SpatialEditorViewport::update_transform_gizmo_view));
 }
 
 //////////////////////////////////////////////////////////////
@@ -5471,12 +5458,12 @@ void SpatialEditor::_notification(int p_what) {
 
 		_refresh_menu_icons();
 
-		get_tree()->connect_compat("node_removed", this, "_node_removed");
-		EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->connect_compat("node_changed", this, "_refresh_menu_icons");
-		editor_selection->connect_compat("selection_changed", this, "_refresh_menu_icons");
+		get_tree()->connect("node_removed", callable_mp(this, &SpatialEditor::_node_removed));
+		EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->connect("node_changed", callable_mp(this, &SpatialEditor::_refresh_menu_icons));
+		editor_selection->connect("selection_changed", callable_mp(this, &SpatialEditor::_refresh_menu_icons));
 
-		editor->connect_compat("stop_pressed", this, "_update_camera_override_button", make_binds(false));
-		editor->connect_compat("play_pressed", this, "_update_camera_override_button", make_binds(true));
+		editor->connect("stop_pressed", callable_mp(this, &SpatialEditor::_update_camera_override_button), make_binds(false));
+		editor->connect("play_pressed", callable_mp(this, &SpatialEditor::_update_camera_override_button), make_binds(true));
 	} else if (p_what == NOTIFICATION_ENTER_TREE) {
 
 		_register_all_gizmos();
@@ -5653,17 +5640,8 @@ void SpatialEditor::_register_all_gizmos() {
 void SpatialEditor::_bind_methods() {
 
 	ClassDB::bind_method("_unhandled_key_input", &SpatialEditor::_unhandled_key_input);
-	ClassDB::bind_method("_node_removed", &SpatialEditor::_node_removed);
-	ClassDB::bind_method("_menu_item_pressed", &SpatialEditor::_menu_item_pressed);
-	ClassDB::bind_method("_menu_gizmo_toggled", &SpatialEditor::_menu_gizmo_toggled);
-	ClassDB::bind_method("_menu_item_toggled", &SpatialEditor::_menu_item_toggled);
-	ClassDB::bind_method("_xform_dialog_action", &SpatialEditor::_xform_dialog_action);
 	ClassDB::bind_method("_get_editor_data", &SpatialEditor::_get_editor_data);
 	ClassDB::bind_method("_request_gizmo", &SpatialEditor::_request_gizmo);
-	ClassDB::bind_method("_toggle_maximize_view", &SpatialEditor::_toggle_maximize_view);
-	ClassDB::bind_method("_refresh_menu_icons", &SpatialEditor::_refresh_menu_icons);
-	ClassDB::bind_method("_update_camera_override_button", &SpatialEditor::_update_camera_override_button);
-	ClassDB::bind_method("_update_camera_override_viewport", &SpatialEditor::_update_camera_override_viewport);
 
 	ADD_SIGNAL(MethodInfo("transform_key_request"));
 	ADD_SIGNAL(MethodInfo("item_lock_status_changed"));
@@ -5732,7 +5710,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SELECT]->set_flat(true);
 	tool_button[TOOL_MODE_SELECT]->set_pressed(true);
 	button_binds.write[0] = MENU_TOOL_SELECT;
-	tool_button[TOOL_MODE_SELECT]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_SELECT]->connect("pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_SELECT]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_select", TTR("Select Mode"), KEY_Q));
 	tool_button[TOOL_MODE_SELECT]->set_tooltip(keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate\nAlt+Drag: Move\nAlt+RMB: Depth list selection"));
 
@@ -5743,7 +5721,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_MOVE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_MOVE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_MOVE;
-	tool_button[TOOL_MODE_MOVE]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_MOVE]->connect("pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_MOVE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_move", TTR("Move Mode"), KEY_W));
 
 	tool_button[TOOL_MODE_ROTATE] = memnew(ToolButton);
@@ -5751,7 +5729,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_ROTATE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_ROTATE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_ROTATE;
-	tool_button[TOOL_MODE_ROTATE]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_ROTATE]->connect("pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_ROTATE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_rotate", TTR("Rotate Mode"), KEY_E));
 
 	tool_button[TOOL_MODE_SCALE] = memnew(ToolButton);
@@ -5759,7 +5737,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SCALE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_SCALE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_SCALE;
-	tool_button[TOOL_MODE_SCALE]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_SCALE]->connect("pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_SCALE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_scale", TTR("Scale Mode"), KEY_R));
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -5769,31 +5747,31 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_LIST_SELECT]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_LIST_SELECT;
-	tool_button[TOOL_MODE_LIST_SELECT]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_LIST_SELECT]->connect("pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_tooltip(TTR("Show a list of all objects at the position clicked\n(same as Alt+RMB in select mode)."));
 
 	tool_button[TOOL_LOCK_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_LOCK_SELECTED]);
 	button_binds.write[0] = MENU_LOCK_SELECTED;
-	tool_button[TOOL_LOCK_SELECTED]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_LOCK_SELECTED]->connect("pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_LOCK_SELECTED]->set_tooltip(TTR("Lock the selected object in place (can't be moved)."));
 
 	tool_button[TOOL_UNLOCK_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_UNLOCK_SELECTED]);
 	button_binds.write[0] = MENU_UNLOCK_SELECTED;
-	tool_button[TOOL_UNLOCK_SELECTED]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_UNLOCK_SELECTED]->connect("pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_UNLOCK_SELECTED]->set_tooltip(TTR("Unlock the selected object (can be moved)."));
 
 	tool_button[TOOL_GROUP_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_GROUP_SELECTED]);
 	button_binds.write[0] = MENU_GROUP_SELECTED;
-	tool_button[TOOL_GROUP_SELECTED]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_GROUP_SELECTED]->connect("pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_GROUP_SELECTED]->set_tooltip(TTR("Makes sure the object's children are not selectable."));
 
 	tool_button[TOOL_UNGROUP_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_UNGROUP_SELECTED]);
 	button_binds.write[0] = MENU_UNGROUP_SELECTED;
-	tool_button[TOOL_UNGROUP_SELECTED]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_UNGROUP_SELECTED]->connect("pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_UNGROUP_SELECTED]->set_tooltip(TTR("Restores the object's children's ability to be selected."));
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -5803,7 +5781,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_LOCAL_COORDS;
-	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect_compat("toggled", this, "_menu_item_toggled", button_binds);
+	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect("toggled", callable_mp(this, &SpatialEditor::_menu_item_toggled), button_binds);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_shortcut(ED_SHORTCUT("spatial_editor/local_coords", TTR("Use Local Space"), KEY_T));
 
 	tool_option_button[TOOL_OPT_USE_SNAP] = memnew(ToolButton);
@@ -5811,7 +5789,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_USE_SNAP;
-	tool_option_button[TOOL_OPT_USE_SNAP]->connect_compat("toggled", this, "_menu_item_toggled", button_binds);
+	tool_option_button[TOOL_OPT_USE_SNAP]->connect("toggled", callable_mp(this, &SpatialEditor::_menu_item_toggled), button_binds);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_shortcut(ED_SHORTCUT("spatial_editor/snap", TTR("Use Snap"), KEY_Y));
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -5822,7 +5800,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->set_flat(true);
 	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->set_disabled(true);
 	button_binds.write[0] = MENU_TOOL_OVERRIDE_CAMERA;
-	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->connect_compat("toggled", this, "_menu_item_toggled", button_binds);
+	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->connect("toggled", callable_mp(this, &SpatialEditor::_menu_item_toggled), button_binds);
 	_update_camera_override_button(false);
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -5859,7 +5837,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("spatial_editor/configure_snap", TTR("Configure Snap...")), MENU_TRANSFORM_CONFIGURE_SNAP);
 
-	p->connect_compat("id_pressed", this, "_menu_item_pressed");
+	p->connect("id_pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed));
 
 	view_menu = memnew(MenuButton);
 	view_menu->set_text(TTR("View"));
@@ -5891,13 +5869,13 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	p->set_item_checked(p->get_item_index(MENU_VIEW_ORIGIN), true);
 	p->set_item_checked(p->get_item_index(MENU_VIEW_GRID), true);
 
-	p->connect_compat("id_pressed", this, "_menu_item_pressed");
+	p->connect("id_pressed", callable_mp(this, &SpatialEditor::_menu_item_pressed));
 
 	gizmos_menu = memnew(PopupMenu);
 	p->add_child(gizmos_menu);
 	gizmos_menu->set_name("GizmosMenu");
 	gizmos_menu->set_hide_on_checkable_item_selection(false);
-	gizmos_menu->connect_compat("id_pressed", this, "_menu_gizmo_toggled");
+	gizmos_menu->connect("id_pressed", callable_mp(this, &SpatialEditor::_menu_gizmo_toggled));
 
 	/* REST OF MENU */
 
@@ -5914,8 +5892,8 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
 
 		viewports[i] = memnew(SpatialEditorViewport(this, editor, i));
-		viewports[i]->connect_compat("toggle_maximize_view", this, "_toggle_maximize_view");
-		viewports[i]->connect_compat("clicked", this, "_update_camera_override_viewport");
+		viewports[i]->connect("toggle_maximize_view", callable_mp(this, &SpatialEditor::_toggle_maximize_view));
+		viewports[i]->connect("clicked", callable_mp(this, &SpatialEditor::_update_camera_override_viewport));
 		viewports[i]->assign_pending_data_pointers(preview_node, &preview_bounds, accept);
 		viewport_base->add_child(viewports[i]);
 	}
@@ -6030,7 +6008,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	xform_type->add_item(TTR("Post"));
 	xform_vbc->add_child(xform_type);
 
-	xform_dialog->connect_compat("confirmed", this, "_xform_dialog_action");
+	xform_dialog->connect("confirmed", callable_mp(this, &SpatialEditor::_xform_dialog_action));
 
 	scenario_debug = VisualServer::SCENARIO_DEBUG_DISABLED;
 

--- a/editor/plugins/sprite_editor_plugin.cpp
+++ b/editor/plugins/sprite_editor_plugin.cpp
@@ -504,10 +504,6 @@ void SpriteEditor::_debug_uv_draw() {
 
 void SpriteEditor::_bind_methods() {
 
-	ClassDB::bind_method("_menu_option", &SpriteEditor::_menu_option);
-	ClassDB::bind_method("_debug_uv_draw", &SpriteEditor::_debug_uv_draw);
-	ClassDB::bind_method("_update_mesh_data", &SpriteEditor::_update_mesh_data);
-	ClassDB::bind_method("_create_node", &SpriteEditor::_create_node);
 	ClassDB::bind_method("_add_as_sibling_or_child", &SpriteEditor::_add_as_sibling_or_child);
 }
 
@@ -526,7 +522,7 @@ SpriteEditor::SpriteEditor() {
 	options->get_popup()->add_item(TTR("Create LightOccluder2D Sibling"), MENU_OPTION_CREATE_LIGHT_OCCLUDER_2D);
 	options->set_switch_on_hover(true);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", callable_mp(this, &SpriteEditor::_menu_option));
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
@@ -542,9 +538,9 @@ SpriteEditor::SpriteEditor() {
 	scroll->set_enable_v_scroll(true);
 	vb->add_margin_child(TTR("Preview:"), scroll, true);
 	debug_uv = memnew(Control);
-	debug_uv->connect_compat("draw", this, "_debug_uv_draw");
+	debug_uv->connect("draw", callable_mp(this, &SpriteEditor::_debug_uv_draw));
 	scroll->add_child(debug_uv);
-	debug_uv_dialog->connect_compat("confirmed", this, "_create_node");
+	debug_uv_dialog->connect("confirmed", callable_mp(this, &SpriteEditor::_create_node));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->add_child(memnew(Label(TTR("Simplification: "))));
@@ -573,7 +569,7 @@ SpriteEditor::SpriteEditor() {
 	hb->add_spacer();
 	update_preview = memnew(Button);
 	update_preview->set_text(TTR("Update Preview"));
-	update_preview->connect_compat("pressed", this, "_update_mesh_data");
+	update_preview->connect("pressed", callable_mp(this, &SpriteEditor::_update_mesh_data));
 	hb->add_child(update_preview);
 	vb->add_margin_child(TTR("Settings:"), hb);
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -860,33 +860,10 @@ void SpriteFramesEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 
 void SpriteFramesEditor::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_load_pressed"), &SpriteFramesEditor::_load_pressed);
-	ClassDB::bind_method(D_METHOD("_empty_pressed"), &SpriteFramesEditor::_empty_pressed);
-	ClassDB::bind_method(D_METHOD("_empty2_pressed"), &SpriteFramesEditor::_empty2_pressed);
-	ClassDB::bind_method(D_METHOD("_delete_pressed"), &SpriteFramesEditor::_delete_pressed);
-	ClassDB::bind_method(D_METHOD("_copy_pressed"), &SpriteFramesEditor::_copy_pressed);
-	ClassDB::bind_method(D_METHOD("_paste_pressed"), &SpriteFramesEditor::_paste_pressed);
-	ClassDB::bind_method(D_METHOD("_file_load_request", "files", "at_position"), &SpriteFramesEditor::_file_load_request, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("_update_library", "skipsel"), &SpriteFramesEditor::_update_library, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("_up_pressed"), &SpriteFramesEditor::_up_pressed);
-	ClassDB::bind_method(D_METHOD("_down_pressed"), &SpriteFramesEditor::_down_pressed);
-	ClassDB::bind_method(D_METHOD("_animation_select"), &SpriteFramesEditor::_animation_select);
-	ClassDB::bind_method(D_METHOD("_animation_name_edited"), &SpriteFramesEditor::_animation_name_edited);
-	ClassDB::bind_method(D_METHOD("_animation_add"), &SpriteFramesEditor::_animation_add);
-	ClassDB::bind_method(D_METHOD("_animation_remove"), &SpriteFramesEditor::_animation_remove);
-	ClassDB::bind_method(D_METHOD("_animation_remove_confirmed"), &SpriteFramesEditor::_animation_remove_confirmed);
-	ClassDB::bind_method(D_METHOD("_animation_loop_changed"), &SpriteFramesEditor::_animation_loop_changed);
-	ClassDB::bind_method(D_METHOD("_animation_fps_changed"), &SpriteFramesEditor::_animation_fps_changed);
 	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &SpriteFramesEditor::get_drag_data_fw);
 	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &SpriteFramesEditor::can_drop_data_fw);
 	ClassDB::bind_method(D_METHOD("drop_data_fw"), &SpriteFramesEditor::drop_data_fw);
-	ClassDB::bind_method(D_METHOD("_prepare_sprite_sheet"), &SpriteFramesEditor::_prepare_sprite_sheet);
-	ClassDB::bind_method(D_METHOD("_open_sprite_sheet"), &SpriteFramesEditor::_open_sprite_sheet);
-	ClassDB::bind_method(D_METHOD("_sheet_preview_draw"), &SpriteFramesEditor::_sheet_preview_draw);
-	ClassDB::bind_method(D_METHOD("_sheet_preview_input"), &SpriteFramesEditor::_sheet_preview_input);
-	ClassDB::bind_method(D_METHOD("_sheet_spin_changed"), &SpriteFramesEditor::_sheet_spin_changed);
-	ClassDB::bind_method(D_METHOD("_sheet_add_frames"), &SpriteFramesEditor::_sheet_add_frames);
-	ClassDB::bind_method(D_METHOD("_sheet_select_clear_all_frames"), &SpriteFramesEditor::_sheet_select_clear_all_frames);
 }
 
 SpriteFramesEditor::SpriteFramesEditor() {
@@ -905,19 +882,19 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	new_anim = memnew(ToolButton);
 	new_anim->set_tooltip(TTR("New Animation"));
 	hbc_animlist->add_child(new_anim);
-	new_anim->connect_compat("pressed", this, "_animation_add");
+	new_anim->connect("pressed", callable_mp(this, &SpriteFramesEditor::_animation_add));
 
 	remove_anim = memnew(ToolButton);
 	remove_anim->set_tooltip(TTR("Remove Animation"));
 	hbc_animlist->add_child(remove_anim);
-	remove_anim->connect_compat("pressed", this, "_animation_remove");
+	remove_anim->connect("pressed", callable_mp(this, &SpriteFramesEditor::_animation_remove));
 
 	animations = memnew(Tree);
 	sub_vb->add_child(animations);
 	animations->set_v_size_flags(SIZE_EXPAND_FILL);
 	animations->set_hide_root(true);
-	animations->connect_compat("cell_selected", this, "_animation_select");
-	animations->connect_compat("item_edited", this, "_animation_name_edited");
+	animations->connect("cell_selected", callable_mp(this, &SpriteFramesEditor::_animation_select));
+	animations->connect("item_edited", callable_mp(this, &SpriteFramesEditor::_animation_name_edited));
 	animations->set_allow_reselect(true);
 
 	anim_speed = memnew(SpinBox);
@@ -925,12 +902,12 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	anim_speed->set_min(0);
 	anim_speed->set_max(100);
 	anim_speed->set_step(0.01);
-	anim_speed->connect_compat("value_changed", this, "_animation_fps_changed");
+	anim_speed->connect("value_changed", callable_mp(this, &SpriteFramesEditor::_animation_fps_changed));
 
 	anim_loop = memnew(CheckButton);
 	anim_loop->set_text(TTR("Loop"));
 	vbc_animlist->add_child(anim_loop);
-	anim_loop->connect_compat("pressed", this, "_animation_loop_changed");
+	anim_loop->connect("pressed", callable_mp(this, &SpriteFramesEditor::_animation_loop_changed));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
@@ -1004,16 +981,16 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	dialog = memnew(AcceptDialog);
 	add_child(dialog);
 
-	load->connect_compat("pressed", this, "_load_pressed");
-	load_sheet->connect_compat("pressed", this, "_open_sprite_sheet");
-	_delete->connect_compat("pressed", this, "_delete_pressed");
-	copy->connect_compat("pressed", this, "_copy_pressed");
-	paste->connect_compat("pressed", this, "_paste_pressed");
-	empty->connect_compat("pressed", this, "_empty_pressed");
-	empty2->connect_compat("pressed", this, "_empty2_pressed");
-	move_up->connect_compat("pressed", this, "_up_pressed");
-	move_down->connect_compat("pressed", this, "_down_pressed");
-	file->connect_compat("files_selected", this, "_file_load_request");
+	load->connect("pressed", callable_mp(this, &SpriteFramesEditor::_load_pressed));
+	load_sheet->connect("pressed", callable_mp(this, &SpriteFramesEditor::_open_sprite_sheet));
+	_delete->connect("pressed", callable_mp(this, &SpriteFramesEditor::_delete_pressed));
+	copy->connect("pressed", callable_mp(this, &SpriteFramesEditor::_copy_pressed));
+	paste->connect("pressed", callable_mp(this, &SpriteFramesEditor::_paste_pressed));
+	empty->connect("pressed", callable_mp(this, &SpriteFramesEditor::_empty_pressed));
+	empty2->connect("pressed", callable_mp(this, &SpriteFramesEditor::_empty2_pressed));
+	move_up->connect("pressed", callable_mp(this, &SpriteFramesEditor::_up_pressed));
+	move_down->connect("pressed", callable_mp(this, &SpriteFramesEditor::_down_pressed));
+	file->connect("files_selected", callable_mp(this, &SpriteFramesEditor::_file_load_request));
 	loading_scene = false;
 	sel = -1;
 
@@ -1023,14 +1000,14 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	delete_dialog = memnew(ConfirmationDialog);
 	add_child(delete_dialog);
-	delete_dialog->connect_compat("confirmed", this, "_animation_remove_confirmed");
+	delete_dialog->connect("confirmed", callable_mp(this, &SpriteFramesEditor::_animation_remove_confirmed));
 
 	split_sheet_dialog = memnew(ConfirmationDialog);
 	add_child(split_sheet_dialog);
 	VBoxContainer *split_sheet_vb = memnew(VBoxContainer);
 	split_sheet_dialog->add_child(split_sheet_vb);
 	split_sheet_dialog->set_title(TTR("Select Frames"));
-	split_sheet_dialog->connect_compat("confirmed", this, "_sheet_add_frames");
+	split_sheet_dialog->connect("confirmed", callable_mp(this, &SpriteFramesEditor::_sheet_add_frames));
 
 	HBoxContainer *split_sheet_hb = memnew(HBoxContainer);
 
@@ -1041,7 +1018,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_h->set_max(128);
 	split_sheet_h->set_step(1);
 	split_sheet_hb->add_child(split_sheet_h);
-	split_sheet_h->connect_compat("value_changed", this, "_sheet_spin_changed");
+	split_sheet_h->connect("value_changed", callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed));
 
 	ss_label = memnew(Label(TTR("Vertical:")));
 	split_sheet_hb->add_child(ss_label);
@@ -1050,13 +1027,13 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_v->set_max(128);
 	split_sheet_v->set_step(1);
 	split_sheet_hb->add_child(split_sheet_v);
-	split_sheet_v->connect_compat("value_changed", this, "_sheet_spin_changed");
+	split_sheet_v->connect("value_changed", callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed));
 
 	split_sheet_hb->add_spacer();
 
 	Button *select_clear_all = memnew(Button);
 	select_clear_all->set_text(TTR("Select/Clear All Frames"));
-	select_clear_all->connect_compat("pressed", this, "_sheet_select_clear_all_frames");
+	select_clear_all->connect("pressed", callable_mp(this, &SpriteFramesEditor::_sheet_select_clear_all_frames));
 	split_sheet_hb->add_child(select_clear_all);
 
 	split_sheet_vb->add_child(split_sheet_hb);
@@ -1064,8 +1041,8 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_preview = memnew(TextureRect);
 	split_sheet_preview->set_expand(false);
 	split_sheet_preview->set_mouse_filter(MOUSE_FILTER_PASS);
-	split_sheet_preview->connect_compat("draw", this, "_sheet_preview_draw");
-	split_sheet_preview->connect_compat("gui_input", this, "_sheet_preview_input");
+	split_sheet_preview->connect("draw", callable_mp(this, &SpriteFramesEditor::_sheet_preview_draw));
+	split_sheet_preview->connect("gui_input", callable_mp(this, &SpriteFramesEditor::_sheet_preview_input));
 
 	splite_sheet_scroll = memnew(ScrollContainer);
 	splite_sheet_scroll->set_enable_h_scroll(true);
@@ -1083,7 +1060,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	file_split_sheet->set_title(TTR("Create Frames from Sprite Sheet"));
 	file_split_sheet->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	add_child(file_split_sheet);
-	file_split_sheet->connect_compat("file_selected", this, "_prepare_sprite_sheet");
+	file_split_sheet->connect("file_selected", callable_mp(this, &SpriteFramesEditor::_prepare_sprite_sheet));
 }
 
 void SpriteFramesEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -54,11 +54,11 @@ void EditorInspectorPluginStyleBox::parse_end() {
 void StyleBoxPreview::edit(const Ref<StyleBox> &p_stylebox) {
 
 	if (stylebox.is_valid())
-		stylebox->disconnect_compat("changed", this, "_sb_changed");
+		stylebox->disconnect("changed", callable_mp(this, &StyleBoxPreview::_sb_changed));
 	stylebox = p_stylebox;
 	if (p_stylebox.is_valid()) {
 		preview->add_style_override("panel", stylebox);
-		stylebox->connect_compat("changed", this, "_sb_changed");
+		stylebox->connect("changed", callable_mp(this, &StyleBoxPreview::_sb_changed));
 	}
 	_sb_changed();
 }
@@ -82,16 +82,13 @@ void StyleBoxPreview::_redraw() {
 }
 
 void StyleBoxPreview::_bind_methods() {
-
-	ClassDB::bind_method("_sb_changed", &StyleBoxPreview::_sb_changed);
-	ClassDB::bind_method("_redraw", &StyleBoxPreview::_redraw);
 }
 
 StyleBoxPreview::StyleBoxPreview() {
 	preview = memnew(Control);
 	preview->set_custom_minimum_size(Size2(0, 150 * EDSCALE));
 	preview->set_clip_contents(true);
-	preview->connect_compat("draw", this, "_redraw");
+	preview->connect("draw", callable_mp(this, &StyleBoxPreview::_redraw));
 	add_margin_child(TTR("Preview:"), preview);
 }
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -526,14 +526,6 @@ void TextEditor::_convert_case(CodeTextEditor::CaseStyle p_case) {
 }
 
 void TextEditor::_bind_methods() {
-
-	ClassDB::bind_method("_validate_script", &TextEditor::_validate_script);
-	ClassDB::bind_method("_update_bookmark_list", &TextEditor::_update_bookmark_list);
-	ClassDB::bind_method("_bookmark_item_pressed", &TextEditor::_bookmark_item_pressed);
-	ClassDB::bind_method("_load_theme_settings", &TextEditor::_load_theme_settings);
-	ClassDB::bind_method("_edit_option", &TextEditor::_edit_option);
-	ClassDB::bind_method("_change_syntax_highlighter", &TextEditor::_change_syntax_highlighter);
-	ClassDB::bind_method("_text_edit_gui_input", &TextEditor::_text_edit_gui_input);
 }
 
 static ScriptEditorBase *create_editor(const RES &p_resource) {
@@ -633,19 +625,19 @@ TextEditor::TextEditor() {
 	code_editor = memnew(CodeTextEditor);
 	add_child(code_editor);
 	code_editor->add_constant_override("separation", 0);
-	code_editor->connect_compat("load_theme_settings", this, "_load_theme_settings");
-	code_editor->connect_compat("validate_script", this, "_validate_script");
+	code_editor->connect("load_theme_settings", callable_mp(this, &TextEditor::_load_theme_settings));
+	code_editor->connect("validate_script", callable_mp(this, &TextEditor::_validate_script));
 	code_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	code_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	update_settings();
 
 	code_editor->get_text_edit()->set_context_menu_enabled(false);
-	code_editor->get_text_edit()->connect_compat("gui_input", this, "_text_edit_gui_input");
+	code_editor->get_text_edit()->connect("gui_input", callable_mp(this, &TextEditor::_text_edit_gui_input));
 
 	context_menu = memnew(PopupMenu);
 	add_child(context_menu);
-	context_menu->connect_compat("id_pressed", this, "_edit_option");
+	context_menu->connect("id_pressed", callable_mp(this, &TextEditor::_edit_option));
 
 	edit_hb = memnew(HBoxContainer);
 
@@ -653,7 +645,7 @@ TextEditor::TextEditor() {
 	edit_hb->add_child(search_menu);
 	search_menu->set_text(TTR("Search"));
 	search_menu->set_switch_on_hover(true);
-	search_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	search_menu->get_popup()->connect("id_pressed", callable_mp(this, &TextEditor::_edit_option));
 
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
@@ -667,7 +659,7 @@ TextEditor::TextEditor() {
 	edit_hb->add_child(edit_menu);
 	edit_menu->set_text(TTR("Edit"));
 	edit_menu->set_switch_on_hover(true);
-	edit_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	edit_menu->get_popup()->connect("id_pressed", callable_mp(this, &TextEditor::_edit_option));
 
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"), EDIT_UNDO);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/redo"), EDIT_REDO);
@@ -700,7 +692,7 @@ TextEditor::TextEditor() {
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/convert_to_uppercase", TTR("Uppercase")), EDIT_TO_UPPERCASE);
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/convert_to_lowercase", TTR("Lowercase")), EDIT_TO_LOWERCASE);
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/capitalize", TTR("Capitalize")), EDIT_CAPITALIZE);
-	convert_case->connect_compat("id_pressed", this, "_edit_option");
+	convert_case->connect("id_pressed", callable_mp(this, &TextEditor::_edit_option));
 
 	highlighters["Standard"] = NULL;
 	highlighter_menu = memnew(PopupMenu);
@@ -708,13 +700,13 @@ TextEditor::TextEditor() {
 	edit_menu->get_popup()->add_child(highlighter_menu);
 	edit_menu->get_popup()->add_submenu_item(TTR("Syntax Highlighter"), "highlighter_menu");
 	highlighter_menu->add_radio_check_item(TTR("Standard"));
-	highlighter_menu->connect_compat("id_pressed", this, "_change_syntax_highlighter");
+	highlighter_menu->connect("id_pressed", callable_mp(this, &TextEditor::_change_syntax_highlighter));
 
 	MenuButton *goto_menu = memnew(MenuButton);
 	edit_hb->add_child(goto_menu);
 	goto_menu->set_text(TTR("Go To"));
 	goto_menu->set_switch_on_hover(true);
-	goto_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	goto_menu->get_popup()->connect("id_pressed", callable_mp(this, &TextEditor::_edit_option));
 
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
 	goto_menu->get_popup()->add_separator();
@@ -724,8 +716,8 @@ TextEditor::TextEditor() {
 	goto_menu->get_popup()->add_child(bookmarks_menu);
 	goto_menu->get_popup()->add_submenu_item(TTR("Bookmarks"), "Bookmarks");
 	_update_bookmark_list();
-	bookmarks_menu->connect_compat("about_to_show", this, "_update_bookmark_list");
-	bookmarks_menu->connect_compat("index_pressed", this, "_bookmark_item_pressed");
+	bookmarks_menu->connect("about_to_show", callable_mp(this, &TextEditor::_update_bookmark_list));
+	bookmarks_menu->connect("index_pressed", callable_mp(this, &TextEditor::_bookmark_item_pressed));
 
 	goto_line_dialog = memnew(GotoLineDialog);
 	add_child(goto_line_dialog);

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -778,21 +778,8 @@ void TextureRegionEditor::_node_removed(Object *p_obj) {
 
 void TextureRegionEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_edit_region"), &TextureRegionEditor::_edit_region);
-	ClassDB::bind_method(D_METHOD("_region_draw"), &TextureRegionEditor::_region_draw);
-	ClassDB::bind_method(D_METHOD("_region_input"), &TextureRegionEditor::_region_input);
-	ClassDB::bind_method(D_METHOD("_scroll_changed"), &TextureRegionEditor::_scroll_changed);
 	ClassDB::bind_method(D_METHOD("_node_removed"), &TextureRegionEditor::_node_removed);
-	ClassDB::bind_method(D_METHOD("_set_snap_mode"), &TextureRegionEditor::_set_snap_mode);
-	ClassDB::bind_method(D_METHOD("_set_snap_off_x"), &TextureRegionEditor::_set_snap_off_x);
-	ClassDB::bind_method(D_METHOD("_set_snap_off_y"), &TextureRegionEditor::_set_snap_off_y);
-	ClassDB::bind_method(D_METHOD("_set_snap_step_x"), &TextureRegionEditor::_set_snap_step_x);
-	ClassDB::bind_method(D_METHOD("_set_snap_step_y"), &TextureRegionEditor::_set_snap_step_y);
-	ClassDB::bind_method(D_METHOD("_set_snap_sep_x"), &TextureRegionEditor::_set_snap_sep_x);
-	ClassDB::bind_method(D_METHOD("_set_snap_sep_y"), &TextureRegionEditor::_set_snap_sep_y);
 	ClassDB::bind_method(D_METHOD("_zoom_on_position"), &TextureRegionEditor::_zoom_on_position);
-	ClassDB::bind_method(D_METHOD("_zoom_in"), &TextureRegionEditor::_zoom_in);
-	ClassDB::bind_method(D_METHOD("_zoom_reset"), &TextureRegionEditor::_zoom_reset);
-	ClassDB::bind_method(D_METHOD("_zoom_out"), &TextureRegionEditor::_zoom_out);
 	ClassDB::bind_method(D_METHOD("_update_rect"), &TextureRegionEditor::_update_rect);
 }
 
@@ -935,7 +922,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	snap_mode_button->add_item(TTR("Grid Snap"), 2);
 	snap_mode_button->add_item(TTR("Auto Slice"), 3);
 	snap_mode_button->select(0);
-	snap_mode_button->connect_compat("item_selected", this, "_set_snap_mode");
+	snap_mode_button->connect("item_selected", callable_mp(this, &TextureRegionEditor::_set_snap_mode));
 
 	hb_grid = memnew(HBoxContainer);
 	hb_tools->add_child(hb_grid);
@@ -949,7 +936,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_off_x->set_step(1);
 	sb_off_x->set_value(snap_offset.x);
 	sb_off_x->set_suffix("px");
-	sb_off_x->connect_compat("value_changed", this, "_set_snap_off_x");
+	sb_off_x->connect("value_changed", callable_mp(this, &TextureRegionEditor::_set_snap_off_x));
 	hb_grid->add_child(sb_off_x);
 
 	sb_off_y = memnew(SpinBox);
@@ -958,7 +945,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_off_y->set_step(1);
 	sb_off_y->set_value(snap_offset.y);
 	sb_off_y->set_suffix("px");
-	sb_off_y->connect_compat("value_changed", this, "_set_snap_off_y");
+	sb_off_y->connect("value_changed", callable_mp(this, &TextureRegionEditor::_set_snap_off_y));
 	hb_grid->add_child(sb_off_y);
 
 	hb_grid->add_child(memnew(VSeparator));
@@ -970,7 +957,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_step_x->set_step(1);
 	sb_step_x->set_value(snap_step.x);
 	sb_step_x->set_suffix("px");
-	sb_step_x->connect_compat("value_changed", this, "_set_snap_step_x");
+	sb_step_x->connect("value_changed", callable_mp(this, &TextureRegionEditor::_set_snap_step_x));
 	hb_grid->add_child(sb_step_x);
 
 	sb_step_y = memnew(SpinBox);
@@ -979,7 +966,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_step_y->set_step(1);
 	sb_step_y->set_value(snap_step.y);
 	sb_step_y->set_suffix("px");
-	sb_step_y->connect_compat("value_changed", this, "_set_snap_step_y");
+	sb_step_y->connect("value_changed", callable_mp(this, &TextureRegionEditor::_set_snap_step_y));
 	hb_grid->add_child(sb_step_y);
 
 	hb_grid->add_child(memnew(VSeparator));
@@ -991,7 +978,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_sep_x->set_step(1);
 	sb_sep_x->set_value(snap_separation.x);
 	sb_sep_x->set_suffix("px");
-	sb_sep_x->connect_compat("value_changed", this, "_set_snap_sep_x");
+	sb_sep_x->connect("value_changed", callable_mp(this, &TextureRegionEditor::_set_snap_sep_x));
 	hb_grid->add_child(sb_sep_x);
 
 	sb_sep_y = memnew(SpinBox);
@@ -1000,7 +987,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_sep_y->set_step(1);
 	sb_sep_y->set_value(snap_separation.y);
 	sb_sep_y->set_suffix("px");
-	sb_sep_y->connect_compat("value_changed", this, "_set_snap_sep_y");
+	sb_sep_y->connect("value_changed", callable_mp(this, &TextureRegionEditor::_set_snap_sep_y));
 	hb_grid->add_child(sb_sep_y);
 
 	hb_grid->hide();
@@ -1008,8 +995,8 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	edit_draw = memnew(Panel);
 	add_child(edit_draw);
 	edit_draw->set_v_size_flags(SIZE_EXPAND_FILL);
-	edit_draw->connect_compat("draw", this, "_region_draw");
-	edit_draw->connect_compat("gui_input", this, "_region_input");
+	edit_draw->connect("draw", callable_mp(this, &TextureRegionEditor::_region_draw));
+	edit_draw->connect("gui_input", callable_mp(this, &TextureRegionEditor::_region_input));
 
 	draw_zoom = 1.0;
 	edit_draw->set_clip_contents(true);
@@ -1020,27 +1007,27 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 
 	zoom_out = memnew(ToolButton);
 	zoom_out->set_tooltip(TTR("Zoom Out"));
-	zoom_out->connect_compat("pressed", this, "_zoom_out");
+	zoom_out->connect("pressed", callable_mp(this, &TextureRegionEditor::_zoom_out));
 	zoom_hb->add_child(zoom_out);
 
 	zoom_reset = memnew(ToolButton);
 	zoom_reset->set_tooltip(TTR("Zoom Reset"));
-	zoom_reset->connect_compat("pressed", this, "_zoom_reset");
+	zoom_reset->connect("pressed", callable_mp(this, &TextureRegionEditor::_zoom_reset));
 	zoom_hb->add_child(zoom_reset);
 
 	zoom_in = memnew(ToolButton);
 	zoom_in->set_tooltip(TTR("Zoom In"));
-	zoom_in->connect_compat("pressed", this, "_zoom_in");
+	zoom_in->connect("pressed", callable_mp(this, &TextureRegionEditor::_zoom_in));
 	zoom_hb->add_child(zoom_in);
 
 	vscroll = memnew(VScrollBar);
 	vscroll->set_step(0.001);
 	edit_draw->add_child(vscroll);
-	vscroll->connect_compat("value_changed", this, "_scroll_changed");
+	vscroll->connect("value_changed", callable_mp(this, &TextureRegionEditor::_scroll_changed));
 	hscroll = memnew(HScrollBar);
 	hscroll->set_step(0.001);
 	edit_draw->add_child(hscroll);
-	hscroll->connect_compat("value_changed", this, "_scroll_changed");
+	hscroll->connect("value_changed", callable_mp(this, &TextureRegionEditor::_scroll_changed));
 
 	updating_scroll = false;
 }
@@ -1115,7 +1102,6 @@ void TextureRegionEditorPlugin::set_state(const Dictionary &p_state) {
 }
 
 void TextureRegionEditorPlugin::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_editor_visiblity_changed"), &TextureRegionEditorPlugin::_editor_visiblity_changed);
 }
 
 TextureRegionEditorPlugin::TextureRegionEditorPlugin(EditorNode *p_node) {
@@ -1125,7 +1111,7 @@ TextureRegionEditorPlugin::TextureRegionEditorPlugin(EditorNode *p_node) {
 	region_editor = memnew(TextureRegionEditor(p_node));
 	region_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	region_editor->hide();
-	region_editor->connect_compat("visibility_changed", this, "_editor_visiblity_changed");
+	region_editor->connect("visibility_changed", callable_mp(this, &TextureRegionEditorPlugin::_editor_visiblity_changed));
 
 	texture_region_button = p_node->add_bottom_panel_item(TTR("TextureRegion"), region_editor);
 	texture_region_button->hide();

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -598,13 +598,6 @@ void ThemeEditor::_notification(int p_what) {
 }
 
 void ThemeEditor::_bind_methods() {
-
-	ClassDB::bind_method("_type_menu_cbk", &ThemeEditor::_type_menu_cbk);
-	ClassDB::bind_method("_name_menu_about_to_show", &ThemeEditor::_name_menu_about_to_show);
-	ClassDB::bind_method("_name_menu_cbk", &ThemeEditor::_name_menu_cbk);
-	ClassDB::bind_method("_theme_menu_cbk", &ThemeEditor::_theme_menu_cbk);
-	ClassDB::bind_method("_dialog_cbk", &ThemeEditor::_dialog_cbk);
-	ClassDB::bind_method("_save_template_cbk", &ThemeEditor::_save_template_cbk);
 }
 
 ThemeEditor::ThemeEditor() {
@@ -629,7 +622,7 @@ ThemeEditor::ThemeEditor() {
 	theme_menu->get_popup()->add_item(TTR("Create Empty Editor Template"), POPUP_CREATE_EDITOR_EMPTY);
 	theme_menu->get_popup()->add_item(TTR("Create From Current Editor Theme"), POPUP_IMPORT_EDITOR_THEME);
 	top_menu->add_child(theme_menu);
-	theme_menu->get_popup()->connect_compat("id_pressed", this, "_theme_menu_cbk");
+	theme_menu->get_popup()->connect("id_pressed", callable_mp(this, &ThemeEditor::_theme_menu_cbk));
 
 	ScrollContainer *scroll = memnew(ScrollContainer);
 	add_child(scroll);
@@ -835,7 +828,7 @@ ThemeEditor::ThemeEditor() {
 	type_menu->set_text("..");
 	type_hbc->add_child(type_menu);
 
-	type_menu->get_popup()->connect_compat("id_pressed", this, "_type_menu_cbk");
+	type_menu->get_popup()->connect("id_pressed", callable_mp(this, &ThemeEditor::_type_menu_cbk));
 
 	l = memnew(Label);
 	l->set_text(TTR("Name:"));
@@ -853,8 +846,8 @@ ThemeEditor::ThemeEditor() {
 	name_menu->set_text("..");
 	name_hbc->add_child(name_menu);
 
-	name_menu->get_popup()->connect_compat("about_to_show", this, "_name_menu_about_to_show");
-	name_menu->get_popup()->connect_compat("id_pressed", this, "_name_menu_cbk");
+	name_menu->get_popup()->connect("about_to_show", callable_mp(this, &ThemeEditor::_name_menu_about_to_show));
+	name_menu->get_popup()->connect("id_pressed", callable_mp(this, &ThemeEditor::_name_menu_cbk));
 
 	type_select_label = memnew(Label);
 	type_select_label->set_text(TTR("Data Type:"));
@@ -869,12 +862,12 @@ ThemeEditor::ThemeEditor() {
 
 	dialog_vbc->add_child(type_select);
 
-	add_del_dialog->get_ok()->connect_compat("pressed", this, "_dialog_cbk");
+	add_del_dialog->get_ok()->connect("pressed", callable_mp(this, &ThemeEditor::_dialog_cbk));
 
 	file_dialog = memnew(EditorFileDialog);
 	file_dialog->add_filter("*.theme ; " + TTR("Theme File"));
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_save_template_cbk");
+	file_dialog->connect("file_selected", callable_mp(this, &ThemeEditor::_save_template_cbk));
 }
 
 void ThemeEditorPlugin::edit(Object *p_node) {

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -1761,30 +1761,30 @@ void TileMapEditor::edit(Node *p_tile_map) {
 	}
 
 	if (node)
-		node->disconnect_compat("settings_changed", this, "_tileset_settings_changed");
+		node->disconnect("settings_changed", callable_mp(this, &TileMapEditor::_tileset_settings_changed));
 	if (p_tile_map) {
 
 		node = Object::cast_to<TileMap>(p_tile_map);
-		if (!canvas_item_editor_viewport->is_connected_compat("mouse_entered", this, "_canvas_mouse_enter"))
-			canvas_item_editor_viewport->connect_compat("mouse_entered", this, "_canvas_mouse_enter");
-		if (!canvas_item_editor_viewport->is_connected_compat("mouse_exited", this, "_canvas_mouse_exit"))
-			canvas_item_editor_viewport->connect_compat("mouse_exited", this, "_canvas_mouse_exit");
+		if (!canvas_item_editor_viewport->is_connected("mouse_entered", callable_mp(this, &TileMapEditor::_canvas_mouse_enter)))
+			canvas_item_editor_viewport->connect("mouse_entered", callable_mp(this, &TileMapEditor::_canvas_mouse_enter));
+		if (!canvas_item_editor_viewport->is_connected("mouse_exited", callable_mp(this, &TileMapEditor::_canvas_mouse_exit)))
+			canvas_item_editor_viewport->connect("mouse_exited", callable_mp(this, &TileMapEditor::_canvas_mouse_exit));
 
 		_update_palette();
 
 	} else {
 		node = NULL;
 
-		if (canvas_item_editor_viewport->is_connected_compat("mouse_entered", this, "_canvas_mouse_enter"))
-			canvas_item_editor_viewport->disconnect_compat("mouse_entered", this, "_canvas_mouse_enter");
-		if (canvas_item_editor_viewport->is_connected_compat("mouse_exited", this, "_canvas_mouse_exit"))
-			canvas_item_editor_viewport->disconnect_compat("mouse_exited", this, "_canvas_mouse_exit");
+		if (canvas_item_editor_viewport->is_connected("mouse_entered", callable_mp(this, &TileMapEditor::_canvas_mouse_enter)))
+			canvas_item_editor_viewport->disconnect("mouse_entered", callable_mp(this, &TileMapEditor::_canvas_mouse_enter));
+		if (canvas_item_editor_viewport->is_connected("mouse_exited", callable_mp(this, &TileMapEditor::_canvas_mouse_exit)))
+			canvas_item_editor_viewport->disconnect("mouse_exited", callable_mp(this, &TileMapEditor::_canvas_mouse_exit));
 
 		_update_palette();
 	}
 
 	if (node)
-		node->connect_compat("settings_changed", this, "_tileset_settings_changed");
+		node->connect("settings_changed", callable_mp(this, &TileMapEditor::_tileset_settings_changed));
 
 	_clear_bucket_cache();
 }
@@ -1805,27 +1805,8 @@ void TileMapEditor::_icon_size_changed(float p_value) {
 
 void TileMapEditor::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_manual_toggled"), &TileMapEditor::_manual_toggled);
-	ClassDB::bind_method(D_METHOD("_priority_toggled"), &TileMapEditor::_priority_toggled);
-	ClassDB::bind_method(D_METHOD("_text_entered"), &TileMapEditor::_text_entered);
-	ClassDB::bind_method(D_METHOD("_text_changed"), &TileMapEditor::_text_changed);
-	ClassDB::bind_method(D_METHOD("_sbox_input"), &TileMapEditor::_sbox_input);
-	ClassDB::bind_method(D_METHOD("_button_tool_select"), &TileMapEditor::_button_tool_select);
-	ClassDB::bind_method(D_METHOD("_menu_option"), &TileMapEditor::_menu_option);
-	ClassDB::bind_method(D_METHOD("_canvas_mouse_enter"), &TileMapEditor::_canvas_mouse_enter);
-	ClassDB::bind_method(D_METHOD("_canvas_mouse_exit"), &TileMapEditor::_canvas_mouse_exit);
-	ClassDB::bind_method(D_METHOD("_tileset_settings_changed"), &TileMapEditor::_tileset_settings_changed);
-	ClassDB::bind_method(D_METHOD("_rotate"), &TileMapEditor::_rotate);
-	ClassDB::bind_method(D_METHOD("_flip_horizontal"), &TileMapEditor::_flip_horizontal);
-	ClassDB::bind_method(D_METHOD("_flip_vertical"), &TileMapEditor::_flip_vertical);
-	ClassDB::bind_method(D_METHOD("_clear_transform"), &TileMapEditor::_clear_transform);
-	ClassDB::bind_method(D_METHOD("_palette_selected"), &TileMapEditor::_palette_selected);
-	ClassDB::bind_method(D_METHOD("_palette_multi_selected"), &TileMapEditor::_palette_multi_selected);
-
 	ClassDB::bind_method(D_METHOD("_fill_points"), &TileMapEditor::_fill_points);
 	ClassDB::bind_method(D_METHOD("_erase_points"), &TileMapEditor::_erase_points);
-
-	ClassDB::bind_method(D_METHOD("_icon_size_changed"), &TileMapEditor::_icon_size_changed);
 }
 
 TileMapEditor::CellOp TileMapEditor::_get_op_from_cell(const Point2i &p_pos) {
@@ -1939,20 +1920,20 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 
 	manual_button = memnew(CheckBox);
 	manual_button->set_text(TTR("Disable Autotile"));
-	manual_button->connect_compat("toggled", this, "_manual_toggled");
+	manual_button->connect("toggled", callable_mp(this, &TileMapEditor::_manual_toggled));
 	add_child(manual_button);
 
 	priority_button = memnew(CheckBox);
 	priority_button->set_text(TTR("Enable Priority"));
-	priority_button->connect_compat("toggled", this, "_priority_toggled");
+	priority_button->connect("toggled", callable_mp(this, &TileMapEditor::_priority_toggled));
 	add_child(priority_button);
 
 	search_box = memnew(LineEdit);
 	search_box->set_placeholder(TTR("Filter tiles"));
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	search_box->connect_compat("text_entered", this, "_text_entered");
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_entered", callable_mp(this, &TileMapEditor::_text_entered));
+	search_box->connect("text_changed", callable_mp(this, &TileMapEditor::_text_changed));
+	search_box->connect("gui_input", callable_mp(this, &TileMapEditor::_sbox_input));
 	add_child(search_box);
 
 	size_slider = memnew(HSlider);
@@ -1961,7 +1942,7 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	size_slider->set_max(4.0f);
 	size_slider->set_step(0.1f);
 	size_slider->set_value(1.0f);
-	size_slider->connect_compat("value_changed", this, "_icon_size_changed");
+	size_slider->connect("value_changed", callable_mp(this, &TileMapEditor::_icon_size_changed));
 	add_child(size_slider);
 
 	int mw = EDITOR_DEF("editors/tile_map/palette_min_width", 80);
@@ -1980,8 +1961,8 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	palette->set_max_text_lines(2);
 	palette->set_select_mode(ItemList::SELECT_MULTI);
 	palette->add_constant_override("vseparation", 8 * EDSCALE);
-	palette->connect_compat("item_selected", this, "_palette_selected");
-	palette->connect_compat("multi_selected", this, "_palette_multi_selected");
+	palette->connect("item_selected", callable_mp(this, &TileMapEditor::_palette_selected));
+	palette->connect("multi_selected", callable_mp(this, &TileMapEditor::_palette_multi_selected));
 	palette_container->add_child(palette);
 
 	// Add message for when no texture is selected.
@@ -2015,25 +1996,25 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	paint_button = memnew(ToolButton);
 	paint_button->set_shortcut(ED_SHORTCUT("tile_map_editor/paint_tile", TTR("Paint Tile"), KEY_P));
 	paint_button->set_tooltip(TTR("Shift+LMB: Line Draw\nShift+Ctrl+LMB: Rectangle Paint"));
-	paint_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_NONE));
+	paint_button->connect("pressed", callable_mp(this, &TileMapEditor::_button_tool_select), make_binds(TOOL_NONE));
 	paint_button->set_toggle_mode(true);
 	toolbar->add_child(paint_button);
 
 	bucket_fill_button = memnew(ToolButton);
 	bucket_fill_button->set_shortcut(ED_SHORTCUT("tile_map_editor/bucket_fill", TTR("Bucket Fill"), KEY_G));
-	bucket_fill_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_BUCKET));
+	bucket_fill_button->connect("pressed", callable_mp(this, &TileMapEditor::_button_tool_select), make_binds(TOOL_BUCKET));
 	bucket_fill_button->set_toggle_mode(true);
 	toolbar->add_child(bucket_fill_button);
 
 	picker_button = memnew(ToolButton);
 	picker_button->set_shortcut(ED_SHORTCUT("tile_map_editor/pick_tile", TTR("Pick Tile"), KEY_I));
-	picker_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_PICKING));
+	picker_button->connect("pressed", callable_mp(this, &TileMapEditor::_button_tool_select), make_binds(TOOL_PICKING));
 	picker_button->set_toggle_mode(true);
 	toolbar->add_child(picker_button);
 
 	select_button = memnew(ToolButton);
 	select_button->set_shortcut(ED_SHORTCUT("tile_map_editor/select", TTR("Select"), KEY_M));
-	select_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_SELECTING));
+	select_button->connect("pressed", callable_mp(this, &TileMapEditor::_button_tool_select), make_binds(TOOL_SELECTING));
 	select_button->set_toggle_mode(true);
 	toolbar->add_child(select_button);
 
@@ -2068,40 +2049,40 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	p->add_shortcut(ED_GET_SHORTCUT("tile_map_editor/erase_selection"), OPTION_ERASE_SELECTION);
 	p->add_separator();
 	p->add_item(TTR("Fix Invalid Tiles"), OPTION_FIX_INVALID);
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", callable_mp(this, &TileMapEditor::_menu_option));
 
 	rotate_left_button = memnew(ToolButton);
 	rotate_left_button->set_tooltip(TTR("Rotate Left"));
 	rotate_left_button->set_focus_mode(FOCUS_NONE);
-	rotate_left_button->connect_compat("pressed", this, "_rotate", varray(-1));
+	rotate_left_button->connect("pressed", callable_mp(this, &TileMapEditor::_rotate), varray(-1));
 	rotate_left_button->set_shortcut(ED_SHORTCUT("tile_map_editor/rotate_left", TTR("Rotate Left"), KEY_A));
 	tool_hb->add_child(rotate_left_button);
 
 	rotate_right_button = memnew(ToolButton);
 	rotate_right_button->set_tooltip(TTR("Rotate Right"));
 	rotate_right_button->set_focus_mode(FOCUS_NONE);
-	rotate_right_button->connect_compat("pressed", this, "_rotate", varray(1));
+	rotate_right_button->connect("pressed", callable_mp(this, &TileMapEditor::_rotate), varray(1));
 	rotate_right_button->set_shortcut(ED_SHORTCUT("tile_map_editor/rotate_right", TTR("Rotate Right"), KEY_S));
 	tool_hb->add_child(rotate_right_button);
 
 	flip_horizontal_button = memnew(ToolButton);
 	flip_horizontal_button->set_tooltip(TTR("Flip Horizontally"));
 	flip_horizontal_button->set_focus_mode(FOCUS_NONE);
-	flip_horizontal_button->connect_compat("pressed", this, "_flip_horizontal");
+	flip_horizontal_button->connect("pressed", callable_mp(this, &TileMapEditor::_flip_horizontal));
 	flip_horizontal_button->set_shortcut(ED_SHORTCUT("tile_map_editor/flip_horizontal", TTR("Flip Horizontally"), KEY_X));
 	tool_hb->add_child(flip_horizontal_button);
 
 	flip_vertical_button = memnew(ToolButton);
 	flip_vertical_button->set_tooltip(TTR("Flip Vertically"));
 	flip_vertical_button->set_focus_mode(FOCUS_NONE);
-	flip_vertical_button->connect_compat("pressed", this, "_flip_vertical");
+	flip_vertical_button->connect("pressed", callable_mp(this, &TileMapEditor::_flip_vertical));
 	flip_vertical_button->set_shortcut(ED_SHORTCUT("tile_map_editor/flip_vertical", TTR("Flip Vertically"), KEY_Z));
 	tool_hb->add_child(flip_vertical_button);
 
 	clear_transform_button = memnew(ToolButton);
 	clear_transform_button->set_tooltip(TTR("Clear Transform"));
 	clear_transform_button->set_focus_mode(FOCUS_NONE);
-	clear_transform_button->connect_compat("pressed", this, "_clear_transform");
+	clear_transform_button->connect("pressed", callable_mp(this, &TileMapEditor::_clear_transform));
 	clear_transform_button->set_shortcut(ED_SHORTCUT("tile_map_editor/clear_transform", TTR("Clear Transform"), KEY_W));
 	tool_hb->add_child(clear_transform_button);
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -260,7 +260,7 @@ void TileSetEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 void TileSetEditor::_bind_methods() {
 
 	ClassDB::bind_method("_undo_redo_import_scene", &TileSetEditor::_undo_redo_import_scene);
-	ClassDB::bind_method("_on_workspace_process", &TileSetEditor::_on_workspace_process);
+	ClassDB::bind_method("_on_workspace_process", &TileSetEditor::_on_workspace_process); // Still used by some connect_compat.
 	ClassDB::bind_method("_set_snap_step", &TileSetEditor::_set_snap_step);
 	ClassDB::bind_method("_set_snap_off", &TileSetEditor::_set_snap_off);
 	ClassDB::bind_method("_set_snap_sep", &TileSetEditor::_set_snap_sep);

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -260,27 +260,11 @@ void TileSetEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 void TileSetEditor::_bind_methods() {
 
 	ClassDB::bind_method("_undo_redo_import_scene", &TileSetEditor::_undo_redo_import_scene);
-	ClassDB::bind_method("_on_tileset_toolbar_button_pressed", &TileSetEditor::_on_tileset_toolbar_button_pressed);
-	ClassDB::bind_method("_on_textures_added", &TileSetEditor::_on_textures_added);
-	ClassDB::bind_method("_on_tileset_toolbar_confirm", &TileSetEditor::_on_tileset_toolbar_confirm);
-	ClassDB::bind_method("_on_texture_list_selected", &TileSetEditor::_on_texture_list_selected);
-	ClassDB::bind_method("_on_edit_mode_changed", &TileSetEditor::_on_edit_mode_changed);
-	ClassDB::bind_method("_on_workspace_mode_changed", &TileSetEditor::_on_workspace_mode_changed);
-	ClassDB::bind_method("_on_workspace_overlay_draw", &TileSetEditor::_on_workspace_overlay_draw);
 	ClassDB::bind_method("_on_workspace_process", &TileSetEditor::_on_workspace_process);
-	ClassDB::bind_method("_on_workspace_draw", &TileSetEditor::_on_workspace_draw);
-	ClassDB::bind_method("_on_workspace_input", &TileSetEditor::_on_workspace_input);
-	ClassDB::bind_method("_on_tool_clicked", &TileSetEditor::_on_tool_clicked);
-	ClassDB::bind_method("_on_priority_changed", &TileSetEditor::_on_priority_changed);
-	ClassDB::bind_method("_on_z_index_changed", &TileSetEditor::_on_z_index_changed);
-	ClassDB::bind_method("_on_grid_snap_toggled", &TileSetEditor::_on_grid_snap_toggled);
 	ClassDB::bind_method("_set_snap_step", &TileSetEditor::_set_snap_step);
 	ClassDB::bind_method("_set_snap_off", &TileSetEditor::_set_snap_off);
 	ClassDB::bind_method("_set_snap_sep", &TileSetEditor::_set_snap_sep);
 	ClassDB::bind_method("_validate_current_tile_id", &TileSetEditor::_validate_current_tile_id);
-	ClassDB::bind_method("_zoom_in", &TileSetEditor::_zoom_in);
-	ClassDB::bind_method("_zoom_out", &TileSetEditor::_zoom_out);
-	ClassDB::bind_method("_zoom_reset", &TileSetEditor::_zoom_reset);
 	ClassDB::bind_method("_select_edited_shape_coord", &TileSetEditor::_select_edited_shape_coord);
 	ClassDB::bind_method("_sort_tiles", &TileSetEditor::_sort_tiles);
 
@@ -358,19 +342,19 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	left_container->add_child(texture_list);
 	texture_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	texture_list->set_custom_minimum_size(Size2(200, 0));
-	texture_list->connect_compat("item_selected", this, "_on_texture_list_selected");
+	texture_list->connect("item_selected", callable_mp(this, &TileSetEditor::_on_texture_list_selected));
 	texture_list->set_drag_forwarding(this);
 
 	HBoxContainer *tileset_toolbar_container = memnew(HBoxContainer);
 	left_container->add_child(tileset_toolbar_container);
 
 	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE] = memnew(ToolButton);
-	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->connect_compat("pressed", this, "_on_tileset_toolbar_button_pressed", varray(TOOL_TILESET_ADD_TEXTURE));
+	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tileset_toolbar_button_pressed), varray(TOOL_TILESET_ADD_TEXTURE));
 	tileset_toolbar_container->add_child(tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]);
 	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->set_tooltip(TTR("Add Texture(s) to TileSet."));
 
 	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE] = memnew(ToolButton);
-	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->connect_compat("pressed", this, "_on_tileset_toolbar_button_pressed", varray(TOOL_TILESET_REMOVE_TEXTURE));
+	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tileset_toolbar_button_pressed), varray(TOOL_TILESET_REMOVE_TEXTURE));
 	tileset_toolbar_container->add_child(tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]);
 	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->set_tooltip(TTR("Remove selected Texture from TileSet."));
 
@@ -383,7 +367,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tileset_toolbar_tools->get_popup()->add_item(TTR("Create from Scene"), TOOL_TILESET_CREATE_SCENE);
 	tileset_toolbar_tools->get_popup()->add_item(TTR("Merge from Scene"), TOOL_TILESET_MERGE_SCENE);
 
-	tileset_toolbar_tools->get_popup()->connect_compat("id_pressed", this, "_on_tileset_toolbar_button_pressed");
+	tileset_toolbar_tools->get_popup()->connect("id_pressed", callable_mp(this, &TileSetEditor::_on_tileset_toolbar_button_pressed));
 	tileset_toolbar_container->add_child(tileset_toolbar_tools);
 
 	//---------------
@@ -416,7 +400,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 		tool_workspacemode[i]->set_text(workspace_label[i]);
 		tool_workspacemode[i]->set_toggle_mode(true);
 		tool_workspacemode[i]->set_button_group(g);
-		tool_workspacemode[i]->connect_compat("pressed", this, "_on_workspace_mode_changed", varray(i));
+		tool_workspacemode[i]->connect("pressed", callable_mp(this, &TileSetEditor::_on_workspace_mode_changed), varray(i));
 		tool_hb->add_child(tool_workspacemode[i]);
 	}
 
@@ -429,14 +413,14 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tool_hb->add_child(tools[SELECT_NEXT]);
 	tool_hb->move_child(tools[SELECT_NEXT], WORKSPACE_CREATE_SINGLE);
 	tools[SELECT_NEXT]->set_shortcut(ED_SHORTCUT("tileset_editor/next_shape", TTR("Next Coordinate"), KEY_PAGEDOWN));
-	tools[SELECT_NEXT]->connect_compat("pressed", this, "_on_tool_clicked", varray(SELECT_NEXT));
+	tools[SELECT_NEXT]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(SELECT_NEXT));
 	tools[SELECT_NEXT]->set_tooltip(TTR("Select the next shape, subtile, or Tile."));
 	tools[SELECT_PREVIOUS] = memnew(ToolButton);
 	tool_hb->add_child(tools[SELECT_PREVIOUS]);
 	tool_hb->move_child(tools[SELECT_PREVIOUS], WORKSPACE_CREATE_SINGLE);
 	tools[SELECT_PREVIOUS]->set_shortcut(ED_SHORTCUT("tileset_editor/previous_shape", TTR("Previous Coordinate"), KEY_PAGEUP));
 	tools[SELECT_PREVIOUS]->set_tooltip(TTR("Select the previous shape, subtile, or Tile."));
-	tools[SELECT_PREVIOUS]->connect_compat("pressed", this, "_on_tool_clicked", varray(SELECT_PREVIOUS));
+	tools[SELECT_PREVIOUS]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(SELECT_PREVIOUS));
 
 	VSeparator *separator_shape_selection = memnew(VSeparator);
 	tool_hb->add_child(separator_shape_selection);
@@ -466,7 +450,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 		tool_editmode[i]->set_text(label[i]);
 		tool_editmode[i]->set_toggle_mode(true);
 		tool_editmode[i]->set_button_group(g);
-		tool_editmode[i]->connect_compat("pressed", this, "_on_edit_mode_changed", varray(i));
+		tool_editmode[i]->connect("pressed", callable_mp(this, &TileSetEditor::_on_edit_mode_changed), varray(i));
 		tool_hb->add_child(tool_editmode[i]);
 	}
 	tool_editmode[EDITMODE_COLLISION]->set_pressed(true);
@@ -493,21 +477,21 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[TOOL_SELECT]->set_toggle_mode(true);
 	tools[TOOL_SELECT]->set_button_group(tg);
 	tools[TOOL_SELECT]->set_pressed(true);
-	tools[TOOL_SELECT]->connect_compat("pressed", this, "_on_tool_clicked", varray(TOOL_SELECT));
+	tools[TOOL_SELECT]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(TOOL_SELECT));
 
 	separator_bitmask = memnew(VSeparator);
 	toolbar->add_child(separator_bitmask);
 	tools[BITMASK_COPY] = memnew(ToolButton);
 	tools[BITMASK_COPY]->set_tooltip(TTR("Copy bitmask."));
-	tools[BITMASK_COPY]->connect_compat("pressed", this, "_on_tool_clicked", varray(BITMASK_COPY));
+	tools[BITMASK_COPY]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(BITMASK_COPY));
 	toolbar->add_child(tools[BITMASK_COPY]);
 	tools[BITMASK_PASTE] = memnew(ToolButton);
 	tools[BITMASK_PASTE]->set_tooltip(TTR("Paste bitmask."));
-	tools[BITMASK_PASTE]->connect_compat("pressed", this, "_on_tool_clicked", varray(BITMASK_PASTE));
+	tools[BITMASK_PASTE]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(BITMASK_PASTE));
 	toolbar->add_child(tools[BITMASK_PASTE]);
 	tools[BITMASK_CLEAR] = memnew(ToolButton);
 	tools[BITMASK_CLEAR]->set_tooltip(TTR("Erase bitmask."));
-	tools[BITMASK_CLEAR]->connect_compat("pressed", this, "_on_tool_clicked", varray(BITMASK_CLEAR));
+	tools[BITMASK_CLEAR]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(BITMASK_CLEAR));
 	toolbar->add_child(tools[BITMASK_CLEAR]);
 
 	tools[SHAPE_NEW_RECTANGLE] = memnew(ToolButton);
@@ -525,13 +509,13 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	separator_shape_toggle = memnew(VSeparator);
 	toolbar->add_child(separator_shape_toggle);
 	tools[SHAPE_TOGGLE_TYPE] = memnew(ToolButton);
-	tools[SHAPE_TOGGLE_TYPE]->connect_compat("pressed", this, "_on_tool_clicked", varray(SHAPE_TOGGLE_TYPE));
+	tools[SHAPE_TOGGLE_TYPE]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(SHAPE_TOGGLE_TYPE));
 	toolbar->add_child(tools[SHAPE_TOGGLE_TYPE]);
 
 	separator_delete = memnew(VSeparator);
 	toolbar->add_child(separator_delete);
 	tools[SHAPE_DELETE] = memnew(ToolButton);
-	tools[SHAPE_DELETE]->connect_compat("pressed", this, "_on_tool_clicked", varray(SHAPE_DELETE));
+	tools[SHAPE_DELETE]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(SHAPE_DELETE));
 	toolbar->add_child(tools[SHAPE_DELETE]);
 
 	spin_priority = memnew(SpinBox);
@@ -539,7 +523,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	spin_priority->set_max(255);
 	spin_priority->set_step(1);
 	spin_priority->set_custom_minimum_size(Size2(100, 0));
-	spin_priority->connect_compat("value_changed", this, "_on_priority_changed");
+	spin_priority->connect("value_changed", callable_mp(this, &TileSetEditor::_on_priority_changed));
 	spin_priority->hide();
 	toolbar->add_child(spin_priority);
 
@@ -548,7 +532,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	spin_z_index->set_max(VS::CANVAS_ITEM_Z_MAX);
 	spin_z_index->set_step(1);
 	spin_z_index->set_custom_minimum_size(Size2(100, 0));
-	spin_z_index->connect_compat("value_changed", this, "_on_z_index_changed");
+	spin_z_index->connect("value_changed", callable_mp(this, &TileSetEditor::_on_z_index_changed));
 	spin_z_index->hide();
 	toolbar->add_child(spin_z_index);
 
@@ -562,7 +546,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[TOOL_GRID_SNAP] = memnew(ToolButton);
 	tools[TOOL_GRID_SNAP]->set_toggle_mode(true);
 	tools[TOOL_GRID_SNAP]->set_tooltip(TTR("Enable snap and show grid (configurable via the Inspector)."));
-	tools[TOOL_GRID_SNAP]->connect_compat("toggled", this, "_on_grid_snap_toggled");
+	tools[TOOL_GRID_SNAP]->connect("toggled", callable_mp(this, &TileSetEditor::_on_grid_snap_toggled));
 	toolbar->add_child(tools[TOOL_GRID_SNAP]);
 
 	Control *separator = memnew(Control);
@@ -570,15 +554,15 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	toolbar->add_child(separator);
 
 	tools[ZOOM_OUT] = memnew(ToolButton);
-	tools[ZOOM_OUT]->connect_compat("pressed", this, "_zoom_out");
+	tools[ZOOM_OUT]->connect("pressed", callable_mp(this, &TileSetEditor::_zoom_out));
 	toolbar->add_child(tools[ZOOM_OUT]);
 	tools[ZOOM_OUT]->set_tooltip(TTR("Zoom Out"));
 	tools[ZOOM_1] = memnew(ToolButton);
-	tools[ZOOM_1]->connect_compat("pressed", this, "_zoom_reset");
+	tools[ZOOM_1]->connect("pressed", callable_mp(this, &TileSetEditor::_zoom_reset));
 	toolbar->add_child(tools[ZOOM_1]);
 	tools[ZOOM_1]->set_tooltip(TTR("Zoom Reset"));
 	tools[ZOOM_IN] = memnew(ToolButton);
-	tools[ZOOM_IN]->connect_compat("pressed", this, "_zoom_in");
+	tools[ZOOM_IN]->connect("pressed", callable_mp(this, &TileSetEditor::_zoom_in));
 	toolbar->add_child(tools[ZOOM_IN]);
 	tools[ZOOM_IN]->set_tooltip(TTR("Zoom In"));
 
@@ -607,13 +591,13 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	scroll->add_child(workspace_container);
 
 	workspace_overlay = memnew(Control);
-	workspace_overlay->connect_compat("draw", this, "_on_workspace_overlay_draw");
+	workspace_overlay->connect("draw", callable_mp(this, &TileSetEditor::_on_workspace_overlay_draw));
 	workspace_container->add_child(workspace_overlay);
 
 	workspace = memnew(Control);
 	workspace->set_focus_mode(FOCUS_ALL);
-	workspace->connect_compat("draw", this, "_on_workspace_draw");
-	workspace->connect_compat("gui_input", this, "_on_workspace_input");
+	workspace->connect("draw", callable_mp(this, &TileSetEditor::_on_workspace_draw));
+	workspace->connect("gui_input", callable_mp(this, &TileSetEditor::_on_workspace_input));
 	workspace->set_draw_behind_parent(true);
 	workspace_overlay->add_child(workspace);
 
@@ -626,7 +610,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	//---------------
 	cd = memnew(ConfirmationDialog);
 	add_child(cd);
-	cd->connect_compat("confirmed", this, "_on_tileset_toolbar_confirm");
+	cd->connect("confirmed", callable_mp(this, &TileSetEditor::_on_tileset_toolbar_confirm));
 
 	//---------------
 	err_dialog = memnew(AcceptDialog);
@@ -645,7 +629,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 		texture_dialog->add_filter("*." + E->get() + " ; " + E->get().to_upper());
 	}
 	add_child(texture_dialog);
-	texture_dialog->connect_compat("files_selected", this, "_on_textures_added");
+	texture_dialog->connect("files_selected", callable_mp(this, &TileSetEditor::_on_textures_added));
 
 	//---------------
 	helper = memnew(TilesetEditorContext(this));

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -39,14 +39,6 @@ VersionControlEditorPlugin *VersionControlEditorPlugin::singleton = NULL;
 
 void VersionControlEditorPlugin::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_selected_a_vcs"), &VersionControlEditorPlugin::_selected_a_vcs);
-	ClassDB::bind_method(D_METHOD("_initialize_vcs"), &VersionControlEditorPlugin::_initialize_vcs);
-	ClassDB::bind_method(D_METHOD("_send_commit_msg"), &VersionControlEditorPlugin::_send_commit_msg);
-	ClassDB::bind_method(D_METHOD("_refresh_stage_area"), &VersionControlEditorPlugin::_refresh_stage_area);
-	ClassDB::bind_method(D_METHOD("_stage_all"), &VersionControlEditorPlugin::_stage_all);
-	ClassDB::bind_method(D_METHOD("_stage_selected"), &VersionControlEditorPlugin::_stage_selected);
-	ClassDB::bind_method(D_METHOD("_view_file_diff"), &VersionControlEditorPlugin::_view_file_diff);
-	ClassDB::bind_method(D_METHOD("_refresh_file_diff"), &VersionControlEditorPlugin::_refresh_file_diff);
 	ClassDB::bind_method(D_METHOD("popup_vcs_set_up_dialog"), &VersionControlEditorPlugin::popup_vcs_set_up_dialog);
 
 	// Used to track the status of files in the staging area
@@ -127,7 +119,7 @@ void VersionControlEditorPlugin::_initialize_vcs() {
 	vcs_interface->set_script_and_instance(script, addon_script_instance);
 
 	EditorVCSInterface::set_singleton(vcs_interface);
-	EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "_refresh_stage_area");
+	EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area));
 
 	String res_dir = OS::get_singleton()->get_resource_dir();
 
@@ -388,8 +380,8 @@ void VersionControlEditorPlugin::clear_stage_area() {
 void VersionControlEditorPlugin::shut_down() {
 
 	if (EditorVCSInterface::get_singleton()) {
-		if (EditorFileSystem::get_singleton()->is_connected_compat("filesystem_changed", this, "_refresh_stage_area")) {
-			EditorFileSystem::get_singleton()->disconnect_compat("filesystem_changed", this, "_refresh_stage_area");
+		if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area))) {
+			EditorFileSystem::get_singleton()->disconnect("filesystem_changed", callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area));
 		}
 		EditorVCSInterface::get_singleton()->shut_down();
 		memdelete(EditorVCSInterface::get_singleton());
@@ -444,14 +436,14 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	set_up_choice = memnew(OptionButton);
 	set_up_choice->set_h_size_flags(HBoxContainer::SIZE_EXPAND_FILL);
-	set_up_choice->connect_compat("item_selected", this, "_selected_a_vcs");
+	set_up_choice->connect("item_selected", callable_mp(this, &VersionControlEditorPlugin::_selected_a_vcs));
 	set_up_hbc->add_child(set_up_choice);
 
 	set_up_init_settings = NULL;
 
 	set_up_init_button = memnew(Button);
 	set_up_init_button->set_text(TTR("Initialize"));
-	set_up_init_button->connect_compat("pressed", this, "_initialize_vcs");
+	set_up_init_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_initialize_vcs));
 	set_up_vbc->add_child(set_up_init_button);
 
 	version_control_actions->set_v_size_flags(PopupMenu::SIZE_EXPAND_FILL);
@@ -479,7 +471,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	refresh_button->set_tooltip(TTR("Detect new changes"));
 	refresh_button->set_text(TTR("Refresh"));
 	refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Reload", "EditorIcons"));
-	refresh_button->connect_compat("pressed", this, "_refresh_stage_area");
+	refresh_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area));
 	stage_tools->add_child(refresh_button);
 
 	stage_files = memnew(Tree);
@@ -492,7 +484,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	stage_files->set_allow_rmb_select(true);
 	stage_files->set_select_mode(Tree::SelectMode::SELECT_MULTI);
 	stage_files->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
-	stage_files->connect_compat("cell_selected", this, "_view_file_diff");
+	stage_files->connect("cell_selected", callable_mp(this, &VersionControlEditorPlugin::_view_file_diff));
 	stage_files->create_item();
 	stage_files->set_hide_root(true);
 	commit_box_vbc->add_child(stage_files);
@@ -516,12 +508,12 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	stage_selected_button = memnew(Button);
 	stage_selected_button->set_h_size_flags(Button::SIZE_EXPAND_FILL);
 	stage_selected_button->set_text(TTR("Stage Selected"));
-	stage_selected_button->connect_compat("pressed", this, "_stage_selected");
+	stage_selected_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_stage_selected));
 	stage_buttons->add_child(stage_selected_button);
 
 	stage_all_button = memnew(Button);
 	stage_all_button->set_text(TTR("Stage All"));
-	stage_all_button->connect_compat("pressed", this, "_stage_all");
+	stage_all_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_stage_all));
 	stage_buttons->add_child(stage_all_button);
 
 	commit_box_vbc->add_child(memnew(HSeparator));
@@ -537,7 +529,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	commit_button = memnew(Button);
 	commit_button->set_text(TTR("Commit Changes"));
-	commit_button->connect_compat("pressed", this, "_send_commit_msg");
+	commit_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_send_commit_msg));
 	commit_box_vbc->add_child(commit_button);
 
 	commit_status = memnew(Label);
@@ -571,7 +563,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	diff_refresh_button = memnew(Button);
 	diff_refresh_button->set_tooltip(TTR("Detect changes in file diff"));
 	diff_refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Reload", "EditorIcons"));
-	diff_refresh_button->connect_compat("pressed", this, "_refresh_file_diff");
+	diff_refresh_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_refresh_file_diff));
 	diff_hbc->add_child(diff_refresh_button);
 
 	diff = memnew(RichTextLabel);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -72,14 +72,14 @@ void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
 			}
 		}
 		visual_shader = Ref<VisualShader>(p_visual_shader);
-		if (!visual_shader->is_connected_compat("changed", this, "_update_preview")) {
-			visual_shader->connect_compat("changed", this, "_update_preview");
+		if (!visual_shader->is_connected("changed", callable_mp(this, &VisualShaderEditor::_update_preview))) {
+			visual_shader->connect("changed", callable_mp(this, &VisualShaderEditor::_update_preview));
 		}
 		visual_shader->set_graph_offset(graph->get_scroll_ofs() / EDSCALE);
 	} else {
 		if (visual_shader.is_valid()) {
 			if (visual_shader->is_connected_compat("changed", this, "")) {
-				visual_shader->disconnect_compat("changed", this, "_update_preview");
+				visual_shader->disconnect("changed", callable_mp(this, &VisualShaderEditor::_update_preview));
 			}
 		}
 		visual_shader.unref();
@@ -498,7 +498,7 @@ void VisualShaderEditor::_update_graph() {
 			size = group_node->get_size();
 
 			node->set_resizable(true);
-			node->connect_compat("resize_request", this, "_node_resized", varray((int)type, nodes[n_i]));
+			node->connect("resize_request", callable_mp(this, &VisualShaderEditor::_node_resized), varray((int)type, nodes[n_i]));
 		}
 		if (is_expression) {
 			expression = expression_node->get_expression();
@@ -515,10 +515,10 @@ void VisualShaderEditor::_update_graph() {
 
 		if (nodes[n_i] >= 2) {
 			node->set_show_close_button(true);
-			node->connect_compat("close_request", this, "_delete_request", varray(nodes[n_i]), CONNECT_DEFERRED);
+			node->connect("close_request", callable_mp(this, &VisualShaderEditor::_delete_request), varray(nodes[n_i]), CONNECT_DEFERRED);
 		}
 
-		node->connect_compat("dragged", this, "_node_dragged", varray(nodes[n_i]));
+		node->connect("dragged", callable_mp(this, &VisualShaderEditor::_node_dragged), varray(nodes[n_i]));
 
 		Control *custom_editor = NULL;
 		int port_offset = 0;
@@ -536,8 +536,8 @@ void VisualShaderEditor::_update_graph() {
 			LineEdit *uniform_name = memnew(LineEdit);
 			uniform_name->set_text(uniform->get_uniform_name());
 			node->add_child(uniform_name);
-			uniform_name->connect_compat("text_entered", this, "_line_edit_changed", varray(uniform_name, nodes[n_i]));
-			uniform_name->connect_compat("focus_exited", this, "_line_edit_focus_out", varray(uniform_name, nodes[n_i]));
+			uniform_name->connect("text_entered", callable_mp(this, &VisualShaderEditor::_line_edit_changed), varray(uniform_name, nodes[n_i]));
+			uniform_name->connect("focus_exited", callable_mp(this, &VisualShaderEditor::_line_edit_focus_out), varray(uniform_name, nodes[n_i]));
 
 			if (vsnode->get_input_port_count() == 0 && vsnode->get_output_port_count() == 1 && vsnode->get_output_port_name(0) == "") {
 				//shortcut
@@ -581,14 +581,14 @@ void VisualShaderEditor::_update_graph() {
 
 				Button *add_input_btn = memnew(Button);
 				add_input_btn->set_text(TTR("Add Input"));
-				add_input_btn->connect_compat("pressed", this, "_add_input_port", varray(nodes[n_i], group_node->get_free_input_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, "input" + itos(group_node->get_free_input_port_id())), CONNECT_DEFERRED);
+				add_input_btn->connect("pressed", callable_mp(this, &VisualShaderEditor::_add_input_port), varray(nodes[n_i], group_node->get_free_input_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, "input" + itos(group_node->get_free_input_port_id())), CONNECT_DEFERRED);
 				hb2->add_child(add_input_btn);
 
 				hb2->add_spacer();
 
 				Button *add_output_btn = memnew(Button);
 				add_output_btn->set_text(TTR("Add Output"));
-				add_output_btn->connect_compat("pressed", this, "_add_output_port", varray(nodes[n_i], group_node->get_free_output_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, "output" + itos(group_node->get_free_output_port_id())), CONNECT_DEFERRED);
+				add_output_btn->connect("pressed", callable_mp(this, &VisualShaderEditor::_add_output_port), varray(nodes[n_i], group_node->get_free_output_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, "output" + itos(group_node->get_free_output_port_id())), CONNECT_DEFERRED);
 				hb2->add_child(add_output_btn);
 
 				node->add_child(hb2);
@@ -636,7 +636,7 @@ void VisualShaderEditor::_update_graph() {
 			if (default_value.get_type() != Variant::NIL) { // only a label
 				Button *button = memnew(Button);
 				hb->add_child(button);
-				button->connect_compat("pressed", this, "_edit_port_default_input", varray(button, nodes[n_i], i));
+				button->connect("pressed", callable_mp(this, &VisualShaderEditor::_edit_port_default_input), varray(button, nodes[n_i], i));
 
 				switch (default_value.get_type()) {
 
@@ -677,20 +677,20 @@ void VisualShaderEditor::_update_graph() {
 						type_box->add_item(TTR("Sampler"));
 						type_box->select(group_node->get_input_port_type(i));
 						type_box->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-						type_box->connect_compat("item_selected", this, "_change_input_port_type", varray(nodes[n_i], i), CONNECT_DEFERRED);
+						type_box->connect("item_selected", callable_mp(this, &VisualShaderEditor::_change_input_port_type), varray(nodes[n_i], i), CONNECT_DEFERRED);
 
 						LineEdit *name_box = memnew(LineEdit);
 						hb->add_child(name_box);
 						name_box->set_custom_minimum_size(Size2(65 * EDSCALE, 0));
 						name_box->set_h_size_flags(SIZE_EXPAND_FILL);
 						name_box->set_text(name_left);
-						name_box->connect_compat("text_entered", this, "_change_input_port_name", varray(name_box, nodes[n_i], i));
-						name_box->connect_compat("focus_exited", this, "_port_name_focus_out", varray(name_box, nodes[n_i], i, false));
+						name_box->connect("text_entered", callable_mp(this, &VisualShaderEditor::_change_input_port_name), varray(name_box, nodes[n_i], i));
+						name_box->connect("focus_exited", callable_mp(this, &VisualShaderEditor::_port_name_focus_out), varray(name_box, nodes[n_i], i, false));
 
 						Button *remove_btn = memnew(Button);
 						remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Remove", "EditorIcons"));
 						remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
-						remove_btn->connect_compat("pressed", this, "_remove_input_port", varray(nodes[n_i], i), CONNECT_DEFERRED);
+						remove_btn->connect("pressed", callable_mp(this, &VisualShaderEditor::_remove_input_port), varray(nodes[n_i], i), CONNECT_DEFERRED);
 						hb->add_child(remove_btn);
 					} else {
 
@@ -719,7 +719,7 @@ void VisualShaderEditor::_update_graph() {
 						Button *remove_btn = memnew(Button);
 						remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Remove", "EditorIcons"));
 						remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
-						remove_btn->connect_compat("pressed", this, "_remove_output_port", varray(nodes[n_i], i), CONNECT_DEFERRED);
+						remove_btn->connect("pressed", callable_mp(this, &VisualShaderEditor::_remove_output_port), varray(nodes[n_i], i), CONNECT_DEFERRED);
 						hb->add_child(remove_btn);
 
 						LineEdit *name_box = memnew(LineEdit);
@@ -727,8 +727,8 @@ void VisualShaderEditor::_update_graph() {
 						name_box->set_custom_minimum_size(Size2(65 * EDSCALE, 0));
 						name_box->set_h_size_flags(SIZE_EXPAND_FILL);
 						name_box->set_text(name_right);
-						name_box->connect_compat("text_entered", this, "_change_output_port_name", varray(name_box, nodes[n_i], i));
-						name_box->connect_compat("focus_exited", this, "_port_name_focus_out", varray(name_box, nodes[n_i], i, true));
+						name_box->connect("text_entered", callable_mp(this, &VisualShaderEditor::_change_output_port_name), varray(name_box, nodes[n_i], i));
+						name_box->connect("focus_exited", callable_mp(this, &VisualShaderEditor::_port_name_focus_out), varray(name_box, nodes[n_i], i, true));
 
 						OptionButton *type_box = memnew(OptionButton);
 						hb->add_child(type_box);
@@ -738,7 +738,7 @@ void VisualShaderEditor::_update_graph() {
 						type_box->add_item(TTR("Transform"));
 						type_box->select(group_node->get_output_port_type(i));
 						type_box->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-						type_box->connect_compat("item_selected", this, "_change_output_port_type", varray(nodes[n_i], i), CONNECT_DEFERRED);
+						type_box->connect("item_selected", callable_mp(this, &VisualShaderEditor::_change_output_port_type), varray(nodes[n_i], i), CONNECT_DEFERRED);
 					} else {
 						Label *label = memnew(Label);
 						label->set_text(name_right);
@@ -759,7 +759,7 @@ void VisualShaderEditor::_update_graph() {
 					preview->set_pressed(true);
 				}
 
-				preview->connect_compat("pressed", this, "_preview_select_port", varray(nodes[n_i], i), CONNECT_DEFERRED);
+				preview->connect("pressed", callable_mp(this, &VisualShaderEditor::_preview_select_port), varray(nodes[n_i], i), CONNECT_DEFERRED);
 				hb->add_child(preview);
 			}
 
@@ -832,7 +832,7 @@ void VisualShaderEditor::_update_graph() {
 			expression_box->set_context_menu_enabled(false);
 			expression_box->set_show_line_numbers(true);
 
-			expression_box->connect_compat("focus_exited", this, "_expression_focus_out", varray(expression_box, nodes[n_i]));
+			expression_box->connect("focus_exited", callable_mp(this, &VisualShaderEditor::_expression_focus_out), varray(expression_box, nodes[n_i]));
 		}
 
 		if (!uniform.is_valid()) {
@@ -2206,57 +2206,17 @@ void VisualShaderEditor::_bind_methods() {
 	ClassDB::bind_method("_rebuild", &VisualShaderEditor::_rebuild);
 	ClassDB::bind_method("_update_graph", &VisualShaderEditor::_update_graph);
 	ClassDB::bind_method("_update_options_menu", &VisualShaderEditor::_update_options_menu);
-	ClassDB::bind_method("_expression_focus_out", &VisualShaderEditor::_expression_focus_out);
 	ClassDB::bind_method("_add_node", &VisualShaderEditor::_add_node);
-	ClassDB::bind_method("_node_dragged", &VisualShaderEditor::_node_dragged);
-	ClassDB::bind_method("_connection_request", &VisualShaderEditor::_connection_request);
-	ClassDB::bind_method("_disconnection_request", &VisualShaderEditor::_disconnection_request);
-	ClassDB::bind_method("_node_selected", &VisualShaderEditor::_node_selected);
-	ClassDB::bind_method("_scroll_changed", &VisualShaderEditor::_scroll_changed);
-	ClassDB::bind_method("_delete_request", &VisualShaderEditor::_delete_request);
-	ClassDB::bind_method("_on_nodes_delete", &VisualShaderEditor::_on_nodes_delete);
 	ClassDB::bind_method("_node_changed", &VisualShaderEditor::_node_changed);
-	ClassDB::bind_method("_edit_port_default_input", &VisualShaderEditor::_edit_port_default_input);
-	ClassDB::bind_method("_port_edited", &VisualShaderEditor::_port_edited);
-	ClassDB::bind_method("_connection_to_empty", &VisualShaderEditor::_connection_to_empty);
-	ClassDB::bind_method("_connection_from_empty", &VisualShaderEditor::_connection_from_empty);
-	ClassDB::bind_method("_line_edit_focus_out", &VisualShaderEditor::_line_edit_focus_out);
-	ClassDB::bind_method("_line_edit_changed", &VisualShaderEditor::_line_edit_changed);
-	ClassDB::bind_method("_port_name_focus_out", &VisualShaderEditor::_port_name_focus_out);
-	ClassDB::bind_method("_duplicate_nodes", &VisualShaderEditor::_duplicate_nodes);
-	ClassDB::bind_method("_copy_nodes", &VisualShaderEditor::_copy_nodes);
-	ClassDB::bind_method("_paste_nodes", &VisualShaderEditor::_paste_nodes);
-	ClassDB::bind_method("_mode_selected", &VisualShaderEditor::_mode_selected);
 	ClassDB::bind_method("_input_select_item", &VisualShaderEditor::_input_select_item);
-	ClassDB::bind_method("_preview_select_port", &VisualShaderEditor::_preview_select_port);
-	ClassDB::bind_method("_graph_gui_input", &VisualShaderEditor::_graph_gui_input);
-	ClassDB::bind_method("_add_input_port", &VisualShaderEditor::_add_input_port);
-	ClassDB::bind_method("_change_input_port_type", &VisualShaderEditor::_change_input_port_type);
-	ClassDB::bind_method("_change_input_port_name", &VisualShaderEditor::_change_input_port_name);
-	ClassDB::bind_method("_remove_input_port", &VisualShaderEditor::_remove_input_port);
-	ClassDB::bind_method("_add_output_port", &VisualShaderEditor::_add_output_port);
-	ClassDB::bind_method("_change_output_port_type", &VisualShaderEditor::_change_output_port_type);
-	ClassDB::bind_method("_change_output_port_name", &VisualShaderEditor::_change_output_port_name);
-	ClassDB::bind_method("_remove_output_port", &VisualShaderEditor::_remove_output_port);
-	ClassDB::bind_method("_node_resized", &VisualShaderEditor::_node_resized);
 	ClassDB::bind_method("_set_node_size", &VisualShaderEditor::_set_node_size);
 	ClassDB::bind_method("_clear_buffer", &VisualShaderEditor::_clear_buffer);
-	ClassDB::bind_method("_show_preview_text", &VisualShaderEditor::_show_preview_text);
-	ClassDB::bind_method("_update_preview", &VisualShaderEditor::_update_preview);
 
 	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &VisualShaderEditor::get_drag_data_fw);
 	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &VisualShaderEditor::can_drop_data_fw);
 	ClassDB::bind_method(D_METHOD("drop_data_fw"), &VisualShaderEditor::drop_data_fw);
 
 	ClassDB::bind_method("_is_available", &VisualShaderEditor::_is_available);
-	ClassDB::bind_method("_tools_menu_option", &VisualShaderEditor::_tools_menu_option);
-	ClassDB::bind_method("_show_members_dialog", &VisualShaderEditor::_show_members_dialog);
-	ClassDB::bind_method("_sbox_input", &VisualShaderEditor::_sbox_input);
-	ClassDB::bind_method("_member_filter_changed", &VisualShaderEditor::_member_filter_changed);
-	ClassDB::bind_method("_member_selected", &VisualShaderEditor::_member_selected);
-	ClassDB::bind_method("_member_unselected", &VisualShaderEditor::_member_unselected);
-	ClassDB::bind_method("_member_create", &VisualShaderEditor::_member_create);
-	ClassDB::bind_method("_member_cancel", &VisualShaderEditor::_member_cancel);
 }
 
 VisualShaderEditor *VisualShaderEditor::singleton = NULL;
@@ -2296,17 +2256,17 @@ VisualShaderEditor::VisualShaderEditor() {
 	graph->add_valid_right_disconnect_type(VisualShaderNode::PORT_TYPE_SAMPLER);
 	//graph->add_valid_left_disconnect_type(0);
 	graph->set_v_size_flags(SIZE_EXPAND_FILL);
-	graph->connect_compat("connection_request", this, "_connection_request", varray(), CONNECT_DEFERRED);
-	graph->connect_compat("disconnection_request", this, "_disconnection_request", varray(), CONNECT_DEFERRED);
-	graph->connect_compat("node_selected", this, "_node_selected");
-	graph->connect_compat("scroll_offset_changed", this, "_scroll_changed");
-	graph->connect_compat("duplicate_nodes_request", this, "_duplicate_nodes");
-	graph->connect_compat("copy_nodes_request", this, "_copy_nodes");
-	graph->connect_compat("paste_nodes_request", this, "_paste_nodes");
-	graph->connect_compat("delete_nodes_request", this, "_on_nodes_delete");
-	graph->connect_compat("gui_input", this, "_graph_gui_input");
-	graph->connect_compat("connection_to_empty", this, "_connection_to_empty");
-	graph->connect_compat("connection_from_empty", this, "_connection_from_empty");
+	graph->connect("connection_request", callable_mp(this, &VisualShaderEditor::_connection_request), varray(), CONNECT_DEFERRED);
+	graph->connect("disconnection_request", callable_mp(this, &VisualShaderEditor::_disconnection_request), varray(), CONNECT_DEFERRED);
+	graph->connect("node_selected", callable_mp(this, &VisualShaderEditor::_node_selected));
+	graph->connect("scroll_offset_changed", callable_mp(this, &VisualShaderEditor::_scroll_changed));
+	graph->connect("duplicate_nodes_request", callable_mp(this, &VisualShaderEditor::_duplicate_nodes));
+	graph->connect("copy_nodes_request", callable_mp(this, &VisualShaderEditor::_copy_nodes));
+	graph->connect("paste_nodes_request", callable_mp(this, &VisualShaderEditor::_paste_nodes));
+	graph->connect("delete_nodes_request", callable_mp(this, &VisualShaderEditor::_on_nodes_delete));
+	graph->connect("gui_input", callable_mp(this, &VisualShaderEditor::_graph_gui_input));
+	graph->connect("connection_to_empty", callable_mp(this, &VisualShaderEditor::_connection_to_empty));
+	graph->connect("connection_from_empty", callable_mp(this, &VisualShaderEditor::_connection_from_empty));
 	graph->add_valid_connection_type(VisualShaderNode::PORT_TYPE_SCALAR, VisualShaderNode::PORT_TYPE_SCALAR);
 	graph->add_valid_connection_type(VisualShaderNode::PORT_TYPE_SCALAR, VisualShaderNode::PORT_TYPE_VECTOR);
 	graph->add_valid_connection_type(VisualShaderNode::PORT_TYPE_SCALAR, VisualShaderNode::PORT_TYPE_BOOLEAN);
@@ -2328,7 +2288,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	edit_type->add_item(TTR("Fragment"));
 	edit_type->add_item(TTR("Light"));
 	edit_type->select(1);
-	edit_type->connect_compat("item_selected", this, "_mode_selected");
+	edit_type->connect("item_selected", callable_mp(this, &VisualShaderEditor::_mode_selected));
 	graph->get_zoom_hbox()->add_child(edit_type);
 	graph->get_zoom_hbox()->move_child(edit_type, 0);
 
@@ -2336,13 +2296,13 @@ VisualShaderEditor::VisualShaderEditor() {
 	graph->get_zoom_hbox()->add_child(add_node);
 	add_node->set_text(TTR("Add Node..."));
 	graph->get_zoom_hbox()->move_child(add_node, 0);
-	add_node->connect_compat("pressed", this, "_show_members_dialog", varray(false));
+	add_node->connect("pressed", callable_mp(this, &VisualShaderEditor::_show_members_dialog), varray(false));
 
 	preview_shader = memnew(ToolButton);
 	preview_shader->set_toggle_mode(true);
 	preview_shader->set_tooltip(TTR("Show resulted shader code."));
 	graph->get_zoom_hbox()->add_child(preview_shader);
-	preview_shader->connect_compat("pressed", this, "_show_preview_text");
+	preview_shader->connect("pressed", callable_mp(this, &VisualShaderEditor::_show_preview_text));
 
 	///////////////////////////////////////
 	// PREVIEW PANEL
@@ -2376,15 +2336,15 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	node_filter = memnew(LineEdit);
 	filter_hb->add_child(node_filter);
-	node_filter->connect_compat("text_changed", this, "_member_filter_changed");
-	node_filter->connect_compat("gui_input", this, "_sbox_input");
+	node_filter->connect("text_changed", callable_mp(this, &VisualShaderEditor::_member_filter_changed));
+	node_filter->connect("gui_input", callable_mp(this, &VisualShaderEditor::_sbox_input));
 	node_filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	node_filter->set_placeholder(TTR("Search"));
 
 	tools = memnew(MenuButton);
 	filter_hb->add_child(tools);
 	tools->set_tooltip(TTR("Options"));
-	tools->get_popup()->connect_compat("id_pressed", this, "_tools_menu_option");
+	tools->get_popup()->connect("id_pressed", callable_mp(this, &VisualShaderEditor::_tools_menu_option));
 	tools->get_popup()->add_item(TTR("Expand All"), EXPAND_ALL);
 	tools->get_popup()->add_item(TTR("Collapse All"), COLLAPSE_ALL);
 
@@ -2397,9 +2357,9 @@ VisualShaderEditor::VisualShaderEditor() {
 	members->set_allow_reselect(true);
 	members->set_hide_folding(false);
 	members->set_custom_minimum_size(Size2(180 * EDSCALE, 200 * EDSCALE));
-	members->connect_compat("item_activated", this, "_member_create");
-	members->connect_compat("item_selected", this, "_member_selected");
-	members->connect_compat("nothing_selected", this, "_member_unselected");
+	members->connect("item_activated", callable_mp(this, &VisualShaderEditor::_member_create));
+	members->connect("item_selected", callable_mp(this, &VisualShaderEditor::_member_selected));
+	members->connect("nothing_selected", callable_mp(this, &VisualShaderEditor::_member_unselected));
 
 	HBoxContainer *desc_hbox = memnew(HBoxContainer);
 	members_vb->add_child(desc_hbox);
@@ -2427,11 +2387,11 @@ VisualShaderEditor::VisualShaderEditor() {
 	members_dialog->set_title(TTR("Create Shader Node"));
 	members_dialog->add_child(members_vb);
 	members_dialog->get_ok()->set_text(TTR("Create"));
-	members_dialog->get_ok()->connect_compat("pressed", this, "_member_create");
+	members_dialog->get_ok()->connect("pressed", callable_mp(this, &VisualShaderEditor::_member_create));
 	members_dialog->get_ok()->set_disabled(true);
 	members_dialog->set_resizable(true);
 	members_dialog->set_as_minsize();
-	members_dialog->connect_compat("hide", this, "_member_cancel");
+	members_dialog->connect("hide", callable_mp(this, &VisualShaderEditor::_member_cancel));
 	add_child(members_dialog);
 
 	alert = memnew(AcceptDialog);
@@ -2810,7 +2770,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	property_editor = memnew(CustomPropertyEditor);
 	add_child(property_editor);
 
-	property_editor->connect_compat("variant_changed", this, "_port_edited");
+	property_editor->connect("variant_changed", callable_mp(this, &VisualShaderEditor::_port_edited));
 }
 
 void VisualShaderEditorPlugin::edit(Object *p_object) {
@@ -3166,8 +3126,6 @@ void EditorPropertyShaderMode::set_option_button_clip(bool p_enable) {
 }
 
 void EditorPropertyShaderMode::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_option_selected"), &EditorPropertyShaderMode::_option_selected);
 }
 
 EditorPropertyShaderMode::EditorPropertyShaderMode() {
@@ -3175,7 +3133,7 @@ EditorPropertyShaderMode::EditorPropertyShaderMode() {
 	options->set_clip_text(true);
 	add_child(options);
 	add_focusable(options);
-	options->connect_compat("item_selected", this, "_option_selected");
+	options->connect("item_selected", callable_mp(this, &EditorPropertyShaderMode::_option_selected));
 }
 
 bool EditorInspectorShaderModePlugin::can_handle(Object *p_object) {
@@ -3248,7 +3206,7 @@ void VisualShaderNodePortPreview::_shader_changed() {
 void VisualShaderNodePortPreview::setup(const Ref<VisualShader> &p_shader, VisualShader::Type p_type, int p_node, int p_port) {
 
 	shader = p_shader;
-	shader->connect_compat("changed", this, "_shader_changed");
+	shader->connect("changed", callable_mp(this, &VisualShaderNodePortPreview::_shader_changed));
 	type = p_type;
 	port = p_port;
 	node = p_node;
@@ -3283,7 +3241,6 @@ void VisualShaderNodePortPreview::_notification(int p_what) {
 }
 
 void VisualShaderNodePortPreview::_bind_methods() {
-	ClassDB::bind_method("_shader_changed", &VisualShaderNodePortPreview::_shader_changed);
 }
 
 VisualShaderNodePortPreview::VisualShaderNodePortPreview() {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -78,7 +78,7 @@ void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
 		visual_shader->set_graph_offset(graph->get_scroll_ofs() / EDSCALE);
 	} else {
 		if (visual_shader.is_valid()) {
-			if (visual_shader->is_connected_compat("changed", this, "")) {
+			if (visual_shader->is_connected("changed", callable_mp(this, &VisualShaderEditor::_update_preview))) {
 				visual_shader->disconnect("changed", callable_mp(this, &VisualShaderEditor::_update_preview));
 			}
 		}
@@ -504,10 +504,6 @@ void VisualShaderEditor::_update_graph() {
 			expression = expression_node->get_expression();
 		}
 
-		/*if (!vsnode->is_connected("changed", this, "_node_changed")) {
-			vsnode->connect("changed", this, "_node_changed", varray(vsnode->get_instance_id()), CONNECT_DEFERRED);
-		}*/
-
 		node->set_offset(position);
 
 		node->set_title(vsnode->get_caption());
@@ -642,7 +638,7 @@ void VisualShaderEditor::_update_graph() {
 
 					case Variant::COLOR: {
 						button->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
-						button->connect_compat("draw", this, "_draw_color_over_button", varray(button, default_value));
+						button->connect("draw", callable_mp(this, &VisualShaderEditor::_draw_color_over_button), varray(button, default_value));
 					} break;
 					case Variant::BOOL: {
 						button->set_text(((bool)default_value) ? "true" : "false");
@@ -2823,15 +2819,10 @@ class VisualShaderNodePluginInputEditor : public OptionButton {
 
 	Ref<VisualShaderNodeInput> input;
 
-protected:
-	static void _bind_methods() {
-		ClassDB::bind_method("_item_selected", &VisualShaderNodePluginInputEditor::_item_selected);
-	}
-
 public:
 	void _notification(int p_what) {
 		if (p_what == NOTIFICATION_READY) {
-			connect_compat("item_selected", this, "_item_selected");
+			connect("item_selected", callable_mp(this, &VisualShaderNodePluginInputEditor::_item_selected));
 		}
 	}
 
@@ -2960,25 +2951,22 @@ public:
 
 			bool res_prop = Object::cast_to<EditorPropertyResource>(p_properties[i]);
 			if (res_prop) {
-				p_properties[i]->connect_compat("resource_selected", this, "_resource_selected");
+				p_properties[i]->connect("resource_selected", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_resource_selected));
 			}
 
-			properties[i]->connect_compat("property_changed", this, "_property_changed");
+			properties[i]->connect("property_changed", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_property_changed));
 			properties[i]->set_object_and_property(node.ptr(), p_names[i]);
 			properties[i]->update_property();
 			properties[i]->set_name_split_ratio(0);
 		}
-		node->connect_compat("changed", this, "_node_changed");
-		node->connect_compat("editor_refresh_request", this, "_refresh_request", varray(), CONNECT_DEFERRED);
+		node->connect("changed", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_node_changed));
+		node->connect("editor_refresh_request", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_refresh_request), varray(), CONNECT_DEFERRED);
 	}
 
 	static void _bind_methods() {
-		ClassDB::bind_method("_property_changed", &VisualShaderNodePluginDefaultEditor::_property_changed, DEFVAL(String()), DEFVAL(false));
-		ClassDB::bind_method("_node_changed", &VisualShaderNodePluginDefaultEditor::_node_changed);
-		ClassDB::bind_method("_refresh_request", &VisualShaderNodePluginDefaultEditor::_refresh_request);
-		ClassDB::bind_method("_resource_selected", &VisualShaderNodePluginDefaultEditor::_resource_selected);
-		ClassDB::bind_method("_open_inspector", &VisualShaderNodePluginDefaultEditor::_open_inspector);
-		ClassDB::bind_method("_show_prop_names", &VisualShaderNodePluginDefaultEditor::_show_prop_names);
+		ClassDB::bind_method("_refresh_request", &VisualShaderNodePluginDefaultEditor::_refresh_request); // Used by UndoRedo.
+		ClassDB::bind_method("_open_inspector", &VisualShaderNodePluginDefaultEditor::_open_inspector); // Used by UndoRedo.
+		ClassDB::bind_method("_show_prop_names", &VisualShaderNodePluginDefaultEditor::_show_prop_names); // Used with call_deferred.
 	}
 };
 

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -245,7 +245,6 @@ void ProgressDialog::_cancel_pressed() {
 }
 
 void ProgressDialog::_bind_methods() {
-	ClassDB::bind_method("_cancel_pressed", &ProgressDialog::_cancel_pressed);
 }
 
 ProgressDialog::ProgressDialog() {
@@ -264,5 +263,5 @@ ProgressDialog::ProgressDialog() {
 	cancel_hb->add_child(cancel);
 	cancel->set_text(TTR("Cancel"));
 	cancel_hb->add_spacer();
-	cancel->connect_compat("pressed", this, "_cancel_pressed");
+	cancel->connect("pressed", callable_mp(this, &ProgressDialog::_cancel_pressed));
 }

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -53,7 +53,7 @@ void ProjectExportDialog::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			duplicate_preset->set_icon(get_icon("Duplicate", "EditorIcons"));
 			delete_preset->set_icon(get_icon("Remove", "EditorIcons"));
-			connect_compat("confirmed", this, "_export_pck_zip");
+			connect("confirmed", callable_mp(this, &ProjectExportDialog::_export_pck_zip));
 			custom_feature_display->get_parent_control()->add_style_override("panel", get_stylebox("bg", "Tree"));
 		} break;
 		case NOTIFICATION_POPUP_HIDE: {
@@ -1022,38 +1022,10 @@ void ProjectExportDialog::_export_all(bool p_debug) {
 
 void ProjectExportDialog::_bind_methods() {
 
-	ClassDB::bind_method("_add_preset", &ProjectExportDialog::_add_preset);
-	ClassDB::bind_method("_edit_preset", &ProjectExportDialog::_edit_preset);
-	ClassDB::bind_method("_update_parameters", &ProjectExportDialog::_update_parameters);
-	ClassDB::bind_method("_runnable_pressed", &ProjectExportDialog::_runnable_pressed);
-	ClassDB::bind_method("_name_changed", &ProjectExportDialog::_name_changed);
-	ClassDB::bind_method("_duplicate_preset", &ProjectExportDialog::_duplicate_preset);
-	ClassDB::bind_method("_delete_preset", &ProjectExportDialog::_delete_preset);
-	ClassDB::bind_method("_delete_preset_confirm", &ProjectExportDialog::_delete_preset_confirm);
 	ClassDB::bind_method("get_drag_data_fw", &ProjectExportDialog::get_drag_data_fw);
 	ClassDB::bind_method("can_drop_data_fw", &ProjectExportDialog::can_drop_data_fw);
 	ClassDB::bind_method("drop_data_fw", &ProjectExportDialog::drop_data_fw);
-	ClassDB::bind_method("_export_type_changed", &ProjectExportDialog::_export_type_changed);
-	ClassDB::bind_method("_filter_changed", &ProjectExportDialog::_filter_changed);
-	ClassDB::bind_method("_tree_changed", &ProjectExportDialog::_tree_changed);
-	ClassDB::bind_method("_patch_button_pressed", &ProjectExportDialog::_patch_button_pressed);
-	ClassDB::bind_method("_patch_selected", &ProjectExportDialog::_patch_selected);
-	ClassDB::bind_method("_patch_deleted", &ProjectExportDialog::_patch_deleted);
-	ClassDB::bind_method("_patch_edited", &ProjectExportDialog::_patch_edited);
-	ClassDB::bind_method("_export_pck_zip", &ProjectExportDialog::_export_pck_zip);
-	ClassDB::bind_method("_export_pck_zip_selected", &ProjectExportDialog::_export_pck_zip_selected);
-	ClassDB::bind_method("_open_export_template_manager", &ProjectExportDialog::_open_export_template_manager);
-	ClassDB::bind_method("_validate_export_path", &ProjectExportDialog::_validate_export_path);
-	ClassDB::bind_method("_export_path_changed", &ProjectExportDialog::_export_path_changed);
-	ClassDB::bind_method("_script_export_mode_changed", &ProjectExportDialog::_script_export_mode_changed);
-	ClassDB::bind_method("_script_encryption_key_changed", &ProjectExportDialog::_script_encryption_key_changed);
-	ClassDB::bind_method("_export_project", &ProjectExportDialog::_export_project);
-	ClassDB::bind_method("_export_project_to_path", &ProjectExportDialog::_export_project_to_path);
 	ClassDB::bind_method("_export_all", &ProjectExportDialog::_export_all);
-	ClassDB::bind_method("_export_all_dialog", &ProjectExportDialog::_export_all_dialog);
-	ClassDB::bind_method("_export_all_dialog_action", &ProjectExportDialog::_export_all_dialog_action);
-	ClassDB::bind_method("_custom_features_changed", &ProjectExportDialog::_custom_features_changed);
-	ClassDB::bind_method("_tab_changed", &ProjectExportDialog::_tab_changed);
 	ClassDB::bind_method("set_export_path", &ProjectExportDialog::set_export_path);
 	ClassDB::bind_method("get_export_path", &ProjectExportDialog::get_export_path);
 	ClassDB::bind_method("get_current_preset", &ProjectExportDialog::get_current_preset);
@@ -1085,7 +1057,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	add_preset = memnew(MenuButton);
 	add_preset->set_text(TTR("Add..."));
-	add_preset->get_popup()->connect_compat("index_pressed", this, "_add_preset");
+	add_preset->get_popup()->connect("index_pressed", callable_mp(this, &ProjectExportDialog::_add_preset));
 	preset_hb->add_child(add_preset);
 	MarginContainer *mc = memnew(MarginContainer);
 	preset_vb->add_child(mc);
@@ -1093,13 +1065,13 @@ ProjectExportDialog::ProjectExportDialog() {
 	presets = memnew(ItemList);
 	presets->set_drag_forwarding(this);
 	mc->add_child(presets);
-	presets->connect_compat("item_selected", this, "_edit_preset");
+	presets->connect("item_selected", callable_mp(this, &ProjectExportDialog::_edit_preset));
 	duplicate_preset = memnew(ToolButton);
 	preset_hb->add_child(duplicate_preset);
-	duplicate_preset->connect_compat("pressed", this, "_duplicate_preset");
+	duplicate_preset->connect("pressed", callable_mp(this, &ProjectExportDialog::_duplicate_preset));
 	delete_preset = memnew(ToolButton);
 	preset_hb->add_child(delete_preset);
-	delete_preset->connect_compat("pressed", this, "_delete_preset");
+	delete_preset->connect("pressed", callable_mp(this, &ProjectExportDialog::_delete_preset));
 
 	// Preset settings.
 
@@ -1109,11 +1081,11 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	name = memnew(LineEdit);
 	settings_vb->add_margin_child(TTR("Name:"), name);
-	name->connect_compat("text_changed", this, "_name_changed");
+	name->connect("text_changed", callable_mp(this, &ProjectExportDialog::_name_changed));
 	runnable = memnew(CheckButton);
 	runnable->set_text(TTR("Runnable"));
 	runnable->set_tooltip(TTR("If checked, the preset will be available for use in one-click deploy.\nOnly one preset per platform may be marked as runnable."));
-	runnable->connect_compat("pressed", this, "_runnable_pressed");
+	runnable->connect("pressed", callable_mp(this, &ProjectExportDialog::_runnable_pressed));
 	settings_vb->add_child(runnable);
 
 	export_path = memnew(EditorPropertyPath);
@@ -1121,7 +1093,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_path->set_label(TTR("Export Path"));
 	export_path->set_object_and_property(this, "export_path");
 	export_path->set_save_mode();
-	export_path->connect_compat("property_changed", this, "_export_path_changed");
+	export_path->connect("property_changed", callable_mp(this, &ProjectExportDialog::_export_path_changed));
 
 	// Subsections.
 
@@ -1137,7 +1109,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	sections->add_child(parameters);
 	parameters->set_name(TTR("Options"));
 	parameters->set_v_size_flags(SIZE_EXPAND_FILL);
-	parameters->connect_compat("property_edited", this, "_update_parameters");
+	parameters->connect("property_edited", callable_mp(this, &ProjectExportDialog::_update_parameters));
 
 	// Resources export parameters.
 
@@ -1150,7 +1122,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_filter->add_item(TTR("Export selected scenes (and dependencies)"));
 	export_filter->add_item(TTR("Export selected resources (and dependencies)"));
 	resources_vb->add_margin_child(TTR("Export Mode:"), export_filter);
-	export_filter->connect_compat("item_selected", this, "_export_type_changed");
+	export_filter->connect("item_selected", callable_mp(this, &ProjectExportDialog::_export_type_changed));
 
 	include_label = memnew(Label);
 	include_label->set_text(TTR("Resources to export:"));
@@ -1161,19 +1133,19 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	include_files = memnew(Tree);
 	include_margin->add_child(include_files);
-	include_files->connect_compat("item_edited", this, "_tree_changed");
+	include_files->connect("item_edited", callable_mp(this, &ProjectExportDialog::_tree_changed));
 
 	include_filters = memnew(LineEdit);
 	resources_vb->add_margin_child(
 			TTR("Filters to export non-resource files/folders\n(comma-separated, e.g: *.json, *.txt, docs/*)"),
 			include_filters);
-	include_filters->connect_compat("text_changed", this, "_filter_changed");
+	include_filters->connect("text_changed", callable_mp(this, &ProjectExportDialog::_filter_changed));
 
 	exclude_filters = memnew(LineEdit);
 	resources_vb->add_margin_child(
 			TTR("Filters to exclude files/folders from project\n(comma-separated, e.g: *.json, *.txt, docs/*)"),
 			exclude_filters);
-	exclude_filters->connect_compat("text_changed", this, "_filter_changed");
+	exclude_filters->connect("text_changed", callable_mp(this, &ProjectExportDialog::_filter_changed));
 
 	// Patch packages.
 
@@ -1190,8 +1162,8 @@ ProjectExportDialog::ProjectExportDialog() {
 	patch_vb->add_child(patches);
 	patches->set_v_size_flags(SIZE_EXPAND_FILL);
 	patches->set_hide_root(true);
-	patches->connect_compat("button_pressed", this, "_patch_button_pressed");
-	patches->connect_compat("item_edited", this, "_patch_edited");
+	patches->connect("button_pressed", callable_mp(this, &ProjectExportDialog::_patch_button_pressed));
+	patches->connect("item_edited", callable_mp(this, &ProjectExportDialog::_patch_edited));
 	patches->set_drag_forwarding(this);
 	patches->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
 
@@ -1206,12 +1178,12 @@ ProjectExportDialog::ProjectExportDialog() {
 	patch_dialog = memnew(EditorFileDialog);
 	patch_dialog->add_filter("*.pck ; " + TTR("Pack File"));
 	patch_dialog->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	patch_dialog->connect_compat("file_selected", this, "_patch_selected");
+	patch_dialog->connect("file_selected", callable_mp(this, &ProjectExportDialog::_patch_selected));
 	add_child(patch_dialog);
 
 	patch_erase = memnew(ConfirmationDialog);
 	patch_erase->get_ok()->set_text(TTR("Delete"));
-	patch_erase->connect_compat("confirmed", this, "_patch_deleted");
+	patch_erase->connect("confirmed", callable_mp(this, &ProjectExportDialog::_patch_deleted));
 	add_child(patch_erase);
 
 	// Feature tags.
@@ -1219,7 +1191,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	VBoxContainer *feature_vb = memnew(VBoxContainer);
 	feature_vb->set_name(TTR("Features"));
 	custom_features = memnew(LineEdit);
-	custom_features->connect_compat("text_changed", this, "_custom_features_changed");
+	custom_features->connect("text_changed", callable_mp(this, &ProjectExportDialog::_custom_features_changed));
 	feature_vb->add_margin_child(TTR("Custom (comma-separated):"), custom_features);
 	Panel *features_panel = memnew(Panel);
 	custom_feature_display = memnew(RichTextLabel);
@@ -1240,9 +1212,9 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_mode->add_item(TTR("Text"), (int)EditorExportPreset::MODE_SCRIPT_TEXT);
 	script_mode->add_item(TTR("Compiled"), (int)EditorExportPreset::MODE_SCRIPT_COMPILED);
 	script_mode->add_item(TTR("Encrypted (Provide Key Below)"), (int)EditorExportPreset::MODE_SCRIPT_ENCRYPTED);
-	script_mode->connect_compat("item_selected", this, "_script_export_mode_changed");
+	script_mode->connect("item_selected", callable_mp(this, &ProjectExportDialog::_script_export_mode_changed));
 	script_key = memnew(LineEdit);
-	script_key->connect_compat("text_changed", this, "_script_encryption_key_changed");
+	script_key->connect("text_changed", callable_mp(this, &ProjectExportDialog::_script_encryption_key_changed));
 	script_key_error = memnew(Label);
 	script_key_error->set_text("- " + TTR("Invalid Encryption Key (must be 64 characters long)"));
 	script_key_error->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
@@ -1250,7 +1222,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_vb->add_child(script_key_error);
 	sections->add_child(script_vb);
 
-	sections->connect_compat("tab_changed", this, "_tab_changed");
+	sections->connect("tab_changed", callable_mp(this, &ProjectExportDialog::_tab_changed));
 
 	// Disable by default.
 	name->set_editable(false);
@@ -1267,7 +1239,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	delete_confirm = memnew(ConfirmationDialog);
 	add_child(delete_confirm);
 	delete_confirm->get_ok()->set_text(TTR("Delete"));
-	delete_confirm->connect_compat("confirmed", this, "_delete_preset_confirm");
+	delete_confirm->connect("confirmed", callable_mp(this, &ProjectExportDialog::_delete_preset_confirm));
 
 	// Export buttons, dialogs and errors.
 
@@ -1276,7 +1248,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	get_cancel()->set_text(TTR("Close"));
 	get_ok()->set_text(TTR("Export PCK/Zip"));
 	export_button = add_button(TTR("Export Project"), !OS::get_singleton()->get_swap_ok_cancel(), "export");
-	export_button->connect_compat("pressed", this, "_export_project");
+	export_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_export_project));
 	// Disable initially before we select a valid preset
 	export_button->set_disabled(true);
 	get_ok()->set_disabled(true);
@@ -1288,10 +1260,10 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_all_dialog->get_ok()->hide();
 	export_all_dialog->add_button(TTR("Debug"), true, "debug");
 	export_all_dialog->add_button(TTR("Release"), true, "release");
-	export_all_dialog->connect_compat("custom_action", this, "_export_all_dialog_action");
+	export_all_dialog->connect("custom_action", callable_mp(this, &ProjectExportDialog::_export_all_dialog_action));
 
 	export_all_button = add_button(TTR("Export All"), !OS::get_singleton()->get_swap_ok_cancel(), "export");
-	export_all_button->connect_compat("pressed", this, "_export_all_dialog");
+	export_all_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_export_all_dialog));
 	export_all_button->set_disabled(true);
 
 	export_pck_zip = memnew(EditorFileDialog);
@@ -1300,7 +1272,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_pck_zip->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	export_pck_zip->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	add_child(export_pck_zip);
-	export_pck_zip->connect_compat("file_selected", this, "_export_pck_zip_selected");
+	export_pck_zip->connect("file_selected", callable_mp(this, &ProjectExportDialog::_export_pck_zip_selected));
 
 	export_error = memnew(Label);
 	main_vb->add_child(export_error);
@@ -1326,13 +1298,13 @@ ProjectExportDialog::ProjectExportDialog() {
 	download_templates->set_text(TTR("Manage Export Templates"));
 	download_templates->set_v_size_flags(SIZE_SHRINK_CENTER);
 	export_templates_error->add_child(download_templates);
-	download_templates->connect_compat("pressed", this, "_open_export_template_manager");
+	download_templates->connect("pressed", callable_mp(this, &ProjectExportDialog::_open_export_template_manager));
 
 	export_project = memnew(EditorFileDialog);
 	export_project->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	add_child(export_project);
-	export_project->connect_compat("file_selected", this, "_export_project_to_path");
-	export_project->get_line_edit()->connect_compat("text_changed", this, "_validate_export_path");
+	export_project->connect("file_selected", callable_mp(this, &ProjectExportDialog::_export_project_to_path));
+	export_project->get_line_edit()->connect("text_changed", callable_mp(this, &ProjectExportDialog::_validate_export_path));
 
 	export_debug = memnew(CheckBox);
 	export_debug->set_text(TTR("Export With Debug"));

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1320,8 +1320,8 @@ void ProjectList::create_project_item_control(int p_index) {
 	Color font_color = get_color("font_color", "Tree");
 
 	ProjectListItemControl *hb = memnew(ProjectListItemControl);
-	hb->connect_compat("draw", this, "_panel_draw", varray(hb));
-	hb->connect_compat("gui_input", this, "_panel_input", varray(hb));
+	hb->connect("draw", callable_mp(this, &ProjectList::_panel_draw), varray(hb));
+	hb->connect("gui_input", callable_mp(this, &ProjectList::_panel_input), varray(hb));
 	hb->add_constant_override("separation", 10 * EDSCALE);
 	hb->set_tooltip(item.description);
 
@@ -1332,7 +1332,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	favorite->set_normal_texture(favorite_icon);
 	// This makes the project's "hover" style display correctly when hovering the favorite icon
 	favorite->set_mouse_filter(MOUSE_FILTER_PASS);
-	favorite->connect_compat("pressed", this, "_favorite_pressed", varray(hb));
+	favorite->connect("pressed", callable_mp(this, &ProjectList::_favorite_pressed), varray(hb));
 	favorite_box->add_child(favorite);
 	favorite_box->set_alignment(BoxContainer::ALIGN_CENTER);
 	hb->add_child(favorite_box);
@@ -1380,7 +1380,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	path_hb->add_child(show);
 
 	if (!item.missing) {
-		show->connect_compat("pressed", this, "_show_project", varray(item.path));
+		show->connect("pressed", callable_mp(this, &ProjectList::_show_project), varray(item.path));
 		show->set_tooltip(TTR("Show in File Manager"));
 	} else {
 		show->set_tooltip(TTR("Error: Project is missing on the filesystem."));
@@ -1812,11 +1812,6 @@ const char *ProjectList::SIGNAL_SELECTION_CHANGED = "selection_changed";
 const char *ProjectList::SIGNAL_PROJECT_ASK_OPEN = "project_ask_open";
 
 void ProjectList::_bind_methods() {
-
-	ClassDB::bind_method("_panel_draw", &ProjectList::_panel_draw);
-	ClassDB::bind_method("_panel_input", &ProjectList::_panel_input);
-	ClassDB::bind_method("_favorite_pressed", &ProjectList::_favorite_pressed);
-	ClassDB::bind_method("_show_project", &ProjectList::_show_project);
 
 	ADD_SIGNAL(MethodInfo(SIGNAL_SELECTION_CHANGED));
 	ADD_SIGNAL(MethodInfo(SIGNAL_PROJECT_ASK_OPEN));
@@ -2358,8 +2353,8 @@ void ProjectManager::_files_dropped(PackedStringArray p_files, int p_screen) {
 			memdelete(dir);
 		}
 		if (confirm) {
-			multi_scan_ask->get_ok()->disconnect_compat("pressed", this, "_scan_multiple_folders");
-			multi_scan_ask->get_ok()->connect_compat("pressed", this, "_scan_multiple_folders", varray(folders));
+			multi_scan_ask->get_ok()->disconnect("pressed", callable_mp(this, &ProjectManager::_scan_multiple_folders));
+			multi_scan_ask->get_ok()->connect("pressed", callable_mp(this, &ProjectManager::_scan_multiple_folders), varray(folders));
 			multi_scan_ask->set_text(
 					vformat(TTR("Are you sure to scan %s folders for existing Godot projects?\nThis could take a while."), folders.size()));
 			multi_scan_ask->popup_centered_minsize();
@@ -2393,34 +2388,9 @@ void ProjectManager::_on_filter_option_changed() {
 
 void ProjectManager::_bind_methods() {
 
-	ClassDB::bind_method("_open_selected_projects_ask", &ProjectManager::_open_selected_projects_ask);
-	ClassDB::bind_method("_open_selected_projects", &ProjectManager::_open_selected_projects);
-	ClassDB::bind_method(D_METHOD("_global_menu_action"), &ProjectManager::_global_menu_action, DEFVAL(Variant()));
-	ClassDB::bind_method("_run_project", &ProjectManager::_run_project);
-	ClassDB::bind_method("_run_project_confirm", &ProjectManager::_run_project_confirm);
-	ClassDB::bind_method("_scan_projects", &ProjectManager::_scan_projects);
-	ClassDB::bind_method("_scan_begin", &ProjectManager::_scan_begin);
-	ClassDB::bind_method("_import_project", &ProjectManager::_import_project);
-	ClassDB::bind_method("_new_project", &ProjectManager::_new_project);
-	ClassDB::bind_method("_rename_project", &ProjectManager::_rename_project);
-	ClassDB::bind_method("_erase_project", &ProjectManager::_erase_project);
-	ClassDB::bind_method("_erase_missing_projects", &ProjectManager::_erase_missing_projects);
-	ClassDB::bind_method("_erase_project_confirm", &ProjectManager::_erase_project_confirm);
-	ClassDB::bind_method("_erase_missing_projects_confirm", &ProjectManager::_erase_missing_projects_confirm);
-	ClassDB::bind_method("_language_selected", &ProjectManager::_language_selected);
-	ClassDB::bind_method("_restart_confirm", &ProjectManager::_restart_confirm);
 	ClassDB::bind_method("_exit_dialog", &ProjectManager::_exit_dialog);
-	ClassDB::bind_method("_on_order_option_changed", &ProjectManager::_on_order_option_changed);
-	ClassDB::bind_method("_on_filter_option_changed", &ProjectManager::_on_filter_option_changed);
-	ClassDB::bind_method("_on_projects_updated", &ProjectManager::_on_projects_updated);
-	ClassDB::bind_method("_on_project_created", &ProjectManager::_on_project_created);
 	ClassDB::bind_method("_unhandled_input", &ProjectManager::_unhandled_input);
-	ClassDB::bind_method("_install_project", &ProjectManager::_install_project);
-	ClassDB::bind_method("_files_dropped", &ProjectManager::_files_dropped);
-	ClassDB::bind_method("_open_asset_library", &ProjectManager::_open_asset_library);
-	ClassDB::bind_method("_confirm_update_settings", &ProjectManager::_confirm_update_settings);
 	ClassDB::bind_method("_update_project_buttons", &ProjectManager::_update_project_buttons);
-	ClassDB::bind_method(D_METHOD("_scan_multiple_folders", "files"), &ProjectManager::_scan_multiple_folders);
 }
 
 void ProjectManager::_open_asset_library() {
@@ -2524,7 +2494,7 @@ ProjectManager::ProjectManager() {
 	project_order_filter->_setup_filters(sort_filter_titles);
 	project_order_filter->set_filter_size(150);
 	sort_filters->add_child(project_order_filter);
-	project_order_filter->connect_compat("filter_changed", this, "_on_order_option_changed");
+	project_order_filter->connect("filter_changed", callable_mp(this, &ProjectManager::_on_order_option_changed));
 	project_order_filter->set_custom_minimum_size(Size2(180, 10) * EDSCALE);
 
 	int projects_sorting_order = (int)EditorSettings::get_singleton()->get("project_manager/sorting_order");
@@ -2534,7 +2504,7 @@ ProjectManager::ProjectManager() {
 
 	project_filter = memnew(ProjectListFilter);
 	project_filter->add_search_box();
-	project_filter->connect_compat("filter_changed", this, "_on_filter_option_changed");
+	project_filter->connect("filter_changed", callable_mp(this, &ProjectManager::_on_filter_option_changed));
 	project_filter->set_custom_minimum_size(Size2(280, 10) * EDSCALE);
 	sort_filters->add_child(project_filter);
 
@@ -2557,13 +2527,13 @@ ProjectManager::ProjectManager() {
 	Button *open = memnew(Button);
 	open->set_text(TTR("Edit"));
 	tree_vb->add_child(open);
-	open->connect_compat("pressed", this, "_open_selected_projects_ask");
+	open->connect("pressed", callable_mp(this, &ProjectManager::_open_selected_projects_ask));
 	open_btn = open;
 
 	Button *run = memnew(Button);
 	run->set_text(TTR("Run"));
 	tree_vb->add_child(run);
-	run->connect_compat("pressed", this, "_run_project");
+	run->connect("pressed", callable_mp(this, &ProjectManager::_run_project));
 	run_btn = run;
 
 	tree_vb->add_child(memnew(HSeparator));
@@ -2571,7 +2541,7 @@ ProjectManager::ProjectManager() {
 	Button *scan = memnew(Button);
 	scan->set_text(TTR("Scan"));
 	tree_vb->add_child(scan);
-	scan->connect_compat("pressed", this, "_scan_projects");
+	scan->connect("pressed", callable_mp(this, &ProjectManager::_scan_projects));
 
 	tree_vb->add_child(memnew(HSeparator));
 
@@ -2581,34 +2551,34 @@ ProjectManager::ProjectManager() {
 	scan_dir->set_title(TTR("Select a Folder to Scan")); // must be after mode or it's overridden
 	scan_dir->set_current_dir(EditorSettings::get_singleton()->get("filesystem/directories/default_project_path"));
 	gui_base->add_child(scan_dir);
-	scan_dir->connect_compat("dir_selected", this, "_scan_begin");
+	scan_dir->connect("dir_selected", callable_mp(this, &ProjectManager::_scan_begin));
 
 	Button *create = memnew(Button);
 	create->set_text(TTR("New Project"));
 	tree_vb->add_child(create);
-	create->connect_compat("pressed", this, "_new_project");
+	create->connect("pressed", callable_mp(this, &ProjectManager::_new_project));
 
 	Button *import = memnew(Button);
 	import->set_text(TTR("Import"));
 	tree_vb->add_child(import);
-	import->connect_compat("pressed", this, "_import_project");
+	import->connect("pressed", callable_mp(this, &ProjectManager::_import_project));
 
 	Button *rename = memnew(Button);
 	rename->set_text(TTR("Rename"));
 	tree_vb->add_child(rename);
-	rename->connect_compat("pressed", this, "_rename_project");
+	rename->connect("pressed", callable_mp(this, &ProjectManager::_rename_project));
 	rename_btn = rename;
 
 	Button *erase = memnew(Button);
 	erase->set_text(TTR("Remove"));
 	tree_vb->add_child(erase);
-	erase->connect_compat("pressed", this, "_erase_project");
+	erase->connect("pressed", callable_mp(this, &ProjectManager::_erase_project));
 	erase_btn = erase;
 
 	Button *erase_missing = memnew(Button);
 	erase_missing->set_text(TTR("Remove Missing"));
 	tree_vb->add_child(erase_missing);
-	erase_missing->connect_compat("pressed", this, "_erase_missing_projects");
+	erase_missing->connect("pressed", callable_mp(this, &ProjectManager::_erase_missing_projects));
 	erase_missing_btn = erase_missing;
 
 	tree_vb->add_spacer();
@@ -2617,7 +2587,7 @@ ProjectManager::ProjectManager() {
 		asset_library = memnew(EditorAssetLibrary(true));
 		asset_library->set_name(TTR("Templates"));
 		tabs->add_child(asset_library);
-		asset_library->connect_compat("install_asset", this, "_install_project");
+		asset_library->connect("install_asset", callable_mp(this, &ProjectManager::_install_project));
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
@@ -2664,7 +2634,7 @@ ProjectManager::ProjectManager() {
 	language_btn->set_icon(get_icon("Environment", "EditorIcons"));
 
 	settings_hb->add_child(language_btn);
-	language_btn->connect_compat("item_selected", this, "_language_selected");
+	language_btn->connect("item_selected", callable_mp(this, &ProjectManager::_language_selected));
 
 	center_box->add_child(settings_hb);
 	settings_hb->set_anchors_and_margins_preset(Control::PRESET_TOP_RIGHT);
@@ -2673,28 +2643,28 @@ ProjectManager::ProjectManager() {
 
 	language_restart_ask = memnew(ConfirmationDialog);
 	language_restart_ask->get_ok()->set_text(TTR("Restart Now"));
-	language_restart_ask->get_ok()->connect_compat("pressed", this, "_restart_confirm");
+	language_restart_ask->get_ok()->connect("pressed", callable_mp(this, &ProjectManager::_restart_confirm));
 	language_restart_ask->get_cancel()->set_text(TTR("Continue"));
 	gui_base->add_child(language_restart_ask);
 
 	erase_missing_ask = memnew(ConfirmationDialog);
 	erase_missing_ask->get_ok()->set_text(TTR("Remove All"));
-	erase_missing_ask->get_ok()->connect_compat("pressed", this, "_erase_missing_projects_confirm");
+	erase_missing_ask->get_ok()->connect("pressed", callable_mp(this, &ProjectManager::_erase_missing_projects_confirm));
 	gui_base->add_child(erase_missing_ask);
 
 	erase_ask = memnew(ConfirmationDialog);
 	erase_ask->get_ok()->set_text(TTR("Remove"));
-	erase_ask->get_ok()->connect_compat("pressed", this, "_erase_project_confirm");
+	erase_ask->get_ok()->connect("pressed", callable_mp(this, &ProjectManager::_erase_project_confirm));
 	gui_base->add_child(erase_ask);
 
 	multi_open_ask = memnew(ConfirmationDialog);
 	multi_open_ask->get_ok()->set_text(TTR("Edit"));
-	multi_open_ask->get_ok()->connect_compat("pressed", this, "_open_selected_projects");
+	multi_open_ask->get_ok()->connect("pressed", callable_mp(this, &ProjectManager::_open_selected_projects));
 	gui_base->add_child(multi_open_ask);
 
 	multi_run_ask = memnew(ConfirmationDialog);
 	multi_run_ask->get_ok()->set_text(TTR("Run"));
-	multi_run_ask->get_ok()->connect_compat("pressed", this, "_run_project_confirm");
+	multi_run_ask->get_ok()->connect("pressed", callable_mp(this, &ProjectManager::_run_project_confirm));
 	gui_base->add_child(multi_run_ask);
 
 	multi_scan_ask = memnew(ConfirmationDialog);
@@ -2702,7 +2672,7 @@ ProjectManager::ProjectManager() {
 	gui_base->add_child(multi_scan_ask);
 
 	ask_update_settings = memnew(ConfirmationDialog);
-	ask_update_settings->get_ok()->connect_compat("pressed", this, "_confirm_update_settings");
+	ask_update_settings->get_ok()->connect("pressed", callable_mp(this, &ProjectManager::_confirm_update_settings));
 	gui_base->add_child(ask_update_settings);
 
 	OS::get_singleton()->set_low_processor_usage_mode(true);
@@ -2710,8 +2680,8 @@ ProjectManager::ProjectManager() {
 	npdialog = memnew(ProjectDialog);
 	gui_base->add_child(npdialog);
 
-	npdialog->connect_compat("projects_updated", this, "_on_projects_updated");
-	npdialog->connect_compat("project_created", this, "_on_project_created");
+	npdialog->connect("projects_updated", callable_mp(this, &ProjectManager::_on_projects_updated));
+	npdialog->connect("project_created", callable_mp(this, &ProjectManager::_on_project_created));
 
 	_load_recent_projects();
 
@@ -2719,8 +2689,8 @@ ProjectManager::ProjectManager() {
 		_scan_begin(EditorSettings::get_singleton()->get("filesystem/directories/autoscan_project_path"));
 	}
 
-	SceneTree::get_singleton()->connect_compat("files_dropped", this, "_files_dropped");
-	SceneTree::get_singleton()->connect_compat("global_menu_action", this, "_global_menu_action");
+	SceneTree::get_singleton()->connect("files_dropped", callable_mp(this, &ProjectManager::_files_dropped));
+	SceneTree::get_singleton()->connect("global_menu_action", callable_mp(this, &ProjectManager::_global_menu_action));
 
 	run_error_diag = memnew(AcceptDialog);
 	gui_base->add_child(run_error_diag);
@@ -2732,7 +2702,7 @@ ProjectManager::ProjectManager() {
 	open_templates = memnew(ConfirmationDialog);
 	open_templates->set_text(TTR("You currently don't have any projects.\nWould you like to explore official example projects in the Asset Library?"));
 	open_templates->get_ok()->set_text(TTR("Open Asset Library"));
-	open_templates->connect_compat("confirmed", this, "_open_asset_library");
+	open_templates->connect("confirmed", callable_mp(this, &ProjectManager::_open_asset_library));
 	add_child(open_templates);
 }
 
@@ -2784,23 +2754,20 @@ void ProjectListFilter::_notification(int p_what) {
 
 void ProjectListFilter::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_search_text_changed"), &ProjectListFilter::_search_text_changed);
-	ClassDB::bind_method(D_METHOD("_filter_option_selected"), &ProjectListFilter::_filter_option_selected);
-
 	ADD_SIGNAL(MethodInfo("filter_changed"));
 }
 
 void ProjectListFilter::add_filter_option() {
 	filter_option = memnew(OptionButton);
 	filter_option->set_clip_text(true);
-	filter_option->connect_compat("item_selected", this, "_filter_option_selected");
+	filter_option->connect("item_selected", callable_mp(this, &ProjectListFilter::_filter_option_selected));
 	add_child(filter_option);
 }
 
 void ProjectListFilter::add_search_box() {
 	search_box = memnew(LineEdit);
 	search_box->set_placeholder(TTR("Search"));
-	search_box->connect_compat("text_changed", this, "_search_text_changed");
+	search_box->connect("text_changed", callable_mp(this, &ProjectListFilter::_search_text_changed));
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_child(search_box);
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -811,7 +811,7 @@ public:
 		create_dir = memnew(Button);
 		pnhb->add_child(create_dir);
 		create_dir->set_text(TTR("Create Folder"));
-		create_dir->connect_compat("pressed", this, "_create_folder");
+		create_dir->connect("pressed", callable_mp(this, &ProjectDialog::_create_folder));
 
 		path_container = memnew(VBoxContainer);
 		vb->add_child(path_container);
@@ -848,7 +848,7 @@ public:
 
 		browse = memnew(Button);
 		browse->set_text(TTR("Browse"));
-		browse->connect_compat("pressed", this, "_browse_path");
+		browse->connect("pressed", callable_mp(this, &ProjectDialog::_browse_path));
 		pphb->add_child(browse);
 
 		// install status icon
@@ -858,7 +858,7 @@ public:
 
 		install_browse = memnew(Button);
 		install_browse->set_text(TTR("Browse"));
-		install_browse->connect_compat("pressed", this, "_browse_install_path");
+		install_browse->connect("pressed", callable_mp(this, &ProjectDialog::_browse_install_path));
 		iphb->add_child(install_browse);
 
 		msg = memnew(Label);
@@ -928,13 +928,13 @@ public:
 		fdialog_install->set_access(FileDialog::ACCESS_FILESYSTEM);
 		add_child(fdialog);
 		add_child(fdialog_install);
-		project_name->connect_compat("text_changed", this, "_text_changed");
-		project_path->connect_compat("text_changed", this, "_path_text_changed");
-		install_path->connect_compat("text_changed", this, "_path_text_changed");
-		fdialog->connect_compat("dir_selected", this, "_path_selected");
-		fdialog->connect_compat("file_selected", this, "_file_selected");
-		fdialog_install->connect_compat("dir_selected", this, "_install_path_selected");
-		fdialog_install->connect_compat("file_selected", this, "_install_path_selected");
+		project_name->connect("text_changed", callable_mp(this, &ProjectDialog::_text_changed));
+		project_path->connect("text_changed", callable_mp(this, &ProjectDialog::_path_text_changed));
+		install_path->connect("text_changed", callable_mp(this, &ProjectDialog::_path_text_changed));
+		fdialog->connect("dir_selected", callable_mp(this, &ProjectDialog::_path_selected));
+		fdialog->connect("file_selected", callable_mp(this, &ProjectDialog::_file_selected));
+		fdialog_install->connect("dir_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
+		fdialog_install->connect("file_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
 
 		set_hide_on_ok(false);
 		mode = MODE_NEW;
@@ -2516,8 +2516,8 @@ ProjectManager::ProjectManager() {
 	pc->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	_project_list = memnew(ProjectList);
-	_project_list->connect_compat(ProjectList::SIGNAL_SELECTION_CHANGED, this, "_update_project_buttons");
-	_project_list->connect_compat(ProjectList::SIGNAL_PROJECT_ASK_OPEN, this, "_open_selected_projects_ask");
+	_project_list->connect(ProjectList::SIGNAL_SELECTION_CHANGED, callable_mp(this, &ProjectManager::_update_project_buttons));
+	_project_list->connect(ProjectList::SIGNAL_PROJECT_ASK_OPEN, callable_mp(this, &ProjectManager::_open_selected_projects_ask));
 	pc->add_child(_project_list);
 	_project_list->set_enable_h_scroll(false);
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -2098,7 +2098,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);
-	timer->connect_compat("timeout", ProjectSettings::get_singleton(), "save");
+	timer->connect("timeout", callable_mp(ProjectSettings::get_singleton(), &ProjectSettings::save));
 	timer->set_one_shot(true);
 	add_child(timer);
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -108,7 +108,7 @@ void ProjectSettingsEditor::_notification(int p_what) {
 
 			action_add_error->add_color_override("font_color", get_color("error_color", "Editor"));
 
-			translation_list->connect_compat("button_pressed", this, "_translation_delete");
+			translation_list->connect("button_pressed", callable_mp(this, &ProjectSettingsEditor::_translation_delete));
 			_update_actions();
 			popup_add->add_icon_item(get_icon("Keyboard", "EditorIcons"), TTR("Key "), INPUT_KEY); //"Key " - because the word 'key' has already been used as a key animation
 			popup_add->add_icon_item(get_icon("JoyButton", "EditorIcons"), TTR("Joy Button"), INPUT_JOY_BUTTON);
@@ -1724,51 +1724,10 @@ void ProjectSettingsEditor::_editor_restart_close() {
 void ProjectSettingsEditor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_unhandled_input"), &ProjectSettingsEditor::_unhandled_input);
-	ClassDB::bind_method(D_METHOD("_item_selected"), &ProjectSettingsEditor::_item_selected);
-	ClassDB::bind_method(D_METHOD("_item_add"), &ProjectSettingsEditor::_item_add);
-	ClassDB::bind_method(D_METHOD("_item_adds"), &ProjectSettingsEditor::_item_adds);
-	ClassDB::bind_method(D_METHOD("_item_del"), &ProjectSettingsEditor::_item_del);
 	ClassDB::bind_method(D_METHOD("_item_checked"), &ProjectSettingsEditor::_item_checked);
 	ClassDB::bind_method(D_METHOD("_save"), &ProjectSettingsEditor::_save);
-	ClassDB::bind_method(D_METHOD("_action_add"), &ProjectSettingsEditor::_action_add);
-	ClassDB::bind_method(D_METHOD("_action_adds"), &ProjectSettingsEditor::_action_adds);
-	ClassDB::bind_method(D_METHOD("_action_check"), &ProjectSettingsEditor::_action_check);
-	ClassDB::bind_method(D_METHOD("_action_selected"), &ProjectSettingsEditor::_action_selected);
-	ClassDB::bind_method(D_METHOD("_action_edited"), &ProjectSettingsEditor::_action_edited);
-	ClassDB::bind_method(D_METHOD("_action_activated"), &ProjectSettingsEditor::_action_activated);
-	ClassDB::bind_method(D_METHOD("_action_button_pressed"), &ProjectSettingsEditor::_action_button_pressed);
 	ClassDB::bind_method(D_METHOD("_update_actions"), &ProjectSettingsEditor::_update_actions);
-	ClassDB::bind_method(D_METHOD("_wait_for_key"), &ProjectSettingsEditor::_wait_for_key);
-	ClassDB::bind_method(D_METHOD("_add_item"), &ProjectSettingsEditor::_add_item, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("_device_input_add"), &ProjectSettingsEditor::_device_input_add);
-	ClassDB::bind_method(D_METHOD("_press_a_key_confirm"), &ProjectSettingsEditor::_press_a_key_confirm);
-	ClassDB::bind_method(D_METHOD("_settings_prop_edited"), &ProjectSettingsEditor::_settings_prop_edited);
-	ClassDB::bind_method(D_METHOD("_copy_to_platform"), &ProjectSettingsEditor::_copy_to_platform);
 	ClassDB::bind_method(D_METHOD("_update_translations"), &ProjectSettingsEditor::_update_translations);
-	ClassDB::bind_method(D_METHOD("_translation_delete"), &ProjectSettingsEditor::_translation_delete);
-	ClassDB::bind_method(D_METHOD("_settings_changed"), &ProjectSettingsEditor::_settings_changed);
-	ClassDB::bind_method(D_METHOD("_translation_add"), &ProjectSettingsEditor::_translation_add);
-	ClassDB::bind_method(D_METHOD("_translation_file_open"), &ProjectSettingsEditor::_translation_file_open);
-
-	ClassDB::bind_method(D_METHOD("_translation_res_add"), &ProjectSettingsEditor::_translation_res_add);
-	ClassDB::bind_method(D_METHOD("_translation_res_file_open"), &ProjectSettingsEditor::_translation_res_file_open);
-	ClassDB::bind_method(D_METHOD("_translation_res_option_add"), &ProjectSettingsEditor::_translation_res_option_add);
-	ClassDB::bind_method(D_METHOD("_translation_res_option_file_open"), &ProjectSettingsEditor::_translation_res_option_file_open);
-	ClassDB::bind_method(D_METHOD("_translation_res_select"), &ProjectSettingsEditor::_translation_res_select);
-	ClassDB::bind_method(D_METHOD("_translation_res_option_changed"), &ProjectSettingsEditor::_translation_res_option_changed);
-	ClassDB::bind_method(D_METHOD("_translation_res_delete"), &ProjectSettingsEditor::_translation_res_delete);
-	ClassDB::bind_method(D_METHOD("_translation_res_option_delete"), &ProjectSettingsEditor::_translation_res_option_delete);
-
-	ClassDB::bind_method(D_METHOD("_translation_filter_option_changed"), &ProjectSettingsEditor::_translation_filter_option_changed);
-	ClassDB::bind_method(D_METHOD("_translation_filter_mode_changed"), &ProjectSettingsEditor::_translation_filter_mode_changed);
-
-	ClassDB::bind_method(D_METHOD("_toggle_search_bar"), &ProjectSettingsEditor::_toggle_search_bar);
-
-	ClassDB::bind_method(D_METHOD("_copy_to_platform_about_to_show"), &ProjectSettingsEditor::_copy_to_platform_about_to_show);
-
-	ClassDB::bind_method(D_METHOD("_editor_restart_request"), &ProjectSettingsEditor::_editor_restart_request);
-	ClassDB::bind_method(D_METHOD("_editor_restart"), &ProjectSettingsEditor::_editor_restart);
-	ClassDB::bind_method(D_METHOD("_editor_restart_close"), &ProjectSettingsEditor::_editor_restart_close);
 
 	ClassDB::bind_method(D_METHOD("get_tabs"), &ProjectSettingsEditor::get_tabs);
 
@@ -1805,7 +1764,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	search_button->set_pressed(false);
 	search_button->set_text(TTR("Search"));
 	hbc->add_child(search_button);
-	search_button->connect_compat("toggled", this, "_toggle_search_bar");
+	search_button->connect("toggled", callable_mp(this, &ProjectSettingsEditor::_toggle_search_bar));
 
 	hbc->add_child(memnew(VSeparator));
 
@@ -1820,7 +1779,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	category = memnew(LineEdit);
 	category->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_prop_bar->add_child(category);
-	category->connect_compat("text_entered", this, "_item_adds");
+	category->connect("text_entered", callable_mp(this, &ProjectSettingsEditor::_item_adds));
 
 	l = memnew(Label);
 	add_prop_bar->add_child(l);
@@ -1829,7 +1788,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	property = memnew(LineEdit);
 	property->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_prop_bar->add_child(property);
-	property->connect_compat("text_entered", this, "_item_adds");
+	property->connect("text_entered", callable_mp(this, &ProjectSettingsEditor::_item_adds));
 
 	l = memnew(Label);
 	add_prop_bar->add_child(l);
@@ -1847,7 +1806,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	Button *add = memnew(Button);
 	add_prop_bar->add_child(add);
 	add->set_text(TTR("Add"));
-	add->connect_compat("pressed", this, "_item_add");
+	add->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_item_add));
 
 	search_bar = memnew(HBoxContainer);
 	search_bar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1863,14 +1822,14 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	globals_editor->get_inspector()->set_undo_redo(EditorNode::get_singleton()->get_undo_redo());
 	globals_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	globals_editor->register_search_box(search_box);
-	globals_editor->get_inspector()->connect_compat("property_selected", this, "_item_selected");
-	globals_editor->get_inspector()->connect_compat("property_edited", this, "_settings_prop_edited");
-	globals_editor->get_inspector()->connect_compat("restart_requested", this, "_editor_restart_request");
+	globals_editor->get_inspector()->connect("property_selected", callable_mp(this, &ProjectSettingsEditor::_item_selected));
+	globals_editor->get_inspector()->connect("property_edited", callable_mp(this, &ProjectSettingsEditor::_settings_prop_edited));
+	globals_editor->get_inspector()->connect("restart_requested", callable_mp(this, &ProjectSettingsEditor::_editor_restart_request));
 
 	Button *del = memnew(Button);
 	hbc->add_child(del);
 	del->set_text(TTR("Delete"));
-	del->connect_compat("pressed", this, "_item_del");
+	del->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_item_del));
 
 	add_prop_bar->add_child(memnew(VSeparator));
 
@@ -1879,8 +1838,8 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	popup_copy_to_feature->set_disabled(true);
 	add_prop_bar->add_child(popup_copy_to_feature);
 
-	popup_copy_to_feature->get_popup()->connect_compat("id_pressed", this, "_copy_to_platform");
-	popup_copy_to_feature->get_popup()->connect_compat("about_to_show", this, "_copy_to_platform_about_to_show");
+	popup_copy_to_feature->get_popup()->connect("id_pressed", callable_mp(this, &ProjectSettingsEditor::_copy_to_platform));
+	popup_copy_to_feature->get_popup()->connect("about_to_show", callable_mp(this, &ProjectSettingsEditor::_copy_to_platform_about_to_show));
 
 	get_ok()->set_text(TTR("Close"));
 	set_hide_on_ok(true);
@@ -1897,11 +1856,11 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	restart_hb->add_child(restart_label);
 	restart_hb->add_spacer();
 	Button *restart_button = memnew(Button);
-	restart_button->connect_compat("pressed", this, "_editor_restart");
+	restart_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_editor_restart));
 	restart_hb->add_child(restart_button);
 	restart_button->set_text(TTR("Save & Restart"));
 	restart_close_button = memnew(ToolButton);
-	restart_close_button->connect_compat("pressed", this, "_editor_restart_close");
+	restart_close_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_editor_restart_close));
 	restart_hb->add_child(restart_close_button);
 	restart_container->hide();
 
@@ -1929,8 +1888,8 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	action_name = memnew(LineEdit);
 	action_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	hbc->add_child(action_name);
-	action_name->connect_compat("text_entered", this, "_action_adds");
-	action_name->connect_compat("text_changed", this, "_action_check");
+	action_name->connect("text_entered", callable_mp(this, &ProjectSettingsEditor::_action_adds));
+	action_name->connect("text_changed", callable_mp(this, &ProjectSettingsEditor::_action_check));
 
 	action_add_error = memnew(Label);
 	hbc->add_child(action_add_error);
@@ -1940,7 +1899,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	hbc->add_child(add);
 	add->set_text(TTR("Add"));
 	add->set_disabled(true);
-	add->connect_compat("pressed", this, "_action_add");
+	add->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_action_add));
 	action_add = add;
 
 	input_editor = memnew(Tree);
@@ -1954,15 +1913,15 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	input_editor->set_column_min_width(1, 80 * EDSCALE);
 	input_editor->set_column_expand(2, false);
 	input_editor->set_column_min_width(2, 50 * EDSCALE);
-	input_editor->connect_compat("item_edited", this, "_action_edited");
-	input_editor->connect_compat("item_activated", this, "_action_activated");
-	input_editor->connect_compat("cell_selected", this, "_action_selected");
-	input_editor->connect_compat("button_pressed", this, "_action_button_pressed");
+	input_editor->connect("item_edited", callable_mp(this, &ProjectSettingsEditor::_action_edited));
+	input_editor->connect("item_activated", callable_mp(this, &ProjectSettingsEditor::_action_activated));
+	input_editor->connect("cell_selected", callable_mp(this, &ProjectSettingsEditor::_action_selected));
+	input_editor->connect("button_pressed", callable_mp(this, &ProjectSettingsEditor::_action_button_pressed));
 	input_editor->set_drag_forwarding(this);
 
 	popup_add = memnew(PopupMenu);
 	add_child(popup_add);
-	popup_add->connect_compat("id_pressed", this, "_add_item");
+	popup_add->connect("id_pressed", callable_mp(this, &ProjectSettingsEditor::_add_item));
 
 	press_a_key = memnew(ConfirmationDialog);
 	press_a_key->set_focus_mode(FOCUS_ALL);
@@ -1977,13 +1936,13 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	press_a_key->get_ok()->set_disabled(true);
 	press_a_key_label = l;
 	press_a_key->add_child(l);
-	press_a_key->connect_compat("gui_input", this, "_wait_for_key");
-	press_a_key->connect_compat("confirmed", this, "_press_a_key_confirm");
+	press_a_key->connect("gui_input", callable_mp(this, &ProjectSettingsEditor::_wait_for_key));
+	press_a_key->connect("confirmed", callable_mp(this, &ProjectSettingsEditor::_press_a_key_confirm));
 
 	device_input = memnew(ConfirmationDialog);
 	add_child(device_input);
 	device_input->get_ok()->set_text(TTR("Add"));
-	device_input->connect_compat("confirmed", this, "_device_input_add");
+	device_input->connect("confirmed", callable_mp(this, &ProjectSettingsEditor::_device_input_add));
 
 	hbc = memnew(HBoxContainer);
 	device_input->add_child(hbc);
@@ -2034,7 +1993,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		thb->add_child(memnew(Label(TTR("Translations:"))));
 		thb->add_spacer();
 		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect_compat("pressed", this, "_translation_file_open");
+		addtr->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_translation_file_open));
 		thb->add_child(addtr);
 		VBoxContainer *tmc = memnew(VBoxContainer);
 		tvb->add_child(tmc);
@@ -2046,7 +2005,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		translation_file_open = memnew(EditorFileDialog);
 		add_child(translation_file_open);
 		translation_file_open->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-		translation_file_open->connect_compat("file_selected", this, "_translation_add");
+		translation_file_open->connect("file_selected", callable_mp(this, &ProjectSettingsEditor::_translation_add));
 	}
 
 	{
@@ -2058,28 +2017,28 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		thb->add_child(memnew(Label(TTR("Resources:"))));
 		thb->add_spacer();
 		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect_compat("pressed", this, "_translation_res_file_open");
+		addtr->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_translation_res_file_open));
 		thb->add_child(addtr);
 		VBoxContainer *tmc = memnew(VBoxContainer);
 		tvb->add_child(tmc);
 		tmc->set_v_size_flags(SIZE_EXPAND_FILL);
 		translation_remap = memnew(Tree);
 		translation_remap->set_v_size_flags(SIZE_EXPAND_FILL);
-		translation_remap->connect_compat("cell_selected", this, "_translation_res_select");
+		translation_remap->connect("cell_selected", callable_mp(this, &ProjectSettingsEditor::_translation_res_select));
 		tmc->add_child(translation_remap);
-		translation_remap->connect_compat("button_pressed", this, "_translation_res_delete");
+		translation_remap->connect("button_pressed", callable_mp(this, &ProjectSettingsEditor::_translation_res_delete));
 
 		translation_res_file_open = memnew(EditorFileDialog);
 		add_child(translation_res_file_open);
 		translation_res_file_open->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-		translation_res_file_open->connect_compat("file_selected", this, "_translation_res_add");
+		translation_res_file_open->connect("file_selected", callable_mp(this, &ProjectSettingsEditor::_translation_res_add));
 
 		thb = memnew(HBoxContainer);
 		tvb->add_child(thb);
 		thb->add_child(memnew(Label(TTR("Remaps by Locale:"))));
 		thb->add_spacer();
 		addtr = memnew(Button(TTR("Add...")));
-		addtr->connect_compat("pressed", this, "_translation_res_option_file_open");
+		addtr->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_translation_res_option_file_open));
 		translation_res_option_add_button = addtr;
 		thb->add_child(addtr);
 		tmc = memnew(VBoxContainer);
@@ -2096,13 +2055,13 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		translation_remap_options->set_column_expand(0, true);
 		translation_remap_options->set_column_expand(1, false);
 		translation_remap_options->set_column_min_width(1, 200);
-		translation_remap_options->connect_compat("item_edited", this, "_translation_res_option_changed");
-		translation_remap_options->connect_compat("button_pressed", this, "_translation_res_option_delete");
+		translation_remap_options->connect("item_edited", callable_mp(this, &ProjectSettingsEditor::_translation_res_option_changed));
+		translation_remap_options->connect("button_pressed", callable_mp(this, &ProjectSettingsEditor::_translation_res_option_delete));
 
 		translation_res_option_file_open = memnew(EditorFileDialog);
 		add_child(translation_res_option_file_open);
 		translation_res_option_file_open->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-		translation_res_option_file_open->connect_compat("file_selected", this, "_translation_res_option_add");
+		translation_res_option_file_open->connect("file_selected", callable_mp(this, &ProjectSettingsEditor::_translation_res_option_add));
 	}
 
 	{
@@ -2118,20 +2077,20 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		translation_locale_filter_mode->add_item(TTR("Show Selected Locales Only"), SHOW_ONLY_SELECTED_LOCALES);
 		translation_locale_filter_mode->select(0);
 		tmc->add_margin_child(TTR("Filter mode:"), translation_locale_filter_mode);
-		translation_locale_filter_mode->connect_compat("item_selected", this, "_translation_filter_mode_changed");
+		translation_locale_filter_mode->connect("item_selected", callable_mp(this, &ProjectSettingsEditor::_translation_filter_mode_changed));
 
 		translation_filter = memnew(Tree);
 		translation_filter->set_v_size_flags(SIZE_EXPAND_FILL);
 		translation_filter->set_columns(1);
 		tmc->add_child(memnew(Label(TTR("Locales:"))));
 		tmc->add_child(translation_filter);
-		translation_filter->connect_compat("item_edited", this, "_translation_filter_option_changed");
+		translation_filter->connect("item_edited", callable_mp(this, &ProjectSettingsEditor::_translation_filter_option_changed));
 	}
 
 	autoload_settings = memnew(EditorAutoloadSettings);
 	autoload_settings->set_name(TTR("AutoLoad"));
 	tab_container->add_child(autoload_settings);
-	autoload_settings->connect_compat("autoload_changed", this, "_settings_changed");
+	autoload_settings->connect("autoload_changed", callable_mp(this, &ProjectSettingsEditor::_settings_changed));
 
 	plugin_settings = memnew(EditorPluginSettings);
 	plugin_settings->set_name(TTR("Plugins"));

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1727,6 +1727,7 @@ void ProjectSettingsEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_item_checked"), &ProjectSettingsEditor::_item_checked);
 	ClassDB::bind_method(D_METHOD("_save"), &ProjectSettingsEditor::_save);
 	ClassDB::bind_method(D_METHOD("_update_actions"), &ProjectSettingsEditor::_update_actions);
+	ClassDB::bind_method(D_METHOD("_settings_changed"), &ProjectSettingsEditor::_settings_changed);
 	ClassDB::bind_method(D_METHOD("_update_translations"), &ProjectSettingsEditor::_update_translations);
 
 	ClassDB::bind_method(D_METHOD("get_tabs"), &ProjectSettingsEditor::get_tabs);
@@ -1921,7 +1922,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	popup_add = memnew(PopupMenu);
 	add_child(popup_add);
-	popup_add->connect("id_pressed", callable_mp(this, &ProjectSettingsEditor::_add_item));
+	popup_add->connect("id_pressed", callable_mp(this, &ProjectSettingsEditor::_add_item), make_binds(Ref<InputEvent>()));
 
 	press_a_key = memnew(ConfirmationDialog);
 	press_a_key->set_focus_mode(FOCUS_ALL);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -589,7 +589,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 				if (!create_dialog) {
 					create_dialog = memnew(CreateDialog);
-					create_dialog->connect_compat("create", this, "_create_dialog_callback");
+					create_dialog->connect("create", callable_mp(this, &CustomPropertyEditor::_create_dialog_callback));
 					add_child(create_dialog);
 				}
 
@@ -605,12 +605,12 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				return false;
 
 			} else if (hint == PROPERTY_HINT_METHOD_OF_VARIANT_TYPE) {
-#define MAKE_PROPSELECT                                                                 \
-	if (!property_select) {                                                             \
-		property_select = memnew(PropertySelector);                                     \
-		property_select->connect_compat("selected", this, "_create_selected_property"); \
-		add_child(property_select);                                                     \
-	}                                                                                   \
+#define MAKE_PROPSELECT                                                                                            \
+	if (!property_select) {                                                                                        \
+		property_select = memnew(PropertySelector);                                                                \
+		property_select->connect("selected", callable_mp(this, &CustomPropertyEditor::_create_selected_property)); \
+		add_child(property_select);                                                                                \
+	}                                                                                                              \
 	hide();
 
 				MAKE_PROPSELECT;
@@ -865,7 +865,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				color_picker->set_deferred_mode(true);
 				add_child(color_picker);
 				color_picker->hide();
-				color_picker->connect_compat("color_changed", this, "_color_changed");
+				color_picker->connect("color_changed", callable_mp(this, &CustomPropertyEditor::_color_changed));
 
 				// get default color picker mode from editor settings
 				int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
@@ -1868,22 +1868,6 @@ void CustomPropertyEditor::config_value_editors(int p_amount, int p_columns, int
 
 void CustomPropertyEditor::_bind_methods() {
 
-	ClassDB::bind_method("_focus_enter", &CustomPropertyEditor::_focus_enter);
-	ClassDB::bind_method("_focus_exit", &CustomPropertyEditor::_focus_exit);
-	ClassDB::bind_method("_modified", &CustomPropertyEditor::_modified);
-	ClassDB::bind_method("_range_modified", &CustomPropertyEditor::_range_modified);
-	ClassDB::bind_method("_action_pressed", &CustomPropertyEditor::_action_pressed);
-	ClassDB::bind_method("_file_selected", &CustomPropertyEditor::_file_selected);
-	ClassDB::bind_method("_type_create_selected", &CustomPropertyEditor::_type_create_selected);
-	ClassDB::bind_method("_node_path_selected", &CustomPropertyEditor::_node_path_selected);
-	ClassDB::bind_method("_color_changed", &CustomPropertyEditor::_color_changed);
-	ClassDB::bind_method("_draw_easing", &CustomPropertyEditor::_draw_easing);
-	ClassDB::bind_method("_drag_easing", &CustomPropertyEditor::_drag_easing);
-	ClassDB::bind_method("_text_edit_changed", &CustomPropertyEditor::_text_edit_changed);
-	ClassDB::bind_method("_menu_option", &CustomPropertyEditor::_menu_option);
-	ClassDB::bind_method("_create_dialog_callback", &CustomPropertyEditor::_create_dialog_callback);
-	ClassDB::bind_method("_create_selected_property", &CustomPropertyEditor::_create_selected_property);
-
 	ADD_SIGNAL(MethodInfo("variant_changed"));
 	ADD_SIGNAL(MethodInfo("variant_field_changed", PropertyInfo(Variant::STRING, "field")));
 	ADD_SIGNAL(MethodInfo("resource_edit_request"));
@@ -1902,9 +1886,9 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		add_child(value_label[i]);
 		value_editor[i]->hide();
 		value_label[i]->hide();
-		value_editor[i]->connect_compat("text_entered", this, "_modified");
-		value_editor[i]->connect_compat("focus_entered", this, "_focus_enter");
-		value_editor[i]->connect_compat("focus_exited", this, "_focus_exit");
+		value_editor[i]->connect("text_entered", callable_mp(this, &CustomPropertyEditor::_modified));
+		value_editor[i]->connect("focus_entered", callable_mp(this, &CustomPropertyEditor::_focus_enter));
+		value_editor[i]->connect("focus_exited", callable_mp(this, &CustomPropertyEditor::_focus_exit));
 	}
 	focused_value_editor = -1;
 
@@ -1934,7 +1918,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		checks20[i]->set_focus_mode(FOCUS_NONE);
 		checks20gc->add_child(checks20[i]);
 		checks20[i]->hide();
-		checks20[i]->connect_compat("pressed", this, "_action_pressed", make_binds(i));
+		checks20[i]->connect("pressed", callable_mp(this, &CustomPropertyEditor::_action_pressed), make_binds(i));
 		checks20[i]->set_tooltip(vformat(TTR("Bit %d, val %d."), i, 1 << i));
 	}
 
@@ -1944,7 +1928,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	text_edit->set_margin(MARGIN_BOTTOM, -30);
 
 	text_edit->hide();
-	text_edit->connect_compat("text_changed", this, "_text_edit_changed");
+	text_edit->connect("text_changed", callable_mp(this, &CustomPropertyEditor::_text_edit_changed));
 
 	for (int i = 0; i < MAX_ACTION_BUTTONS; i++) {
 
@@ -1953,7 +1937,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		add_child(action_buttons[i]);
 		Vector<Variant> binds;
 		binds.push_back(i);
-		action_buttons[i]->connect_compat("pressed", this, "_action_pressed", binds);
+		action_buttons[i]->connect("pressed", callable_mp(this, &CustomPropertyEditor::_action_pressed), binds);
 		action_buttons[i]->set_flat(true);
 	}
 
@@ -1964,8 +1948,8 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	add_child(file);
 	file->hide();
 
-	file->connect_compat("file_selected", this, "_file_selected");
-	file->connect_compat("dir_selected", this, "_file_selected");
+	file->connect("file_selected", callable_mp(this, &CustomPropertyEditor::_file_selected));
+	file->connect("dir_selected", callable_mp(this, &CustomPropertyEditor::_file_selected));
 
 	error = memnew(ConfirmationDialog);
 	error->set_title(TTR("Error!"));
@@ -1973,7 +1957,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 
 	scene_tree = memnew(SceneTreeDialog);
 	add_child(scene_tree);
-	scene_tree->connect_compat("selected", this, "_node_path_selected");
+	scene_tree->connect("selected", callable_mp(this, &CustomPropertyEditor::_node_path_selected));
 	scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
 
 	texture_preview = memnew(TextureRect);
@@ -1983,31 +1967,31 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	easing_draw = memnew(Control);
 	add_child(easing_draw);
 	easing_draw->hide();
-	easing_draw->connect_compat("draw", this, "_draw_easing");
-	easing_draw->connect_compat("gui_input", this, "_drag_easing");
+	easing_draw->connect("draw", callable_mp(this, &CustomPropertyEditor::_draw_easing));
+	easing_draw->connect("gui_input", callable_mp(this, &CustomPropertyEditor::_drag_easing));
 	easing_draw->set_default_cursor_shape(Control::CURSOR_MOVE);
 
 	type_button = memnew(MenuButton);
 	add_child(type_button);
 	type_button->hide();
-	type_button->get_popup()->connect_compat("id_pressed", this, "_type_create_selected");
+	type_button->get_popup()->connect("id_pressed", callable_mp(this, &CustomPropertyEditor::_type_create_selected));
 
 	menu = memnew(PopupMenu);
 	menu->set_pass_on_modal_close_click(false);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_menu_option");
+	menu->connect("id_pressed", callable_mp(this, &CustomPropertyEditor::_menu_option));
 
 	evaluator = NULL;
 
 	spinbox = memnew(SpinBox);
 	add_child(spinbox);
 	spinbox->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
-	spinbox->connect_compat("value_changed", this, "_range_modified");
+	spinbox->connect("value_changed", callable_mp(this, &CustomPropertyEditor::_range_modified));
 
 	slider = memnew(HSlider);
 	add_child(slider);
 	slider->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
-	slider->connect_compat("value_changed", this, "_range_modified");
+	slider->connect("value_changed", callable_mp(this, &CustomPropertyEditor::_range_modified));
 
 	create_dialog = NULL;
 	property_select = NULL;

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -393,9 +393,9 @@ void PropertySelector::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		connect_compat("confirmed", this, "_confirmed");
+		connect("confirmed", callable_mp(this, &PropertySelector::_confirmed));
 	} else if (p_what == NOTIFICATION_EXIT_TREE) {
-		disconnect_compat("confirmed", this, "_confirmed");
+		disconnect("confirmed", callable_mp(this, &PropertySelector::_confirmed));
 	}
 }
 
@@ -542,11 +542,6 @@ void PropertySelector::set_type_filter(const Vector<Variant::Type> &p_type_filte
 
 void PropertySelector::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_text_changed"), &PropertySelector::_text_changed);
-	ClassDB::bind_method(D_METHOD("_confirmed"), &PropertySelector::_confirmed);
-	ClassDB::bind_method(D_METHOD("_sbox_input"), &PropertySelector::_sbox_input);
-	ClassDB::bind_method(D_METHOD("_item_selected"), &PropertySelector::_item_selected);
-
 	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::STRING, "name")));
 }
 
@@ -557,16 +552,16 @@ PropertySelector::PropertySelector() {
 	//set_child_rect(vbc);
 	search_box = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", callable_mp(this, &PropertySelector::_text_changed));
+	search_box->connect("gui_input", callable_mp(this, &PropertySelector::_sbox_input));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_text(TTR("Open"));
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
-	search_options->connect_compat("cell_selected", this, "_item_selected");
+	search_options->connect("item_activated", callable_mp(this, &PropertySelector::_confirmed));
+	search_options->connect("cell_selected", callable_mp(this, &PropertySelector::_item_selected));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
 	virtuals_only = false;

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -257,7 +257,7 @@ void EditorQuickOpen::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("confirmed", this, "_confirmed");
+			connect("confirmed", callable_mp(this, &EditorQuickOpen::_confirmed));
 
 			search_box->set_clear_button_enabled(true);
 			[[fallthrough]];
@@ -266,7 +266,7 @@ void EditorQuickOpen::_notification(int p_what) {
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("confirmed", this, "_confirmed");
+			disconnect("confirmed", callable_mp(this, &EditorQuickOpen::_confirmed));
 		} break;
 	}
 }
@@ -278,10 +278,6 @@ StringName EditorQuickOpen::get_base_type() const {
 
 void EditorQuickOpen::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_text_changed"), &EditorQuickOpen::_text_changed);
-	ClassDB::bind_method(D_METHOD("_confirmed"), &EditorQuickOpen::_confirmed);
-	ClassDB::bind_method(D_METHOD("_sbox_input"), &EditorQuickOpen::_sbox_input);
-
 	ADD_SIGNAL(MethodInfo("quick_open"));
 }
 
@@ -291,15 +287,15 @@ EditorQuickOpen::EditorQuickOpen() {
 	add_child(vbc);
 	search_box = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", callable_mp(this, &EditorQuickOpen::_text_changed));
+	search_box->connect("gui_input", callable_mp(this, &EditorQuickOpen::_sbox_input));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_text(TTR("Open"));
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
+	search_options->connect("item_activated", callable_mp(this, &EditorQuickOpen::_confirmed));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
 	search_options->add_constant_override("draw_guides", 1);

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -144,7 +144,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_name->set_text("NAME");
 	but_insert_name->set_tooltip(String("${NAME}\n") + TTR("Node name"));
 	but_insert_name->set_focus_mode(FOCUS_NONE);
-	but_insert_name->connect_compat("pressed", this, "_insert_text", make_binds("${NAME}"));
+	but_insert_name->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${NAME}"));
 	but_insert_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_name);
 
@@ -154,7 +154,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_parent->set_text("PARENT");
 	but_insert_parent->set_tooltip(String("${PARENT}\n") + TTR("Node's parent name, if available"));
 	but_insert_parent->set_focus_mode(FOCUS_NONE);
-	but_insert_parent->connect_compat("pressed", this, "_insert_text", make_binds("${PARENT}"));
+	but_insert_parent->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${PARENT}"));
 	but_insert_parent->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_parent);
 
@@ -164,7 +164,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_type->set_text("TYPE");
 	but_insert_type->set_tooltip(String("${TYPE}\n") + TTR("Node type"));
 	but_insert_type->set_focus_mode(FOCUS_NONE);
-	but_insert_type->connect_compat("pressed", this, "_insert_text", make_binds("${TYPE}"));
+	but_insert_type->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${TYPE}"));
 	but_insert_type->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_type);
 
@@ -174,7 +174,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_scene->set_text("SCENE");
 	but_insert_scene->set_tooltip(String("${SCENE}\n") + TTR("Current scene name"));
 	but_insert_scene->set_focus_mode(FOCUS_NONE);
-	but_insert_scene->connect_compat("pressed", this, "_insert_text", make_binds("${SCENE}"));
+	but_insert_scene->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${SCENE}"));
 	but_insert_scene->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_scene);
 
@@ -184,7 +184,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_root->set_text("ROOT");
 	but_insert_root->set_tooltip(String("${ROOT}\n") + TTR("Root node name"));
 	but_insert_root->set_focus_mode(FOCUS_NONE);
-	but_insert_root->connect_compat("pressed", this, "_insert_text", make_binds("${ROOT}"));
+	but_insert_root->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${ROOT}"));
 	but_insert_root->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_root);
 
@@ -194,7 +194,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_count->set_text("COUNTER");
 	but_insert_count->set_tooltip(String("${COUNTER}\n") + TTR("Sequential integer counter.\nCompare counter options."));
 	but_insert_count->set_focus_mode(FOCUS_NONE);
-	but_insert_count->connect_compat("pressed", this, "_insert_text", make_binds("${COUNTER}"));
+	but_insert_count->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${COUNTER}"));
 	but_insert_count->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_count);
 
@@ -306,35 +306,35 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	// ---- Connections
 
-	cbut_collapse_features->connect_compat("toggled", this, "_features_toggled");
+	cbut_collapse_features->connect("toggled", callable_mp(this, &RenameDialog::_features_toggled));
 
 	// Substitite Buttons
 
-	lne_search->connect_compat("focus_entered", this, "_update_substitute");
-	lne_search->connect_compat("focus_exited", this, "_update_substitute");
-	lne_replace->connect_compat("focus_entered", this, "_update_substitute");
-	lne_replace->connect_compat("focus_exited", this, "_update_substitute");
-	lne_prefix->connect_compat("focus_entered", this, "_update_substitute");
-	lne_prefix->connect_compat("focus_exited", this, "_update_substitute");
-	lne_suffix->connect_compat("focus_entered", this, "_update_substitute");
-	lne_suffix->connect_compat("focus_exited", this, "_update_substitute");
+	lne_search->connect("focus_entered", callable_mp(this, &RenameDialog::_update_substitute));
+	lne_search->connect("focus_exited", callable_mp(this, &RenameDialog::_update_substitute));
+	lne_replace->connect("focus_entered", callable_mp(this, &RenameDialog::_update_substitute));
+	lne_replace->connect("focus_exited", callable_mp(this, &RenameDialog::_update_substitute));
+	lne_prefix->connect("focus_entered", callable_mp(this, &RenameDialog::_update_substitute));
+	lne_prefix->connect("focus_exited", callable_mp(this, &RenameDialog::_update_substitute));
+	lne_suffix->connect("focus_entered", callable_mp(this, &RenameDialog::_update_substitute));
+	lne_suffix->connect("focus_exited", callable_mp(this, &RenameDialog::_update_substitute));
 
 	// Preview
 
-	lne_prefix->connect_compat("text_changed", this, "_update_preview");
-	lne_suffix->connect_compat("text_changed", this, "_update_preview");
-	lne_search->connect_compat("text_changed", this, "_update_preview");
-	lne_replace->connect_compat("text_changed", this, "_update_preview");
-	spn_count_start->connect_compat("value_changed", this, "_update_preview_int");
-	spn_count_step->connect_compat("value_changed", this, "_update_preview_int");
-	spn_count_padding->connect_compat("value_changed", this, "_update_preview_int");
-	opt_style->connect_compat("item_selected", this, "_update_preview_int");
-	opt_case->connect_compat("item_selected", this, "_update_preview_int");
-	cbut_substitute->connect_compat("pressed", this, "_update_preview", varray(""));
-	cbut_regex->connect_compat("pressed", this, "_update_preview", varray(""));
-	cbut_process->connect_compat("pressed", this, "_update_preview", varray(""));
+	lne_prefix->connect("text_changed", callable_mp(this, &RenameDialog::_update_preview));
+	lne_suffix->connect("text_changed", callable_mp(this, &RenameDialog::_update_preview));
+	lne_search->connect("text_changed", callable_mp(this, &RenameDialog::_update_preview));
+	lne_replace->connect("text_changed", callable_mp(this, &RenameDialog::_update_preview));
+	spn_count_start->connect("value_changed", callable_mp(this, &RenameDialog::_update_preview_int));
+	spn_count_step->connect("value_changed", callable_mp(this, &RenameDialog::_update_preview_int));
+	spn_count_padding->connect("value_changed", callable_mp(this, &RenameDialog::_update_preview_int));
+	opt_style->connect("item_selected", callable_mp(this, &RenameDialog::_update_preview_int));
+	opt_case->connect("item_selected", callable_mp(this, &RenameDialog::_update_preview_int));
+	cbut_substitute->connect("pressed", callable_mp(this, &RenameDialog::_update_preview), varray(""));
+	cbut_regex->connect("pressed", callable_mp(this, &RenameDialog::_update_preview), varray(""));
+	cbut_process->connect("pressed", callable_mp(this, &RenameDialog::_update_preview), varray(""));
 
-	but_reset->connect_compat("pressed", this, "reset");
+	but_reset->connect("pressed", callable_mp(this, &RenameDialog::reset));
 
 	reset();
 	_features_toggled(false);
@@ -342,12 +342,6 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 void RenameDialog::_bind_methods() {
 
-	ClassDB::bind_method("_features_toggled", &RenameDialog::_features_toggled);
-	ClassDB::bind_method("_update_preview", &RenameDialog::_update_preview);
-	ClassDB::bind_method("_update_preview_int", &RenameDialog::_update_preview_int);
-	ClassDB::bind_method("_insert_text", &RenameDialog::_insert_text);
-	ClassDB::bind_method("_update_substitute", &RenameDialog::_update_substitute);
-	ClassDB::bind_method("reset", &RenameDialog::reset);
 	ClassDB::bind_method("rename", &RenameDialog::rename);
 }
 

--- a/editor/reparent_dialog.cpp
+++ b/editor/reparent_dialog.cpp
@@ -38,12 +38,12 @@ void ReparentDialog::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		connect_compat("confirmed", this, "_reparent");
+		connect("confirmed", callable_mp(this, &ReparentDialog::_reparent));
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
-		disconnect_compat("confirmed", this, "_reparent");
+		disconnect("confirmed", callable_mp(this, &ReparentDialog::_reparent));
 	}
 
 	if (p_what == NOTIFICATION_DRAW) {
@@ -74,7 +74,6 @@ void ReparentDialog::set_current(const Set<Node *> &p_selection) {
 
 void ReparentDialog::_bind_methods() {
 
-	ClassDB::bind_method("_reparent", &ReparentDialog::_reparent);
 	ClassDB::bind_method("_cancel", &ReparentDialog::_cancel);
 
 	ADD_SIGNAL(MethodInfo("reparent", PropertyInfo(Variant::NODE_PATH, "path"), PropertyInfo(Variant::BOOL, "keep_global_xform")));
@@ -93,7 +92,7 @@ ReparentDialog::ReparentDialog() {
 
 	vbc->add_margin_child(TTR("Reparent Location (Select new Parent):"), tree, true);
 
-	tree->get_scene_tree()->connect_compat("item_activated", this, "_reparent");
+	tree->get_scene_tree()->connect("item_activated", callable_mp(this, &ReparentDialog::_reparent));
 
 	//Label *label = memnew( Label );
 	//label->set_position( Point2( 15,8) );

--- a/editor/run_settings_dialog.cpp
+++ b/editor/run_settings_dialog.cpp
@@ -46,7 +46,6 @@ String RunSettingsDialog::get_custom_arguments() const {
 
 void RunSettingsDialog::_bind_methods() {
 
-	ClassDB::bind_method("_run_mode_changed", &RunSettingsDialog::_run_mode_changed);
 	//ClassDB::bind_method("_browse_selected_file",&RunSettingsDialog::_browse_selected_file);
 }
 
@@ -81,7 +80,7 @@ RunSettingsDialog::RunSettingsDialog() {
 	vbc->add_margin_child(TTR("Run Mode:"), run_mode);
 	run_mode->add_item(TTR("Current Scene"));
 	run_mode->add_item(TTR("Main Scene"));
-	run_mode->connect_compat("item_selected", this, "_run_mode_changed");
+	run_mode->connect("item_selected", callable_mp(this, &RunSettingsDialog::_run_mode_changed));
 	arguments = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Main Scene Arguments:"), arguments);
 	arguments->set_editable(false);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -34,7 +34,6 @@
 #include "core/os/input.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
-
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_node.h"
@@ -1052,7 +1051,7 @@ void SceneTreeDock::_notification(int p_what) {
 			if (canvas_item_plugin) {
 				canvas_item_plugin->get_canvas_item_editor()->connect_compat("item_lock_status_changed", scene_tree, "_update_tree");
 				canvas_item_plugin->get_canvas_item_editor()->connect_compat("item_group_status_changed", scene_tree, "_update_tree");
-				scene_tree->connect_compat("node_changed", canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), "update");
+				scene_tree->connect("node_changed", callable_mp((CanvasItem *)canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), &CanvasItem::update));
 			}
 
 			SpatialEditorPlugin *spatial_editor_plugin = Object::cast_to<SpatialEditorPlugin>(editor_data->get_editor("3D"));
@@ -2113,7 +2112,7 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 			Object::Connection &c = F->get();
 			if (!(c.flags & Object::CONNECT_PERSIST))
 				continue;
-			newnode->connect_compat(c.signal.get_name(), c.callable.get_object(), c.callable.get_method(), c.binds, Object::CONNECT_PERSIST);
+			newnode->connect(c.signal.get_name(), c.callable, c.binds, Object::CONNECT_PERSIST);
 		}
 	}
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2945,11 +2945,11 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect("id_pressed", callable_mp(this, &SceneTreeDock::_tool_selected));
+	menu->connect("id_pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(false));
 	menu->set_hide_on_window_lose_focus(true);
 	menu_subresources = memnew(PopupMenu);
 	menu_subresources->set_name("Sub-Resources");
-	menu_subresources->connect("id_pressed", callable_mp(this, &SceneTreeDock::_tool_selected));
+	menu_subresources->connect("id_pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(false));
 	menu->add_child(menu_subresources);
 	first_enter = true;
 	restore_script_editor_on_drag = false;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1046,7 +1046,7 @@ void SceneTreeDock::_notification(int p_what) {
 				break;
 			first_enter = false;
 
-			EditorFeatureProfileManager::get_singleton()->connect_compat("current_feature_profile_changed", this, "_feature_profile_changed");
+			EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &SceneTreeDock::_feature_profile_changed));
 
 			CanvasItemEditorPlugin *canvas_item_plugin = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor("2D"));
 			if (canvas_item_plugin) {
@@ -1067,8 +1067,8 @@ void SceneTreeDock::_notification(int p_what) {
 			filter->set_right_icon(get_icon("Search", "EditorIcons"));
 			filter->set_clear_button_enabled(true);
 
-			EditorNode::get_singleton()->get_editor_selection()->connect_compat("selection_changed", this, "_selection_changed");
-			scene_tree->get_scene_tree()->connect_compat("item_collapsed", this, "_node_collapsed");
+			EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", callable_mp(this, &SceneTreeDock::_selection_changed));
+			scene_tree->get_scene_tree()->connect("item_collapsed", callable_mp(this, &SceneTreeDock::_node_collapsed));
 
 			// create_root_dialog
 			HBoxContainer *top_row = memnew(HBoxContainer);
@@ -1083,7 +1083,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts_toggle->set_toggle_mode(true);
 			node_shortcuts_toggle->set_pressed(EDITOR_GET("_use_favorites_root_selection"));
 			node_shortcuts_toggle->set_anchors_and_margins_preset(Control::PRESET_CENTER_RIGHT);
-			node_shortcuts_toggle->connect_compat("pressed", this, "_update_create_root_dialog");
+			node_shortcuts_toggle->connect("pressed", callable_mp(this, &SceneTreeDock::_update_create_root_dialog));
 			top_row->add_child(node_shortcuts_toggle);
 
 			create_root_dialog->add_child(top_row);
@@ -1099,18 +1099,18 @@ void SceneTreeDock::_notification(int p_what) {
 			beginner_node_shortcuts->add_child(button_2d);
 			button_2d->set_text(TTR("2D Scene"));
 			button_2d->set_icon(get_icon("Node2D", "EditorIcons"));
-			button_2d->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_CREATE_2D_SCENE, false));
+			button_2d->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_2D_SCENE, false));
 			button_3d = memnew(Button);
 			beginner_node_shortcuts->add_child(button_3d);
 			button_3d->set_text(TTR("3D Scene"));
 			button_3d->set_icon(get_icon("Spatial", "EditorIcons"));
-			button_3d->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_CREATE_3D_SCENE, false));
+			button_3d->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_3D_SCENE, false));
 
 			Button *button_ui = memnew(Button);
 			beginner_node_shortcuts->add_child(button_ui);
 			button_ui->set_text(TTR("User Interface"));
 			button_ui->set_icon(get_icon("Control", "EditorIcons"));
-			button_ui->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_CREATE_USER_INTERFACE, false));
+			button_ui->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_USER_INTERFACE, false));
 
 			VBoxContainer *favorite_node_shortcuts = memnew(VBoxContainer);
 			favorite_node_shortcuts->set_name("FavoriteNodeShortcuts");
@@ -1120,7 +1120,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts->add_child(button_custom);
 			button_custom->set_text(TTR("Other Node"));
 			button_custom->set_icon(get_icon("Add", "EditorIcons"));
-			button_custom->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_NEW, false));
+			button_custom->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_NEW, false));
 
 			node_shortcuts->add_spacer();
 			create_root_dialog->add_child(node_shortcuts);
@@ -1128,11 +1128,11 @@ void SceneTreeDock::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			clear_inherit_confirm->connect_compat("confirmed", this, "_tool_selected", varray(TOOL_SCENE_CLEAR_INHERITANCE_CONFIRM));
+			clear_inherit_confirm->connect("confirmed", callable_mp(this, &SceneTreeDock::_tool_selected), varray(TOOL_SCENE_CLEAR_INHERITANCE_CONFIRM));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			clear_inherit_confirm->disconnect_compat("confirmed", this, "_tool_selected");
+			clear_inherit_confirm->disconnect("confirmed", callable_mp(this, &SceneTreeDock::_tool_selected));
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			button_add->set_icon(get_icon("Add", "EditorIcons"));
@@ -1738,7 +1738,7 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 }
 
 void SceneTreeDock::_script_creation_closed() {
-	script_create_dialog->disconnect_compat("script_created", this, "_script_created");
+	script_create_dialog->disconnect("script_created", callable_mp(this, &SceneTreeDock::_script_created));
 }
 
 void SceneTreeDock::_toggle_editable_children_from_selection() {
@@ -2616,8 +2616,8 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 		}
 	}
 
-	script_create_dialog->connect_compat("script_created", this, "_script_created");
-	script_create_dialog->connect_compat("popup_hide", this, "_script_creation_closed", varray(), CONNECT_ONESHOT);
+	script_create_dialog->connect("script_created", callable_mp(this, &SceneTreeDock::_script_created));
+	script_create_dialog->connect("popup_hide", callable_mp(this, &SceneTreeDock::_script_creation_closed), varray(), CONNECT_ONESHOT);
 	script_create_dialog->set_inheritance_base_type("Node");
 	script_create_dialog->config(inherits, path);
 	script_create_dialog->popup_centered();
@@ -2719,7 +2719,7 @@ void SceneTreeDock::_update_create_root_dialog() {
 					if (ScriptServer::is_global_class(name))
 						name = ScriptServer::get_global_class_native_base(name);
 					button->set_icon(EditorNode::get_singleton()->get_class_icon(name));
-					button->connect_compat("pressed", this, "_favorite_root_selected", make_binds(l));
+					button->connect("pressed", callable_mp(this, &SceneTreeDock::_favorite_root_selected), make_binds(l));
 				}
 			}
 
@@ -2772,40 +2772,10 @@ void SceneTreeDock::_feature_profile_changed() {
 
 void SceneTreeDock::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_tool_selected"), &SceneTreeDock::_tool_selected, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("_create"), &SceneTreeDock::_create);
-	ClassDB::bind_method(D_METHOD("_node_reparent"), &SceneTreeDock::_node_reparent);
 	ClassDB::bind_method(D_METHOD("_set_owners"), &SceneTreeDock::_set_owners);
-	ClassDB::bind_method(D_METHOD("_node_selected"), &SceneTreeDock::_node_selected);
-	ClassDB::bind_method(D_METHOD("_node_renamed"), &SceneTreeDock::_node_renamed);
-	ClassDB::bind_method(D_METHOD("_script_created"), &SceneTreeDock::_script_created);
-	ClassDB::bind_method(D_METHOD("_script_creation_closed"), &SceneTreeDock::_script_creation_closed);
-	ClassDB::bind_method(D_METHOD("_load_request"), &SceneTreeDock::_load_request);
-	ClassDB::bind_method(D_METHOD("_script_open_request"), &SceneTreeDock::_script_open_request);
 	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &SceneTreeDock::_unhandled_key_input);
 	ClassDB::bind_method(D_METHOD("_input"), &SceneTreeDock::_input);
-	ClassDB::bind_method(D_METHOD("_nodes_drag_begin"), &SceneTreeDock::_nodes_drag_begin);
-	ClassDB::bind_method(D_METHOD("_delete_confirm"), &SceneTreeDock::_delete_confirm);
-	ClassDB::bind_method(D_METHOD("_toggle_editable_children_from_selection"), &SceneTreeDock::_toggle_editable_children_from_selection);
-	ClassDB::bind_method(D_METHOD("_toggle_placeholder_from_selection"), &SceneTreeDock::_toggle_placeholder_from_selection);
-	ClassDB::bind_method(D_METHOD("_node_prerenamed"), &SceneTreeDock::_node_prerenamed);
-	ClassDB::bind_method(D_METHOD("_import_subscene"), &SceneTreeDock::_import_subscene);
-	ClassDB::bind_method(D_METHOD("_selection_changed"), &SceneTreeDock::_selection_changed);
-	ClassDB::bind_method(D_METHOD("_node_collapsed"), &SceneTreeDock::_node_collapsed);
-	ClassDB::bind_method(D_METHOD("_new_scene_from"), &SceneTreeDock::_new_scene_from);
-	ClassDB::bind_method(D_METHOD("_nodes_dragged"), &SceneTreeDock::_nodes_dragged);
-	ClassDB::bind_method(D_METHOD("_files_dropped"), &SceneTreeDock::_files_dropped);
-	ClassDB::bind_method(D_METHOD("_quick_open"), &SceneTreeDock::_quick_open);
-	ClassDB::bind_method(D_METHOD("_script_dropped"), &SceneTreeDock::_script_dropped);
-	ClassDB::bind_method(D_METHOD("_tree_rmb"), &SceneTreeDock::_tree_rmb);
-	ClassDB::bind_method(D_METHOD("_filter_changed"), &SceneTreeDock::_filter_changed);
-	ClassDB::bind_method(D_METHOD("_focus_node"), &SceneTreeDock::_focus_node);
-	ClassDB::bind_method(D_METHOD("_remote_tree_selected"), &SceneTreeDock::_remote_tree_selected);
-	ClassDB::bind_method(D_METHOD("_local_tree_selected"), &SceneTreeDock::_local_tree_selected);
 	ClassDB::bind_method(D_METHOD("_update_script_button"), &SceneTreeDock::_update_script_button);
-	ClassDB::bind_method(D_METHOD("_favorite_root_selected"), &SceneTreeDock::_favorite_root_selected);
-	ClassDB::bind_method(D_METHOD("_update_create_root_dialog"), &SceneTreeDock::_update_create_root_dialog);
-	ClassDB::bind_method(D_METHOD("_feature_profile_changed"), &SceneTreeDock::_feature_profile_changed);
 
 	ClassDB::bind_method(D_METHOD("instance"), &SceneTreeDock::instance);
 	ClassDB::bind_method(D_METHOD("get_tree_editor"), &SceneTreeDock::get_tree_editor);
@@ -2850,13 +2820,13 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	ED_SHORTCUT("scene_tree/delete", TTR("Delete"), KEY_DELETE);
 
 	button_add = memnew(ToolButton);
-	button_add->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_NEW, false));
+	button_add->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_NEW, false));
 	button_add->set_tooltip(TTR("Add/Create a New Node."));
 	button_add->set_shortcut(ED_GET_SHORTCUT("scene_tree/add_child_node"));
 	filter_hbc->add_child(button_add);
 
 	button_instance = memnew(ToolButton);
-	button_instance->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_INSTANCE, false));
+	button_instance->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_INSTANCE, false));
 	button_instance->set_tooltip(TTR("Instance a scene file as a Node. Creates an inherited scene if no root node exists."));
 	button_instance->set_shortcut(ED_GET_SHORTCUT("scene_tree/instance_scene"));
 	filter_hbc->add_child(button_instance);
@@ -2867,17 +2837,17 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	filter->set_placeholder(TTR("Filter nodes"));
 	filter_hbc->add_child(filter);
 	filter->add_constant_override("minimum_spaces", 0);
-	filter->connect_compat("text_changed", this, "_filter_changed");
+	filter->connect("text_changed", callable_mp(this, &SceneTreeDock::_filter_changed));
 
 	button_create_script = memnew(ToolButton);
-	button_create_script->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_ATTACH_SCRIPT, false));
+	button_create_script->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_ATTACH_SCRIPT, false));
 	button_create_script->set_tooltip(TTR("Attach a new or existing script for the selected node."));
 	button_create_script->set_shortcut(ED_GET_SHORTCUT("scene_tree/attach_script"));
 	filter_hbc->add_child(button_create_script);
 	button_create_script->hide();
 
 	button_clear_script = memnew(ToolButton);
-	button_clear_script->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_CLEAR_SCRIPT, false));
+	button_clear_script->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CLEAR_SCRIPT, false));
 	button_clear_script->set_tooltip(TTR("Clear a script for the selected node."));
 	button_clear_script->set_shortcut(ED_GET_SHORTCUT("scene_tree/clear_script"));
 	filter_hbc->add_child(button_clear_script);
@@ -2891,14 +2861,14 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	edit_remote->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_remote->set_text(TTR("Remote"));
 	edit_remote->set_toggle_mode(true);
-	edit_remote->connect_compat("pressed", this, "_remote_tree_selected");
+	edit_remote->connect("pressed", callable_mp(this, &SceneTreeDock::_remote_tree_selected));
 
 	edit_local = memnew(ToolButton);
 	button_hb->add_child(edit_local);
 	edit_local->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_local->set_text(TTR("Local"));
 	edit_local->set_toggle_mode(true);
-	edit_local->connect_compat("pressed", this, "_local_tree_selected");
+	edit_local->connect("pressed", callable_mp(this, &SceneTreeDock::_local_tree_selected));
 
 	remote_tree = NULL;
 	button_hb->hide();
@@ -2911,19 +2881,19 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	vbc->add_child(scene_tree);
 	scene_tree->set_v_size_flags(SIZE_EXPAND | SIZE_FILL);
-	scene_tree->connect_compat("rmb_pressed", this, "_tree_rmb");
+	scene_tree->connect("rmb_pressed", callable_mp(this, &SceneTreeDock::_tree_rmb));
 
-	scene_tree->connect_compat("node_selected", this, "_node_selected", varray(), CONNECT_DEFERRED);
-	scene_tree->connect_compat("node_renamed", this, "_node_renamed", varray(), CONNECT_DEFERRED);
-	scene_tree->connect_compat("node_prerename", this, "_node_prerenamed");
-	scene_tree->connect_compat("open", this, "_load_request");
-	scene_tree->connect_compat("open_script", this, "_script_open_request");
-	scene_tree->connect_compat("nodes_rearranged", this, "_nodes_dragged");
-	scene_tree->connect_compat("files_dropped", this, "_files_dropped");
-	scene_tree->connect_compat("script_dropped", this, "_script_dropped");
-	scene_tree->connect_compat("nodes_dragged", this, "_nodes_drag_begin");
+	scene_tree->connect("node_selected", callable_mp(this, &SceneTreeDock::_node_selected), varray(), CONNECT_DEFERRED);
+	scene_tree->connect("node_renamed", callable_mp(this, &SceneTreeDock::_node_renamed), varray(), CONNECT_DEFERRED);
+	scene_tree->connect("node_prerename", callable_mp(this, &SceneTreeDock::_node_prerenamed));
+	scene_tree->connect("open", callable_mp(this, &SceneTreeDock::_load_request));
+	scene_tree->connect("open_script", callable_mp(this, &SceneTreeDock::_script_open_request));
+	scene_tree->connect("nodes_rearranged", callable_mp(this, &SceneTreeDock::_nodes_dragged));
+	scene_tree->connect("files_dropped", callable_mp(this, &SceneTreeDock::_files_dropped));
+	scene_tree->connect("script_dropped", callable_mp(this, &SceneTreeDock::_script_dropped));
+	scene_tree->connect("nodes_dragged", callable_mp(this, &SceneTreeDock::_nodes_drag_begin));
 
-	scene_tree->get_scene_tree()->connect_compat("item_double_clicked", this, "_focus_node");
+	scene_tree->get_scene_tree()->connect("item_double_clicked", callable_mp(this, &SceneTreeDock::_focus_node));
 
 	scene_tree->set_undo_redo(&editor_data->get_undo_redo());
 	scene_tree->set_editor_selection(editor_selection);
@@ -2931,8 +2901,8 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	create_dialog = memnew(CreateDialog);
 	create_dialog->set_base_type("Node");
 	add_child(create_dialog);
-	create_dialog->connect_compat("create", this, "_create");
-	create_dialog->connect_compat("favorites_updated", this, "_update_create_root_dialog");
+	create_dialog->connect("create", callable_mp(this, &SceneTreeDock::_create));
+	create_dialog->connect("favorites_updated", callable_mp(this, &SceneTreeDock::_update_create_root_dialog));
 
 	rename_dialog = memnew(RenameDialog(scene_tree, &editor_data->get_undo_redo()));
 	add_child(rename_dialog);
@@ -2943,44 +2913,44 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	reparent_dialog = memnew(ReparentDialog);
 	add_child(reparent_dialog);
-	reparent_dialog->connect_compat("reparent", this, "_node_reparent");
+	reparent_dialog->connect("reparent", callable_mp(this, &SceneTreeDock::_node_reparent));
 
 	accept = memnew(AcceptDialog);
 	add_child(accept);
 
 	quick_open = memnew(EditorQuickOpen);
 	add_child(quick_open);
-	quick_open->connect_compat("quick_open", this, "_quick_open");
+	quick_open->connect("quick_open", callable_mp(this, &SceneTreeDock::_quick_open));
 	set_process_unhandled_key_input(true);
 
 	delete_dialog = memnew(ConfirmationDialog);
 	add_child(delete_dialog);
-	delete_dialog->connect_compat("confirmed", this, "_delete_confirm");
+	delete_dialog->connect("confirmed", callable_mp(this, &SceneTreeDock::_delete_confirm));
 
 	editable_instance_remove_dialog = memnew(ConfirmationDialog);
 	add_child(editable_instance_remove_dialog);
-	editable_instance_remove_dialog->connect_compat("confirmed", this, "_toggle_editable_children_from_selection");
+	editable_instance_remove_dialog->connect("confirmed", callable_mp(this, &SceneTreeDock::_toggle_editable_children_from_selection));
 
 	placeholder_editable_instance_remove_dialog = memnew(ConfirmationDialog);
 	add_child(placeholder_editable_instance_remove_dialog);
-	placeholder_editable_instance_remove_dialog->connect_compat("confirmed", this, "_toggle_placeholder_from_selection");
+	placeholder_editable_instance_remove_dialog->connect("confirmed", callable_mp(this, &SceneTreeDock::_toggle_placeholder_from_selection));
 
 	import_subscene_dialog = memnew(EditorSubScene);
 	add_child(import_subscene_dialog);
-	import_subscene_dialog->connect_compat("subscene_selected", this, "_import_subscene");
+	import_subscene_dialog->connect("subscene_selected", callable_mp(this, &SceneTreeDock::_import_subscene));
 
 	new_scene_from_dialog = memnew(EditorFileDialog);
 	new_scene_from_dialog->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	add_child(new_scene_from_dialog);
-	new_scene_from_dialog->connect_compat("file_selected", this, "_new_scene_from");
+	new_scene_from_dialog->connect("file_selected", callable_mp(this, &SceneTreeDock::_new_scene_from));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_tool_selected");
+	menu->connect("id_pressed", callable_mp(this, &SceneTreeDock::_tool_selected));
 	menu->set_hide_on_window_lose_focus(true);
 	menu_subresources = memnew(PopupMenu);
 	menu_subresources->set_name("Sub-Resources");
-	menu_subresources->connect_compat("id_pressed", this, "_tool_selected");
+	menu_subresources->connect("id_pressed", callable_mp(this, &SceneTreeDock::_tool_selected));
 	menu->add_child(menu_subresources);
 	first_enter = true;
 	restore_script_editor_on_drag = false;

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -323,8 +323,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 
 	if (can_open_instance && undo_redo) { //Show buttons only when necessary(SceneTreeDock) to avoid crashes
 
-		if (!p_node->is_connected_compat("script_changed", this, "_node_script_changed"))
-			p_node->connect_compat("script_changed", this, "_node_script_changed", varray(p_node));
+		if (!p_node->is_connected("script_changed", callable_mp(this, &SceneTreeEditor::_node_script_changed)))
+			p_node->connect("script_changed", callable_mp(this, &SceneTreeEditor::_node_script_changed), varray(p_node));
 
 		Ref<Script> script = p_node->get_script();
 		if (!script.is_null()) {
@@ -350,8 +350,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			else
 				item->add_button(0, get_icon("GuiVisibilityHidden", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
 
-			if (!p_node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-				p_node->connect_compat("visibility_changed", this, "_node_visibility_changed", varray(p_node));
+			if (!p_node->is_connected("visibility_changed", callable_mp(this, &SceneTreeEditor::_node_visibility_changed)))
+				p_node->connect("visibility_changed", callable_mp(this, &SceneTreeEditor::_node_visibility_changed), varray(p_node));
 
 			_update_visibility_color(p_node, item);
 		} else if (p_node->is_class("Spatial")) {
@@ -370,8 +370,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			else
 				item->add_button(0, get_icon("GuiVisibilityHidden", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
 
-			if (!p_node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-				p_node->connect_compat("visibility_changed", this, "_node_visibility_changed", varray(p_node));
+			if (!p_node->is_connected("visibility_changed", callable_mp(this, &SceneTreeEditor::_node_visibility_changed)))
+				p_node->connect("visibility_changed", callable_mp(this, &SceneTreeEditor::_node_visibility_changed), varray(p_node));
 
 			_update_visibility_color(p_node, item);
 		} else if (p_node->is_class("AnimationPlayer")) {
@@ -495,12 +495,12 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 	if (EditorNode::get_singleton()->is_exiting())
 		return; //speed up exit
 
-	if (p_node->is_connected_compat("script_changed", this, "_node_script_changed"))
-		p_node->disconnect_compat("script_changed", this, "_node_script_changed");
+	if (p_node->is_connected("script_changed", callable_mp(this, &SceneTreeEditor::_node_script_changed)))
+		p_node->disconnect("script_changed", callable_mp(this, &SceneTreeEditor::_node_script_changed));
 
 	if (p_node->is_class("Spatial") || p_node->is_class("CanvasItem")) {
-		if (p_node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-			p_node->disconnect_compat("visibility_changed", this, "_node_visibility_changed");
+		if (p_node->is_connected("visibility_changed", callable_mp(this, &SceneTreeEditor::_node_visibility_changed)))
+			p_node->disconnect("visibility_changed", callable_mp(this, &SceneTreeEditor::_node_visibility_changed));
 	}
 
 	if (p_node == selected) {
@@ -640,22 +640,22 @@ void SceneTreeEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 
-			get_tree()->connect_compat("tree_changed", this, "_tree_changed");
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
-			get_tree()->connect_compat("node_renamed", this, "_node_renamed");
-			get_tree()->connect_compat("node_configuration_warning_changed", this, "_warning_changed");
+			get_tree()->connect("tree_changed", callable_mp(this, &SceneTreeEditor::_tree_changed));
+			get_tree()->connect("node_removed", callable_mp(this, &SceneTreeEditor::_node_removed));
+			get_tree()->connect("node_renamed", callable_mp(this, &SceneTreeEditor::_node_renamed));
+			get_tree()->connect("node_configuration_warning_changed", callable_mp(this, &SceneTreeEditor::_warning_changed));
 
-			tree->connect_compat("item_collapsed", this, "_cell_collapsed");
+			tree->connect("item_collapsed", callable_mp(this, &SceneTreeEditor::_cell_collapsed));
 
 			_update_tree();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 
-			get_tree()->disconnect_compat("tree_changed", this, "_tree_changed");
-			get_tree()->disconnect_compat("node_removed", this, "_node_removed");
-			get_tree()->disconnect_compat("node_renamed", this, "_node_renamed");
-			tree->disconnect_compat("item_collapsed", this, "_cell_collapsed");
-			get_tree()->disconnect_compat("node_configuration_warning_changed", this, "_warning_changed");
+			get_tree()->disconnect("tree_changed", callable_mp(this, &SceneTreeEditor::_tree_changed));
+			get_tree()->disconnect("node_removed", callable_mp(this, &SceneTreeEditor::_node_removed));
+			get_tree()->disconnect("node_renamed", callable_mp(this, &SceneTreeEditor::_node_renamed));
+			tree->disconnect("item_collapsed", callable_mp(this, &SceneTreeEditor::_cell_collapsed));
+			get_tree()->disconnect("node_configuration_warning_changed", callable_mp(this, &SceneTreeEditor::_warning_changed));
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 
@@ -836,7 +836,7 @@ void SceneTreeEditor::set_editor_selection(EditorSelection *p_selection) {
 	editor_selection = p_selection;
 	tree->set_select_mode(Tree::SELECT_MULTI);
 	tree->set_cursor_can_exit_tree(false);
-	editor_selection->connect_compat("selection_changed", this, "_selection_changed");
+	editor_selection->connect("selection_changed", callable_mp(this, &SceneTreeEditor::_selection_changed));
 }
 
 void SceneTreeEditor::_update_selection(TreeItem *item) {
@@ -1089,24 +1089,8 @@ void SceneTreeEditor::set_connecting_signal(bool p_enable) {
 
 void SceneTreeEditor::_bind_methods() {
 
-	ClassDB::bind_method("_tree_changed", &SceneTreeEditor::_tree_changed);
-	ClassDB::bind_method("_update_tree", &SceneTreeEditor::_update_tree);
-	ClassDB::bind_method("_node_removed", &SceneTreeEditor::_node_removed);
-	ClassDB::bind_method("_node_renamed", &SceneTreeEditor::_node_renamed);
-	ClassDB::bind_method("_selected_changed", &SceneTreeEditor::_selected_changed);
-	ClassDB::bind_method("_deselect_items", &SceneTreeEditor::_deselect_items);
-	ClassDB::bind_method("_renamed", &SceneTreeEditor::_renamed);
 	ClassDB::bind_method("_rename_node", &SceneTreeEditor::_rename_node);
 	ClassDB::bind_method("_test_update_tree", &SceneTreeEditor::_test_update_tree);
-	ClassDB::bind_method("_cell_multi_selected", &SceneTreeEditor::_cell_multi_selected);
-	ClassDB::bind_method("_selection_changed", &SceneTreeEditor::_selection_changed);
-	ClassDB::bind_method("_cell_button_pressed", &SceneTreeEditor::_cell_button_pressed);
-	ClassDB::bind_method("_cell_collapsed", &SceneTreeEditor::_cell_collapsed);
-	ClassDB::bind_method("_rmb_select", &SceneTreeEditor::_rmb_select);
-	ClassDB::bind_method("_warning_changed", &SceneTreeEditor::_warning_changed);
-
-	ClassDB::bind_method("_node_script_changed", &SceneTreeEditor::_node_script_changed);
-	ClassDB::bind_method("_node_visibility_changed", &SceneTreeEditor::_node_visibility_changed);
 
 	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &SceneTreeEditor::get_drag_data_fw);
 	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &SceneTreeEditor::can_drop_data_fw);
@@ -1163,15 +1147,15 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	tree->set_drag_forwarding(this);
 	if (p_can_rename) {
 		tree->set_allow_rmb_select(true);
-		tree->connect_compat("item_rmb_selected", this, "_rmb_select");
-		tree->connect_compat("empty_tree_rmb_selected", this, "_rmb_select");
+		tree->connect("item_rmb_selected", callable_mp(this, &SceneTreeEditor::_rmb_select));
+		tree->connect("empty_tree_rmb_selected", callable_mp(this, &SceneTreeEditor::_rmb_select));
 	}
 
-	tree->connect_compat("cell_selected", this, "_selected_changed");
-	tree->connect_compat("item_edited", this, "_renamed", varray(), CONNECT_DEFERRED);
-	tree->connect_compat("multi_selected", this, "_cell_multi_selected");
-	tree->connect_compat("button_pressed", this, "_cell_button_pressed");
-	tree->connect_compat("nothing_selected", this, "_deselect_items");
+	tree->connect("cell_selected", callable_mp(this, &SceneTreeEditor::_selected_changed));
+	tree->connect("item_edited", callable_mp(this, &SceneTreeEditor::_renamed), varray(), CONNECT_DEFERRED);
+	tree->connect("multi_selected", callable_mp(this, &SceneTreeEditor::_cell_multi_selected));
+	tree->connect("button_pressed", callable_mp(this, &SceneTreeEditor::_cell_button_pressed));
+	tree->connect("nothing_selected", callable_mp(this, &SceneTreeEditor::_deselect_items));
 	//tree->connect("item_edited", this,"_renamed",Vector<Variant>(),true);
 
 	error = memnew(AcceptDialog);
@@ -1189,7 +1173,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	blocked = 0;
 
 	update_timer = memnew(Timer);
-	update_timer->connect_compat("timeout", this, "_update_tree");
+	update_timer->connect("timeout", callable_mp(this, &SceneTreeEditor::_update_tree));
 	update_timer->set_one_shot(true);
 	update_timer->set_wait_time(0.5);
 	add_child(update_timer);
@@ -1209,12 +1193,12 @@ void SceneTreeDialog::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("confirmed", this, "_select");
+			connect("confirmed", callable_mp(this, &SceneTreeDialog::_select));
 			filter->set_right_icon(get_icon("Search", "EditorIcons"));
 			filter->set_clear_button_enabled(true);
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("confirmed", this, "_select");
+			disconnect("confirmed", callable_mp(this, &SceneTreeDialog::_select));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible_in_tree())
@@ -1242,9 +1226,7 @@ void SceneTreeDialog::_filter_changed(const String &p_filter) {
 
 void SceneTreeDialog::_bind_methods() {
 
-	ClassDB::bind_method("_select", &SceneTreeDialog::_select);
 	ClassDB::bind_method("_cancel", &SceneTreeDialog::_cancel);
-	ClassDB::bind_method(D_METHOD("_filter_changed"), &SceneTreeDialog::_filter_changed);
 
 	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::NODE_PATH, "path")));
 }
@@ -1259,12 +1241,12 @@ SceneTreeDialog::SceneTreeDialog() {
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTR("Filter nodes"));
 	filter->add_constant_override("minimum_spaces", 0);
-	filter->connect_compat("text_changed", this, "_filter_changed");
+	filter->connect("text_changed", callable_mp(this, &SceneTreeDialog::_filter_changed));
 	vbc->add_child(filter);
 
 	tree = memnew(SceneTreeEditor(false, false, true));
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
-	tree->get_scene_tree()->connect_compat("item_activated", this, "_select");
+	tree->get_scene_tree()->connect("item_activated", callable_mp(this, &SceneTreeDialog::_select));
 	vbc->add_child(tree);
 }
 

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1089,6 +1089,7 @@ void SceneTreeEditor::set_connecting_signal(bool p_enable) {
 
 void SceneTreeEditor::_bind_methods() {
 
+	ClassDB::bind_method("_update_tree", &SceneTreeEditor::_update_tree); // Still used by some connect_compat.
 	ClassDB::bind_method("_rename_node", &SceneTreeEditor::_rename_node);
 	ClassDB::bind_method("_test_update_tree", &SceneTreeEditor::_test_update_tree);
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -728,19 +728,6 @@ void ScriptCreateDialog::_update_dialog() {
 
 void ScriptCreateDialog::_bind_methods() {
 
-	ClassDB::bind_method("_path_hbox_sorted", &ScriptCreateDialog::_path_hbox_sorted);
-	ClassDB::bind_method("_class_name_changed", &ScriptCreateDialog::_class_name_changed);
-	ClassDB::bind_method("_parent_name_changed", &ScriptCreateDialog::_parent_name_changed);
-	ClassDB::bind_method("_lang_changed", &ScriptCreateDialog::_lang_changed);
-	ClassDB::bind_method("_built_in_pressed", &ScriptCreateDialog::_built_in_pressed);
-	ClassDB::bind_method("_browse_path", &ScriptCreateDialog::_browse_path);
-	ClassDB::bind_method("_file_selected", &ScriptCreateDialog::_file_selected);
-	ClassDB::bind_method("_path_changed", &ScriptCreateDialog::_path_changed);
-	ClassDB::bind_method("_path_entered", &ScriptCreateDialog::_path_entered);
-	ClassDB::bind_method("_template_changed", &ScriptCreateDialog::_template_changed);
-	ClassDB::bind_method("_create", &ScriptCreateDialog::_create);
-	ClassDB::bind_method("_browse_class_in_tree", &ScriptCreateDialog::_browse_class_in_tree);
-
 	ClassDB::bind_method(D_METHOD("config", "inherits", "path", "built_in_enabled", "load_enabled"), &ScriptCreateDialog::config, DEFVAL(true), DEFVAL(true));
 
 	ADD_SIGNAL(MethodInfo("script_created", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
@@ -804,7 +791,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	language_menu->select(default_language);
 	current_language = default_language;
 
-	language_menu->connect_compat("item_selected", this, "_lang_changed");
+	language_menu->connect("item_selected", callable_mp(this, &ScriptCreateDialog::_lang_changed));
 
 	/* Inherits */
 
@@ -813,16 +800,16 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
 	parent_name = memnew(LineEdit);
-	parent_name->connect_compat("text_changed", this, "_parent_name_changed");
+	parent_name->connect("text_changed", callable_mp(this, &ScriptCreateDialog::_parent_name_changed));
 	parent_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(parent_name);
 	parent_search_button = memnew(Button);
 	parent_search_button->set_flat(true);
-	parent_search_button->connect_compat("pressed", this, "_browse_class_in_tree");
+	parent_search_button->connect("pressed", callable_mp(this, &ScriptCreateDialog::_browse_class_in_tree));
 	hb->add_child(parent_search_button);
 	parent_browse_button = memnew(Button);
 	parent_browse_button->set_flat(true);
-	parent_browse_button->connect_compat("pressed", this, "_browse_path", varray(true, false));
+	parent_browse_button->connect("pressed", callable_mp(this, &ScriptCreateDialog::_browse_path), varray(true, false));
 	hb->add_child(parent_browse_button);
 	gc->add_child(memnew(Label(TTR("Inherits:"))));
 	gc->add_child(hb);
@@ -831,7 +818,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Class Name */
 
 	class_name = memnew(LineEdit);
-	class_name->connect_compat("text_changed", this, "_class_name_changed");
+	class_name->connect("text_changed", callable_mp(this, &ScriptCreateDialog::_class_name_changed));
 	class_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	gc->add_child(memnew(Label(TTR("Class Name:"))));
 	gc->add_child(class_name);
@@ -841,28 +828,28 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	template_menu = memnew(OptionButton);
 	gc->add_child(memnew(Label(TTR("Template:"))));
 	gc->add_child(template_menu);
-	template_menu->connect_compat("item_selected", this, "_template_changed");
+	template_menu->connect("item_selected", callable_mp(this, &ScriptCreateDialog::_template_changed));
 
 	/* Built-in Script */
 
 	internal = memnew(CheckBox);
 	internal->set_text(TTR("On"));
-	internal->connect_compat("pressed", this, "_built_in_pressed");
+	internal->connect("pressed", callable_mp(this, &ScriptCreateDialog::_built_in_pressed));
 	gc->add_child(memnew(Label(TTR("Built-in Script:"))));
 	gc->add_child(internal);
 
 	/* Path */
 
 	hb = memnew(HBoxContainer);
-	hb->connect_compat("sort_children", this, "_path_hbox_sorted");
+	hb->connect("sort_children", callable_mp(this, &ScriptCreateDialog::_path_hbox_sorted));
 	file_path = memnew(LineEdit);
-	file_path->connect_compat("text_changed", this, "_path_changed");
-	file_path->connect_compat("text_entered", this, "_path_entered");
+	file_path->connect("text_changed", callable_mp(this, &ScriptCreateDialog::_path_changed));
+	file_path->connect("text_entered", callable_mp(this, &ScriptCreateDialog::_path_entered));
 	file_path->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(file_path);
 	path_button = memnew(Button);
 	path_button->set_flat(true);
-	path_button->connect_compat("pressed", this, "_browse_path", varray(false, true));
+	path_button->connect("pressed", callable_mp(this, &ScriptCreateDialog::_browse_path), varray(false, true));
 	hb->add_child(path_button);
 	gc->add_child(memnew(Label(TTR("Path:"))));
 	gc->add_child(hb);
@@ -871,11 +858,11 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Dialog Setup */
 
 	select_class = memnew(CreateDialog);
-	select_class->connect_compat("create", this, "_create");
+	select_class->connect("create", callable_mp(this, &ScriptCreateDialog::_create));
 	add_child(select_class);
 
 	file_browse = memnew(EditorFileDialog);
-	file_browse->connect_compat("file_selected", this, "_file_selected");
+	file_browse->connect("file_selected", callable_mp(this, &ScriptCreateDialog::_file_selected));
 	file_browse->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	add_child(file_browse);
 	get_ok()->set_text(TTR("Create"));

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -388,19 +388,7 @@ void EditorSettingsDialog::_editor_restart_close() {
 void EditorSettingsDialog::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_unhandled_input"), &EditorSettingsDialog::_unhandled_input);
-	ClassDB::bind_method(D_METHOD("_settings_save"), &EditorSettingsDialog::_settings_save);
-	ClassDB::bind_method(D_METHOD("_settings_changed"), &EditorSettingsDialog::_settings_changed);
-	ClassDB::bind_method(D_METHOD("_settings_property_edited"), &EditorSettingsDialog::_settings_property_edited);
-	ClassDB::bind_method(D_METHOD("_shortcut_button_pressed"), &EditorSettingsDialog::_shortcut_button_pressed);
-	ClassDB::bind_method(D_METHOD("_filter_shortcuts"), &EditorSettingsDialog::_filter_shortcuts);
 	ClassDB::bind_method(D_METHOD("_update_shortcuts"), &EditorSettingsDialog::_update_shortcuts);
-	ClassDB::bind_method(D_METHOD("_press_a_key_confirm"), &EditorSettingsDialog::_press_a_key_confirm);
-	ClassDB::bind_method(D_METHOD("_wait_for_key"), &EditorSettingsDialog::_wait_for_key);
-	ClassDB::bind_method(D_METHOD("_tabs_tab_changed"), &EditorSettingsDialog::_tabs_tab_changed);
-
-	ClassDB::bind_method(D_METHOD("_editor_restart_request"), &EditorSettingsDialog::_editor_restart_request);
-	ClassDB::bind_method(D_METHOD("_editor_restart"), &EditorSettingsDialog::_editor_restart);
-	ClassDB::bind_method(D_METHOD("_editor_restart_close"), &EditorSettingsDialog::_editor_restart_close);
 }
 
 EditorSettingsDialog::EditorSettingsDialog() {
@@ -411,7 +399,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	tabs = memnew(TabContainer);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
-	tabs->connect_compat("tab_changed", this, "_tabs_tab_changed");
+	tabs->connect("tab_changed", callable_mp(this, &EditorSettingsDialog::_tabs_tab_changed));
 	add_child(tabs);
 
 	// General Tab
@@ -434,8 +422,8 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector->get_inspector()->set_undo_redo(undo_redo);
 	tab_general->add_child(inspector);
-	inspector->get_inspector()->connect_compat("property_edited", this, "_settings_property_edited");
-	inspector->get_inspector()->connect_compat("restart_requested", this, "_editor_restart_request");
+	inspector->get_inspector()->connect("property_edited", callable_mp(this, &EditorSettingsDialog::_settings_property_edited));
+	inspector->get_inspector()->connect("restart_requested", callable_mp(this, &EditorSettingsDialog::_editor_restart_request));
 
 	restart_container = memnew(PanelContainer);
 	tab_general->add_child(restart_container);
@@ -449,11 +437,11 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	restart_hb->add_child(restart_label);
 	restart_hb->add_spacer();
 	Button *restart_button = memnew(Button);
-	restart_button->connect_compat("pressed", this, "_editor_restart");
+	restart_button->connect("pressed", callable_mp(this, &EditorSettingsDialog::_editor_restart));
 	restart_hb->add_child(restart_button);
 	restart_button->set_text(TTR("Save & Restart"));
 	restart_close_button = memnew(ToolButton);
-	restart_close_button->connect_compat("pressed", this, "_editor_restart_close");
+	restart_close_button->connect("pressed", callable_mp(this, &EditorSettingsDialog::_editor_restart_close));
 	restart_hb->add_child(restart_close_button);
 	restart_container->hide();
 
@@ -470,7 +458,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcut_search_box = memnew(LineEdit);
 	shortcut_search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(shortcut_search_box);
-	shortcut_search_box->connect_compat("text_changed", this, "_filter_shortcuts");
+	shortcut_search_box->connect("text_changed", callable_mp(this, &EditorSettingsDialog::_filter_shortcuts));
 
 	shortcuts = memnew(Tree);
 	tab_shortcuts->add_child(shortcuts, true);
@@ -480,7 +468,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcuts->set_column_titles_visible(true);
 	shortcuts->set_column_title(0, TTR("Name"));
 	shortcuts->set_column_title(1, TTR("Binding"));
-	shortcuts->connect_compat("button_pressed", this, "_shortcut_button_pressed");
+	shortcuts->connect("button_pressed", callable_mp(this, &EditorSettingsDialog::_shortcut_button_pressed));
 
 	press_a_key = memnew(ConfirmationDialog);
 	press_a_key->set_focus_mode(FOCUS_ALL);
@@ -494,17 +482,17 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	l->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_BEGIN, 30);
 	press_a_key_label = l;
 	press_a_key->add_child(l);
-	press_a_key->connect_compat("gui_input", this, "_wait_for_key");
-	press_a_key->connect_compat("confirmed", this, "_press_a_key_confirm");
+	press_a_key->connect("gui_input", callable_mp(this, &EditorSettingsDialog::_wait_for_key));
+	press_a_key->connect("confirmed", callable_mp(this, &EditorSettingsDialog::_press_a_key_confirm));
 
 	set_hide_on_ok(true);
 
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);
-	timer->connect_compat("timeout", this, "_settings_save");
+	timer->connect("timeout", callable_mp(this, &EditorSettingsDialog::_settings_save));
 	timer->set_one_shot(true);
 	add_child(timer);
-	EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_settings_changed");
+	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorSettingsDialog::_settings_changed));
 	get_ok()->set_text(TTR("Close"));
 
 	updating = false;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -884,8 +884,6 @@ void CSGMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &CSGMesh::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &CSGMesh::get_mesh);
 
-	ClassDB::bind_method(D_METHOD("_mesh_changed"), &CSGMesh::_mesh_changed);
-
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &CSGMesh::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &CSGMesh::get_material);
 
@@ -898,12 +896,12 @@ void CSGMesh::set_mesh(const Ref<Mesh> &p_mesh) {
 	if (mesh == p_mesh)
 		return;
 	if (mesh.is_valid()) {
-		mesh->disconnect_compat("changed", this, "_mesh_changed");
+		mesh->disconnect("changed", callable_mp(this, &CSGMesh::_mesh_changed));
 	}
 	mesh = p_mesh;
 
 	if (mesh.is_valid()) {
-		mesh->connect_compat("changed", this, "_mesh_changed");
+		mesh->connect("changed", callable_mp(this, &CSGMesh::_mesh_changed));
 	}
 
 	_make_dirty();
@@ -1812,15 +1810,15 @@ CSGBrush *CSGPolygon::_build_brush() {
 
 		if (path != path_cache) {
 			if (path_cache) {
-				path_cache->disconnect_compat("tree_exited", this, "_path_exited");
-				path_cache->disconnect_compat("curve_changed", this, "_path_changed");
+				path_cache->disconnect("tree_exited", callable_mp(this, &CSGPolygon::_path_exited));
+				path_cache->disconnect("curve_changed", callable_mp(this, &CSGPolygon::_path_changed));
 				path_cache = NULL;
 			}
 
 			path_cache = path;
 
-			path_cache->connect_compat("tree_exited", this, "_path_exited");
-			path_cache->connect_compat("curve_changed", this, "_path_changed");
+			path_cache->connect("tree_exited", callable_mp(this, &CSGPolygon::_path_exited));
+			path_cache->connect("curve_changed", callable_mp(this, &CSGPolygon::_path_changed));
 			path_cache = NULL;
 		}
 		curve = path->get_curve();
@@ -2236,8 +2234,8 @@ CSGBrush *CSGPolygon::_build_brush() {
 void CSGPolygon::_notification(int p_what) {
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 		if (path_cache) {
-			path_cache->disconnect_compat("tree_exited", this, "_path_exited");
-			path_cache->disconnect_compat("curve_changed", this, "_path_changed");
+			path_cache->disconnect("tree_exited", callable_mp(this, &CSGPolygon::_path_exited));
+			path_cache->disconnect("curve_changed", callable_mp(this, &CSGPolygon::_path_changed));
 			path_cache = NULL;
 		}
 	}
@@ -2308,9 +2306,6 @@ void CSGPolygon::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_is_editable_3d_polygon"), &CSGPolygon::_is_editable_3d_polygon);
 	ClassDB::bind_method(D_METHOD("_has_editable_3d_polygon_no_depth"), &CSGPolygon::_has_editable_3d_polygon_no_depth);
-
-	ClassDB::bind_method(D_METHOD("_path_exited"), &CSGPolygon::_path_exited);
-	ClassDB::bind_method(D_METHOD("_path_changed"), &CSGPolygon::_path_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "polygon"), "set_polygon", "get_polygon");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Depth,Spin,Path"), "set_mode", "get_mode");

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -53,14 +53,6 @@ void GDNativeLibraryEditor::edit(Ref<GDNativeLibrary> p_library) {
 }
 
 void GDNativeLibraryEditor::_bind_methods() {
-
-	ClassDB::bind_method("_on_item_button", &GDNativeLibraryEditor::_on_item_button);
-	ClassDB::bind_method("_on_library_selected", &GDNativeLibraryEditor::_on_library_selected);
-	ClassDB::bind_method("_on_dependencies_selected", &GDNativeLibraryEditor::_on_dependencies_selected);
-	ClassDB::bind_method("_on_filter_selected", &GDNativeLibraryEditor::_on_filter_selected);
-	ClassDB::bind_method("_on_item_collapsed", &GDNativeLibraryEditor::_on_item_collapsed);
-	ClassDB::bind_method("_on_item_activated", &GDNativeLibraryEditor::_on_item_activated);
-	ClassDB::bind_method("_on_create_new_entry", &GDNativeLibraryEditor::_on_create_new_entry);
 }
 
 void GDNativeLibraryEditor::_update_tree() {
@@ -359,7 +351,7 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 		filter_list->set_item_checked(idx, true);
 		idx += 1;
 	}
-	filter_list->connect_compat("index_pressed", this, "_on_filter_selected");
+	filter_list->connect("index_pressed", callable_mp(this, &GDNativeLibraryEditor::_on_filter_selected));
 
 	tree = memnew(Tree);
 	container->add_child(tree);
@@ -374,16 +366,16 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 	tree->set_column_title(2, TTR("Dependencies"));
 	tree->set_column_expand(3, false);
 	tree->set_column_min_width(3, int(110 * EDSCALE));
-	tree->connect_compat("button_pressed", this, "_on_item_button");
-	tree->connect_compat("item_collapsed", this, "_on_item_collapsed");
-	tree->connect_compat("item_activated", this, "_on_item_activated");
+	tree->connect("button_pressed", callable_mp(this, &GDNativeLibraryEditor::_on_item_button));
+	tree->connect("item_collapsed", callable_mp(this, &GDNativeLibraryEditor::_on_item_collapsed));
+	tree->connect("item_activated", callable_mp(this, &GDNativeLibraryEditor::_on_item_activated));
 
 	file_dialog = memnew(EditorFileDialog);
 	file_dialog->set_access(EditorFileDialog::ACCESS_RESOURCES);
 	file_dialog->set_resizable(true);
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_on_library_selected");
-	file_dialog->connect_compat("files_selected", this, "_on_dependencies_selected");
+	file_dialog->connect("file_selected", callable_mp(this, &GDNativeLibraryEditor::_on_library_selected));
+	file_dialog->connect("files_selected", callable_mp(this, &GDNativeLibraryEditor::_on_dependencies_selected));
 
 	new_architecture_dialog = memnew(ConfirmationDialog);
 	add_child(new_architecture_dialog);
@@ -392,7 +384,7 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 	new_architecture_dialog->add_child(new_architecture_input);
 	new_architecture_dialog->set_custom_minimum_size(Vector2(300, 80) * EDSCALE);
 	new_architecture_input->set_anchors_and_margins_preset(PRESET_HCENTER_WIDE, PRESET_MODE_MINSIZE, 5 * EDSCALE);
-	new_architecture_dialog->get_ok()->connect_compat("pressed", this, "_on_create_new_entry");
+	new_architecture_dialog->get_ok()->connect("pressed", callable_mp(this, &GDNativeLibraryEditor::_on_create_new_entry));
 }
 
 void GDNativeLibraryEditorPlugin::edit(Object *p_node) {

--- a/modules/gdnative/gdnative_library_singleton_editor.cpp
+++ b/modules/gdnative/gdnative_library_singleton_editor.cpp
@@ -192,8 +192,6 @@ void GDNativeLibrarySingletonEditor::_notification(int p_what) {
 
 void GDNativeLibrarySingletonEditor::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_item_edited"), &GDNativeLibrarySingletonEditor::_item_edited);
-	ClassDB::bind_method(D_METHOD("_discover_singletons"), &GDNativeLibrarySingletonEditor::_discover_singletons);
 	ClassDB::bind_method(D_METHOD("_update_libraries"), &GDNativeLibrarySingletonEditor::_update_libraries);
 }
 
@@ -207,8 +205,8 @@ GDNativeLibrarySingletonEditor::GDNativeLibrarySingletonEditor() {
 	libraries->set_hide_root(true);
 	add_margin_child(TTR("Libraries: "), libraries, true);
 	updating = false;
-	libraries->connect_compat("item_edited", this, "_item_edited");
-	EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "_discover_singletons");
+	libraries->connect("item_edited", callable_mp(this, &GDNativeLibrarySingletonEditor::_item_edited));
+	EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &GDNativeLibrarySingletonEditor::_discover_singletons));
 }
 
 #endif // TOOLS_ENABLED

--- a/modules/gdnavigation/navigation_mesh_editor_plugin.cpp
+++ b/modules/gdnavigation/navigation_mesh_editor_plugin.cpp
@@ -94,9 +94,6 @@ void NavigationMeshEditor::edit(NavigationMeshInstance *p_nav_mesh_instance) {
 }
 
 void NavigationMeshEditor::_bind_methods() {
-
-	ClassDB::bind_method("_bake_pressed", &NavigationMeshEditor::_bake_pressed);
-	ClassDB::bind_method("_clear_pressed", &NavigationMeshEditor::_clear_pressed);
 }
 
 NavigationMeshEditor::NavigationMeshEditor() {
@@ -107,13 +104,13 @@ NavigationMeshEditor::NavigationMeshEditor() {
 	bake_hbox->add_child(button_bake);
 	button_bake->set_toggle_mode(true);
 	button_bake->set_text(TTR("Bake NavMesh"));
-	button_bake->connect_compat("pressed", this, "_bake_pressed");
+	button_bake->connect("pressed", callable_mp(this, &NavigationMeshEditor::_bake_pressed));
 
 	button_reset = memnew(ToolButton);
 	bake_hbox->add_child(button_reset);
 	// No button text, we only use a revert icon which is set when entering the tree.
 	button_reset->set_tooltip(TTR("Clear the navigation mesh."));
-	button_reset->connect_compat("pressed", this, "_clear_pressed");
+	button_reset->connect("pressed", callable_mp(this, &NavigationMeshEditor::_clear_pressed));
 
 	bake_info = memnew(Label);
 	bake_hbox->add_child(bake_info);

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -954,7 +954,7 @@ void GridMapEditor::update_palette() {
 
 void GridMapEditor::edit(GridMap *p_gridmap) {
 	if (!p_gridmap && node)
-		node->disconnect_compat("cell_size_changed", this, "_draw_grids");
+		node->disconnect("cell_size_changed", callable_mp(this, &GridMapEditor::_draw_grids));
 
 	node = p_gridmap;
 
@@ -988,7 +988,7 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	update_grid();
 	_update_clip();
 
-	node->connect_compat("cell_size_changed", this, "_draw_grids");
+	node->connect("cell_size_changed", callable_mp(this, &GridMapEditor::_draw_grids));
 }
 
 void GridMapEditor::_update_clip() {
@@ -1077,8 +1077,8 @@ void GridMapEditor::_notification(int p_what) {
 	switch (p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
-			mesh_library_palette->connect_compat("item_selected", this, "_item_selected_cbk");
+			get_tree()->connect("node_removed", callable_mp(this, &GridMapEditor::_node_removed));
+			mesh_library_palette->connect("item_selected", callable_mp(this, &GridMapEditor::_item_selected_cbk));
 			for (int i = 0; i < 3; i++) {
 
 				grid[i] = VS::get_singleton()->mesh_create();
@@ -1094,7 +1094,7 @@ void GridMapEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			get_tree()->disconnect_compat("node_removed", this, "_node_removed");
+			get_tree()->disconnect("node_removed", callable_mp(this, &GridMapEditor::_node_removed));
 			_clear_clipboard_data();
 
 			for (int i = 0; i < 3; i++) {
@@ -1198,20 +1198,8 @@ void GridMapEditor::_floor_mouse_exited() {
 
 void GridMapEditor::_bind_methods() {
 
-	ClassDB::bind_method("_text_changed", &GridMapEditor::_text_changed);
-	ClassDB::bind_method("_sbox_input", &GridMapEditor::_sbox_input);
-	ClassDB::bind_method("_mesh_library_palette_input", &GridMapEditor::_mesh_library_palette_input);
-	ClassDB::bind_method("_icon_size_changed", &GridMapEditor::_icon_size_changed);
-	ClassDB::bind_method("_menu_option", &GridMapEditor::_menu_option);
 	ClassDB::bind_method("_configure", &GridMapEditor::_configure);
-	ClassDB::bind_method("_item_selected_cbk", &GridMapEditor::_item_selected_cbk);
-	ClassDB::bind_method("_floor_changed", &GridMapEditor::_floor_changed);
-	ClassDB::bind_method("_floor_mouse_exited", &GridMapEditor::_floor_mouse_exited);
 	ClassDB::bind_method("_set_selection", &GridMapEditor::_set_selection);
-	ClassDB::bind_method("_node_removed", &GridMapEditor::_node_removed);
-
-	ClassDB::bind_method(D_METHOD("_set_display_mode", "mode"), &GridMapEditor::_set_display_mode);
-	ClassDB::bind_method("_draw_grids", &GridMapEditor::_draw_grids);
 }
 
 GridMapEditor::GridMapEditor(EditorNode *p_editor) {
@@ -1241,9 +1229,9 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	floor->get_line_edit()->add_constant_override("minimum_spaces", 16);
 
 	spatial_editor_hb->add_child(floor);
-	floor->connect_compat("value_changed", this, "_floor_changed");
-	floor->connect_compat("mouse_exited", this, "_floor_mouse_exited");
-	floor->get_line_edit()->connect_compat("mouse_exited", this, "_floor_mouse_exited");
+	floor->connect("value_changed", callable_mp(this, &GridMapEditor::_floor_changed));
+	floor->connect("mouse_exited", callable_mp(this, &GridMapEditor::_floor_mouse_exited));
+	floor->get_line_edit()->connect("mouse_exited", callable_mp(this, &GridMapEditor::_floor_mouse_exited));
 
 	spatial_editor_hb->add_child(memnew(VSeparator));
 
@@ -1300,7 +1288,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	settings_vbc->add_margin_child(TTR("Pick Distance:"), settings_pick_distance);
 
 	clip_mode = CLIP_DISABLED;
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", callable_mp(this, &GridMapEditor::_menu_option));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
@@ -1310,22 +1298,22 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	search_box->set_placeholder(TTR("Filter meshes"));
 	hb->add_child(search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", callable_mp(this, &GridMapEditor::_text_changed));
+	search_box->connect("gui_input", callable_mp(this, &GridMapEditor::_sbox_input));
 
 	mode_thumbnail = memnew(ToolButton);
 	mode_thumbnail->set_toggle_mode(true);
 	mode_thumbnail->set_pressed(true);
 	mode_thumbnail->set_icon(p_editor->get_gui_base()->get_icon("FileThumbnail", "EditorIcons"));
 	hb->add_child(mode_thumbnail);
-	mode_thumbnail->connect_compat("pressed", this, "_set_display_mode", varray(DISPLAY_THUMBNAIL));
+	mode_thumbnail->connect("pressed", callable_mp(this, &GridMapEditor::_set_display_mode), varray(DISPLAY_THUMBNAIL));
 
 	mode_list = memnew(ToolButton);
 	mode_list->set_toggle_mode(true);
 	mode_list->set_pressed(false);
 	mode_list->set_icon(p_editor->get_gui_base()->get_icon("FileList", "EditorIcons"));
 	hb->add_child(mode_list);
-	mode_list->connect_compat("pressed", this, "_set_display_mode", varray(DISPLAY_LIST));
+	mode_list->connect("pressed", callable_mp(this, &GridMapEditor::_set_display_mode), varray(DISPLAY_LIST));
 
 	size_slider = memnew(HSlider);
 	size_slider->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1333,7 +1321,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	size_slider->set_max(4.0f);
 	size_slider->set_step(0.1f);
 	size_slider->set_value(1.0f);
-	size_slider->connect_compat("value_changed", this, "_icon_size_changed");
+	size_slider->connect("value_changed", callable_mp(this, &GridMapEditor::_icon_size_changed));
 	add_child(size_slider);
 
 	EDITOR_DEF("editors/grid_map/preview_size", 64);
@@ -1343,7 +1331,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	mesh_library_palette = memnew(ItemList);
 	add_child(mesh_library_palette);
 	mesh_library_palette->set_v_size_flags(SIZE_EXPAND_FILL);
-	mesh_library_palette->connect_compat("gui_input", this, "_mesh_library_palette_input");
+	mesh_library_palette->connect("gui_input", callable_mp(this, &GridMapEditor::_mesh_library_palette_input));
 
 	info_message = memnew(Label);
 	info_message->set_text(TTR("Give a MeshLibrary resource to this GridMap to use its meshes."));

--- a/modules/opensimplex/noise_texture.cpp
+++ b/modules/opensimplex/noise_texture.cpp
@@ -76,7 +76,6 @@ void NoiseTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bump_strength"), &NoiseTexture::get_bump_strength);
 
 	ClassDB::bind_method(D_METHOD("_update_texture"), &NoiseTexture::_update_texture);
-	ClassDB::bind_method(D_METHOD("_queue_update"), &NoiseTexture::_queue_update);
 	ClassDB::bind_method(D_METHOD("_generate_texture"), &NoiseTexture::_generate_texture);
 	ClassDB::bind_method(D_METHOD("_thread_done", "image"), &NoiseTexture::_thread_done);
 
@@ -184,11 +183,11 @@ void NoiseTexture::set_noise(Ref<OpenSimplexNoise> p_noise) {
 	if (p_noise == noise)
 		return;
 	if (noise.is_valid()) {
-		noise->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_queue_update");
+		noise->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture::_queue_update));
 	}
 	noise = p_noise;
 	if (noise.is_valid()) {
-		noise->connect_compat(CoreStringNames::get_singleton()->changed, this, "_queue_update");
+		noise->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture::_queue_update));
 	}
 	_queue_update();
 }

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -30,13 +30,13 @@
 
 #include "visual_script.h"
 
-#include <stdint.h>
-
 #include "core/core_string_names.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "scene/main/node.h"
 #include "visual_script_nodes.h"
+
+#include <stdint.h>
 
 //used by editor, this is not really saved
 void VisualScriptNode::set_breakpoint(bool p_breakpoint) {

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -198,7 +198,7 @@ void VisualScript::remove_function(const StringName &p_name) {
 
 	for (Map<int, Function::NodeData>::Element *E = functions[p_name].nodes.front(); E; E = E->next()) {
 
-		E->get().node->disconnect_compat("ports_changed", this, "_node_ports_changed");
+		E->get().node->disconnect("ports_changed", callable_mp(this, &VisualScript::_node_ports_changed));
 		E->get().node->scripts_used.erase(this);
 	}
 
@@ -340,7 +340,7 @@ void VisualScript::add_node(const StringName &p_func, int p_id, const Ref<Visual
 	nd.pos = p_pos;
 
 	Ref<VisualScriptNode> vsn = p_node;
-	vsn->connect_compat("ports_changed", this, "_node_ports_changed", varray(p_id));
+	vsn->connect("ports_changed", callable_mp(this, &VisualScript::_node_ports_changed), varray(p_id));
 	vsn->scripts_used.insert(this);
 	vsn->validate_input_default_values(); // Validate when fully loaded
 
@@ -389,7 +389,7 @@ void VisualScript::remove_node(const StringName &p_func, int p_id) {
 		func.function_id = -1; //revert to invalid
 	}
 
-	func.nodes[p_id].node->disconnect_compat("ports_changed", this, "_node_ports_changed");
+	func.nodes[p_id].node->disconnect("ports_changed", callable_mp(this, &VisualScript::_node_ports_changed));
 	func.nodes[p_id].node->scripts_used.erase(this);
 
 	func.nodes.erase(p_id);
@@ -1374,8 +1374,6 @@ Dictionary VisualScript::_get_data() const {
 }
 
 void VisualScript::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_node_ports_changed"), &VisualScript::_node_ports_changed);
 
 	ClassDB::bind_method(D_METHOD("add_function", "name"), &VisualScript::add_function);
 	ClassDB::bind_method(D_METHOD("has_function", "name"), &VisualScript::has_function);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -556,8 +556,8 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 			gnode->set_meta("__vnode", node);
 			gnode->set_name(itos(E->get()));
-			gnode->connect_compat("dragged", this, "_node_moved", varray(E->get()));
-			gnode->connect_compat("close_request", this, "_remove_node", varray(E->get()), CONNECT_DEFERRED);
+			gnode->connect("dragged", callable_mp(this, &VisualScriptEditor::_node_moved), varray(E->get()));
+			gnode->connect("close_request", callable_mp(this, &VisualScriptEditor::_remove_node), varray(E->get()), CONNECT_DEFERRED);
 
 			if (E->get() != script->get_function_node_id(F->get())) {
 				//function can't be erased
@@ -575,7 +575,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					Button *btn = memnew(Button);
 					btn->set_text(TTR("Add Input Port"));
 					hbnc->add_child(btn);
-					btn->connect_compat("pressed", this, "_add_input_port", varray(E->get()), CONNECT_DEFERRED);
+					btn->connect("pressed", callable_mp(this, &VisualScriptEditor::_add_input_port), varray(E->get()), CONNECT_DEFERRED);
 				}
 				if (nd_list->is_output_port_editable()) {
 					if (nd_list->is_input_port_editable())
@@ -584,7 +584,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					Button *btn = memnew(Button);
 					btn->set_text(TTR("Add Output Port"));
 					hbnc->add_child(btn);
-					btn->connect_compat("pressed", this, "_add_output_port", varray(E->get()), CONNECT_DEFERRED);
+					btn->connect("pressed", callable_mp(this, &VisualScriptEditor::_add_output_port), varray(E->get()), CONNECT_DEFERRED);
 				}
 				gnode->add_child(hbnc);
 			} else if (Object::cast_to<VisualScriptExpression>(node.ptr())) {
@@ -594,7 +594,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				line_edit->set_expand_to_text_length(true);
 				line_edit->add_font_override("font", get_font("source", "EditorFonts"));
 				gnode->add_child(line_edit);
-				line_edit->connect_compat("text_changed", this, "_expression_text_changed", varray(E->get()));
+				line_edit->connect("text_changed", callable_mp(this, &VisualScriptEditor::_expression_text_changed), varray(E->get()));
 			} else {
 				String text = node->get_text();
 				if (!text.empty()) {
@@ -610,7 +610,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				gnode->set_comment(true);
 				gnode->set_resizable(true);
 				gnode->set_custom_minimum_size(vsc->get_size() * EDSCALE);
-				gnode->connect_compat("resize_request", this, "_comment_node_resized", varray(E->get()));
+				gnode->connect("resize_request", callable_mp(this, &VisualScriptEditor::_comment_node_resized), varray(E->get()));
 			}
 
 			if (node_styles.has(node->get_category())) {
@@ -720,8 +720,8 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							name_box->set_custom_minimum_size(Size2(60 * EDSCALE, 0));
 							name_box->set_text(left_name);
 							name_box->set_expand_to_text_length(true);
-							name_box->connect_compat("resized", this, "_update_node_size", varray(E->get()));
-							name_box->connect_compat("focus_exited", this, "_port_name_focus_out", varray(name_box, E->get(), i, true));
+							name_box->connect("resized", callable_mp(this, &VisualScriptEditor::_update_node_size), varray(E->get()));
+							name_box->connect("focus_exited", callable_mp(this, &VisualScriptEditor::_port_name_focus_out), varray(name_box, E->get(), i, true));
 						} else {
 							hbc->add_child(memnew(Label(left_name)));
 						}
@@ -734,13 +734,13 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							opbtn->select(left_type);
 							opbtn->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 							hbc->add_child(opbtn);
-							opbtn->connect_compat("item_selected", this, "_change_port_type", varray(E->get(), i, true), CONNECT_DEFERRED);
+							opbtn->connect("item_selected", callable_mp(this, &VisualScriptEditor::_change_port_type), varray(E->get(), i, true), CONNECT_DEFERRED);
 						}
 
 						Button *rmbtn = memnew(Button);
 						rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Remove", "EditorIcons"));
 						hbc->add_child(rmbtn);
-						rmbtn->connect_compat("pressed", this, "_remove_input_port", varray(E->get(), i), CONNECT_DEFERRED);
+						rmbtn->connect("pressed", callable_mp(this, &VisualScriptEditor::_remove_input_port), varray(E->get(), i), CONNECT_DEFERRED);
 					} else {
 						hbc->add_child(memnew(Label(left_name)));
 					}
@@ -760,7 +760,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 						if (left_type == Variant::COLOR) {
 							button->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
-							button->connect_compat("draw", this, "_draw_color_over_button", varray(button, value));
+							button->connect("draw", callable_mp(this, &VisualScriptEditor::_draw_color_over_button), varray(button, value));
 						} else if (left_type == Variant::OBJECT && Ref<Resource>(value).is_valid()) {
 
 							Ref<Resource> res = value;
@@ -776,7 +776,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 							button->set_text(value);
 						}
-						button->connect_compat("pressed", this, "_default_value_edited", varray(button, E->get(), i));
+						button->connect("pressed", callable_mp(this, &VisualScriptEditor::_default_value_edited), varray(button, E->get(), i));
 						hbc2->add_child(button);
 					}
 				} else {
@@ -802,7 +802,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 						Button *rmbtn = memnew(Button);
 						rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Remove", "EditorIcons"));
 						hbc->add_child(rmbtn);
-						rmbtn->connect_compat("pressed", this, "_remove_output_port", varray(E->get(), i), CONNECT_DEFERRED);
+						rmbtn->connect("pressed", callable_mp(this, &VisualScriptEditor::_remove_output_port), varray(E->get(), i), CONNECT_DEFERRED);
 
 						if (nd_list->is_output_port_type_editable()) {
 							OptionButton *opbtn = memnew(OptionButton);
@@ -812,7 +812,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							opbtn->select(right_type);
 							opbtn->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 							hbc->add_child(opbtn);
-							opbtn->connect_compat("item_selected", this, "_change_port_type", varray(E->get(), i, false), CONNECT_DEFERRED);
+							opbtn->connect("item_selected", callable_mp(this, &VisualScriptEditor::_change_port_type), varray(E->get(), i, false), CONNECT_DEFERRED);
 						}
 
 						if (nd_list->is_output_port_name_editable()) {
@@ -821,8 +821,8 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							name_box->set_custom_minimum_size(Size2(60 * EDSCALE, 0));
 							name_box->set_text(right_name);
 							name_box->set_expand_to_text_length(true);
-							name_box->connect_compat("resized", this, "_update_node_size", varray(E->get()));
-							name_box->connect_compat("focus_exited", this, "_port_name_focus_out", varray(name_box, E->get(), i, false));
+							name_box->connect("resized", callable_mp(this, &VisualScriptEditor::_update_node_size), varray(E->get()));
+							name_box->connect("focus_exited", callable_mp(this, &VisualScriptEditor::_port_name_focus_out), varray(name_box, E->get(), i, false));
 						} else {
 							hbc->add_child(memnew(Label(right_name)));
 						}
@@ -1225,7 +1225,7 @@ void VisualScriptEditor::_add_func_input() {
 	LineEdit *name_box = memnew(LineEdit);
 	name_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	name_box->set_text("input");
-	name_box->connect_compat("focus_entered", this, "_deselect_input_names");
+	name_box->connect("focus_entered", callable_mp(this, &VisualScriptEditor::_deselect_input_names));
 	hbox->add_child(name_box);
 
 	Label *type_label = memnew(Label);
@@ -1252,7 +1252,7 @@ void VisualScriptEditor::_add_func_input() {
 	func_input_vbox->add_child(hbox);
 	hbox->set_meta("id", hbox->get_position_in_parent());
 
-	delete_button->connect_compat("pressed", this, "_remove_func_input", varray(hbox));
+	delete_button->connect("pressed", callable_mp(this, &VisualScriptEditor::_remove_func_input), varray(hbox));
 
 	name_box->select_all();
 	name_box->grab_focus();
@@ -2408,7 +2408,7 @@ void VisualScriptEditor::set_edited_resource(const RES &p_res) {
 	variable_editor->script = script;
 	variable_editor->undo_redo = undo_redo;
 
-	script->connect_compat("node_ports_changed", this, "_node_ports_changed");
+	script->connect("node_ports_changed", callable_mp(this, &VisualScriptEditor::_node_ports_changed));
 
 	default_func = script->get_default_func();
 
@@ -3904,8 +3904,8 @@ void VisualScriptEditor::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			variable_editor->connect_compat("changed", this, "_update_members");
-			signal_editor->connect_compat("changed", this, "_update_members");
+			variable_editor->connect("changed", callable_mp(this, &VisualScriptEditor::_update_members));
+			signal_editor->connect("changed", callable_mp(this, &VisualScriptEditor::_update_members));
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
@@ -4601,76 +4601,22 @@ void VisualScriptEditor::set_syntax_highlighter(SyntaxHighlighter *p_highlighter
 
 void VisualScriptEditor::_bind_methods() {
 
-	ClassDB::bind_method("_member_button", &VisualScriptEditor::_member_button);
-	ClassDB::bind_method("_member_edited", &VisualScriptEditor::_member_edited);
-	ClassDB::bind_method("_member_selected", &VisualScriptEditor::_member_selected);
-	ClassDB::bind_method("_update_members", &VisualScriptEditor::_update_members);
-	ClassDB::bind_method("_members_gui_input", &VisualScriptEditor::_members_gui_input);
-	ClassDB::bind_method("_member_rmb_selected", &VisualScriptEditor::_member_rmb_selected);
-	ClassDB::bind_method("_member_option", &VisualScriptEditor::_member_option);
-	ClassDB::bind_method("_fn_name_box_input", &VisualScriptEditor::_fn_name_box_input);
-
-	ClassDB::bind_method("_change_base_type", &VisualScriptEditor::_change_base_type);
-	ClassDB::bind_method("_change_base_type_callback", &VisualScriptEditor::_change_base_type_callback);
-	ClassDB::bind_method("_toggle_tool_script", &VisualScriptEditor::_toggle_tool_script);
-	ClassDB::bind_method("_node_selected", &VisualScriptEditor::_node_selected);
-	ClassDB::bind_method("_node_moved", &VisualScriptEditor::_node_moved);
 	ClassDB::bind_method("_move_node", &VisualScriptEditor::_move_node);
-	ClassDB::bind_method("_begin_node_move", &VisualScriptEditor::_begin_node_move);
-	ClassDB::bind_method("_end_node_move", &VisualScriptEditor::_end_node_move);
-	ClassDB::bind_method("_remove_node", &VisualScriptEditor::_remove_node);
 	ClassDB::bind_method("_update_graph", &VisualScriptEditor::_update_graph, DEFVAL(-1));
-	ClassDB::bind_method("_node_ports_changed", &VisualScriptEditor::_node_ports_changed);
 
-	ClassDB::bind_method("_create_function_dialog", &VisualScriptEditor::_create_function_dialog);
-	ClassDB::bind_method("_create_function", &VisualScriptEditor::_create_function);
-	ClassDB::bind_method("_add_node_dialog", &VisualScriptEditor::_add_node_dialog);
-	ClassDB::bind_method("_add_func_input", &VisualScriptEditor::_add_func_input);
-	ClassDB::bind_method("_remove_func_input", &VisualScriptEditor::_remove_func_input);
-	ClassDB::bind_method("_deselect_input_names", &VisualScriptEditor::_deselect_input_names);
-
-	ClassDB::bind_method("_default_value_edited", &VisualScriptEditor::_default_value_edited);
-	ClassDB::bind_method("_default_value_changed", &VisualScriptEditor::_default_value_changed);
-	ClassDB::bind_method("_menu_option", &VisualScriptEditor::_menu_option);
-	ClassDB::bind_method("_graph_ofs_changed", &VisualScriptEditor::_graph_ofs_changed);
 	ClassDB::bind_method("_center_on_node", &VisualScriptEditor::_center_on_node);
-	ClassDB::bind_method("_comment_node_resized", &VisualScriptEditor::_comment_node_resized);
 	ClassDB::bind_method("_button_resource_previewed", &VisualScriptEditor::_button_resource_previewed);
 	ClassDB::bind_method("_port_action_menu", &VisualScriptEditor::_port_action_menu);
-	ClassDB::bind_method("_selected_connect_node", &VisualScriptEditor::_selected_connect_node);
-	ClassDB::bind_method("_selected_new_virtual_method", &VisualScriptEditor::_selected_new_virtual_method);
 
-	ClassDB::bind_method("_cancel_connect_node", &VisualScriptEditor::_cancel_connect_node);
 	ClassDB::bind_method("_create_new_node_from_name", &VisualScriptEditor::_create_new_node_from_name);
-	ClassDB::bind_method("_expression_text_changed", &VisualScriptEditor::_expression_text_changed);
-	ClassDB::bind_method("_add_input_port", &VisualScriptEditor::_add_input_port);
-	ClassDB::bind_method("_add_output_port", &VisualScriptEditor::_add_output_port);
-	ClassDB::bind_method("_remove_input_port", &VisualScriptEditor::_remove_input_port);
-	ClassDB::bind_method("_remove_output_port", &VisualScriptEditor::_remove_output_port);
-	ClassDB::bind_method("_change_port_type", &VisualScriptEditor::_change_port_type);
-	ClassDB::bind_method("_update_node_size", &VisualScriptEditor::_update_node_size);
-	ClassDB::bind_method("_port_name_focus_out", &VisualScriptEditor::_port_name_focus_out);
 
 	ClassDB::bind_method("get_drag_data_fw", &VisualScriptEditor::get_drag_data_fw);
 	ClassDB::bind_method("can_drop_data_fw", &VisualScriptEditor::can_drop_data_fw);
 	ClassDB::bind_method("drop_data_fw", &VisualScriptEditor::drop_data_fw);
 
 	ClassDB::bind_method("_input", &VisualScriptEditor::_input);
-	ClassDB::bind_method("_graph_gui_input", &VisualScriptEditor::_graph_gui_input);
-
-	ClassDB::bind_method("_on_nodes_delete", &VisualScriptEditor::_on_nodes_delete);
-	ClassDB::bind_method("_on_nodes_duplicate", &VisualScriptEditor::_on_nodes_duplicate);
-
-	ClassDB::bind_method("_hide_timer", &VisualScriptEditor::_hide_timer);
-
-	ClassDB::bind_method("_graph_connected", &VisualScriptEditor::_graph_connected);
-	ClassDB::bind_method("_graph_disconnected", &VisualScriptEditor::_graph_disconnected);
-	ClassDB::bind_method("_graph_connect_to_empty", &VisualScriptEditor::_graph_connect_to_empty);
 
 	ClassDB::bind_method("_update_graph_connections", &VisualScriptEditor::_update_graph_connections);
-
-	ClassDB::bind_method("_selected_method", &VisualScriptEditor::_selected_method);
-	ClassDB::bind_method("_draw_color_over_button", &VisualScriptEditor::_draw_color_over_button);
 
 	ClassDB::bind_method("_generic_search", &VisualScriptEditor::_generic_search);
 }
@@ -4697,7 +4643,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/create_function"), EDIT_CREATE_FUNCTION);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/refresh_nodes"), REFRESH_GRAPH);
-	edit_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	edit_menu->get_popup()->connect("id_pressed", callable_mp(this, &VisualScriptEditor::_menu_option));
 
 	members_section = memnew(VBoxContainer);
 	// Add but wait until done setting up this.
@@ -4707,7 +4653,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	CheckButton *tool_script_check = memnew(CheckButton);
 	tool_script_check->set_text(TTR("Make Tool:"));
 	members_section->add_child(tool_script_check);
-	tool_script_check->connect_compat("pressed", this, "_toggle_tool_script");
+	tool_script_check->connect("pressed", callable_mp(this, &VisualScriptEditor::_toggle_tool_script));
 
 	///       Members        ///
 
@@ -4715,11 +4661,11 @@ VisualScriptEditor::VisualScriptEditor() {
 	members_section->add_margin_child(TTR("Members:"), members, true);
 	members->set_custom_minimum_size(Size2(0, 50 * EDSCALE));
 	members->set_hide_root(true);
-	members->connect_compat("button_pressed", this, "_member_button");
-	members->connect_compat("item_edited", this, "_member_edited");
-	members->connect_compat("cell_selected", this, "_member_selected", varray(), CONNECT_DEFERRED);
-	members->connect_compat("gui_input", this, "_members_gui_input");
-	members->connect_compat("item_rmb_selected", this, "_member_rmb_selected");
+	members->connect("button_pressed", callable_mp(this, &VisualScriptEditor::_member_button));
+	members->connect("item_edited", callable_mp(this, &VisualScriptEditor::_member_edited));
+	members->connect("cell_selected", callable_mp(this, &VisualScriptEditor::_member_selected), varray(), CONNECT_DEFERRED);
+	members->connect("gui_input", callable_mp(this, &VisualScriptEditor::_members_gui_input));
+	members->connect("item_rmb_selected", callable_mp(this, &VisualScriptEditor::_member_rmb_selected));
 	members->set_allow_rmb_select(true);
 	members->set_allow_reselect(true);
 	members->set_hide_folding(true);
@@ -4727,13 +4673,13 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	member_popup = memnew(PopupMenu);
 	add_child(member_popup);
-	member_popup->connect_compat("id_pressed", this, "_member_option");
+	member_popup->connect("id_pressed", callable_mp(this, &VisualScriptEditor::_member_option));
 
 	function_name_edit = memnew(PopupDialog);
 	function_name_box = memnew(LineEdit);
 	function_name_edit->add_child(function_name_box);
 	function_name_edit->set_h_size_flags(SIZE_EXPAND);
-	function_name_box->connect_compat("gui_input", this, "_fn_name_box_input");
+	function_name_box->connect("gui_input", callable_mp(this, &VisualScriptEditor::_fn_name_box_input));
 	function_name_box->set_expand_to_text_length(true);
 	add_child(function_name_edit);
 
@@ -4743,15 +4689,15 @@ VisualScriptEditor::VisualScriptEditor() {
 	add_child(graph);
 	graph->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	graph->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	graph->connect_compat("node_selected", this, "_node_selected");
-	graph->connect_compat("_begin_node_move", this, "_begin_node_move");
-	graph->connect_compat("_end_node_move", this, "_end_node_move");
-	graph->connect_compat("delete_nodes_request", this, "_on_nodes_delete");
-	graph->connect_compat("duplicate_nodes_request", this, "_on_nodes_duplicate");
-	graph->connect_compat("gui_input", this, "_graph_gui_input");
+	graph->connect("node_selected", callable_mp(this, &VisualScriptEditor::_node_selected));
+	graph->connect("_begin_node_move", callable_mp(this, &VisualScriptEditor::_begin_node_move));
+	graph->connect("_end_node_move", callable_mp(this, &VisualScriptEditor::_end_node_move));
+	graph->connect("delete_nodes_request", callable_mp(this, &VisualScriptEditor::_on_nodes_delete));
+	graph->connect("duplicate_nodes_request", callable_mp(this, &VisualScriptEditor::_on_nodes_duplicate));
+	graph->connect("gui_input", callable_mp(this, &VisualScriptEditor::_graph_gui_input));
 	graph->set_drag_forwarding(this);
 	graph->hide();
-	graph->connect_compat("scroll_offset_changed", this, "_graph_ofs_changed");
+	graph->connect("scroll_offset_changed", callable_mp(this, &VisualScriptEditor::_graph_ofs_changed));
 
 	/// Add Buttons to Top Bar/Zoom bar.
 	HBoxContainer *graph_hbc = graph->get_zoom_hbox();
@@ -4761,18 +4707,18 @@ VisualScriptEditor::VisualScriptEditor() {
 	graph_hbc->add_child(base_lbl);
 
 	base_type_select = memnew(Button);
-	base_type_select->connect_compat("pressed", this, "_change_base_type");
+	base_type_select->connect("pressed", callable_mp(this, &VisualScriptEditor::_change_base_type));
 	graph_hbc->add_child(base_type_select);
 
 	Button *add_nds = memnew(Button);
 	add_nds->set_text(TTR("Add Nodes..."));
 	graph_hbc->add_child(add_nds);
-	add_nds->connect_compat("pressed", this, "_add_node_dialog");
+	add_nds->connect("pressed", callable_mp(this, &VisualScriptEditor::_add_node_dialog));
 
 	Button *fn_btn = memnew(Button);
 	fn_btn->set_text(TTR("Add Function..."));
 	graph_hbc->add_child(fn_btn);
-	fn_btn->connect_compat("pressed", this, "_create_function_dialog");
+	fn_btn->connect("pressed", callable_mp(this, &VisualScriptEditor::_create_function_dialog));
 
 	// Add Function Dialog.
 	VBoxContainer *function_vb = memnew(VBoxContainer);
@@ -4790,7 +4736,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	func_name_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	func_name_box->set_placeholder(TTR("function_name"));
 	func_name_box->set_text("");
-	func_name_box->connect_compat("focus_entered", this, "_deselect_input_names");
+	func_name_box->connect("focus_entered", callable_mp(this, &VisualScriptEditor::_deselect_input_names));
 	func_name_hbox->add_child(func_name_box);
 
 	// Add minor setting for function if needed, here!
@@ -4800,7 +4746,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	Button *add_input_button = memnew(Button);
 	add_input_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_input_button->set_text(TTR("Add Input"));
-	add_input_button->connect_compat("pressed", this, "_add_func_input");
+	add_input_button->connect("pressed", callable_mp(this, &VisualScriptEditor::_add_func_input));
 	function_vb->add_child(add_input_button);
 
 	func_input_scroll = memnew(ScrollContainer);
@@ -4816,7 +4762,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	function_create_dialog->set_title(TTR("Create Function"));
 	function_create_dialog->add_child(function_vb);
 	function_create_dialog->get_ok()->set_text(TTR("Create"));
-	function_create_dialog->get_ok()->connect_compat("pressed", this, "_create_function");
+	function_create_dialog->get_ok()->connect("pressed", callable_mp(this, &VisualScriptEditor::_create_function));
 	add_child(function_create_dialog);
 
 	select_func_text = memnew(Label);
@@ -4836,7 +4782,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	hint_text_timer = memnew(Timer);
 	hint_text_timer->set_wait_time(4);
-	hint_text_timer->connect_compat("timeout", this, "_hide_timer");
+	hint_text_timer->connect("timeout", callable_mp(this, &VisualScriptEditor::_hide_timer));
 	add_child(hint_text_timer);
 
 	// Allowed casts (connections).
@@ -4854,9 +4800,9 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	graph->add_valid_left_disconnect_type(TYPE_SEQUENCE);
 
-	graph->connect_compat("connection_request", this, "_graph_connected");
-	graph->connect_compat("disconnection_request", this, "_graph_disconnected");
-	graph->connect_compat("connection_to_empty", this, "_graph_connect_to_empty");
+	graph->connect("connection_request", callable_mp(this, &VisualScriptEditor::_graph_connected));
+	graph->connect("disconnection_request", callable_mp(this, &VisualScriptEditor::_graph_disconnected));
+	graph->connect("connection_to_empty", callable_mp(this, &VisualScriptEditor::_graph_connect_to_empty));
 
 	edit_signal_dialog = memnew(AcceptDialog);
 	edit_signal_dialog->get_ok()->set_text(TTR("Close"));
@@ -4880,7 +4826,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	select_base_type = memnew(CreateDialog);
 	select_base_type->set_base_type("Object"); // Anything goes.
-	select_base_type->connect_compat("create", this, "_change_base_type_callback");
+	select_base_type->connect("create", callable_mp(this, &VisualScriptEditor::_change_base_type_callback));
 	add_child(select_base_type);
 
 	undo_redo = EditorNode::get_singleton()->get_undo_redo();
@@ -4892,22 +4838,22 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	default_value_edit = memnew(CustomPropertyEditor);
 	add_child(default_value_edit);
-	default_value_edit->connect_compat("variant_changed", this, "_default_value_changed");
+	default_value_edit->connect("variant_changed", callable_mp(this, &VisualScriptEditor::_default_value_changed));
 
 	method_select = memnew(VisualScriptPropertySelector);
 	add_child(method_select);
-	method_select->connect_compat("selected", this, "_selected_method");
+	method_select->connect("selected", callable_mp(this, &VisualScriptEditor::_selected_method));
 	error_line = -1;
 
 	new_connect_node_select = memnew(VisualScriptPropertySelector);
 	add_child(new_connect_node_select);
 	new_connect_node_select->set_resizable(true);
-	new_connect_node_select->connect_compat("selected", this, "_selected_connect_node");
-	new_connect_node_select->get_cancel()->connect_compat("pressed", this, "_cancel_connect_node");
+	new_connect_node_select->connect("selected", callable_mp(this, &VisualScriptEditor::_selected_connect_node));
+	new_connect_node_select->get_cancel()->connect("pressed", callable_mp(this, &VisualScriptEditor::_cancel_connect_node));
 
 	new_virtual_method_select = memnew(VisualScriptPropertySelector);
 	add_child(new_virtual_method_select);
-	new_virtual_method_select->connect_compat("selected", this, "_selected_new_virtual_method");
+	new_virtual_method_select->connect("selected", callable_mp(this, &VisualScriptEditor::_selected_new_virtual_method));
 }
 
 VisualScriptEditor::~VisualScriptEditor() {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -3130,8 +3130,6 @@ void VisualScriptCustomNode::_bind_methods() {
 	stepmi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 	BIND_VMETHOD(stepmi);
 
-	ClassDB::bind_method(D_METHOD("_script_changed"), &VisualScriptCustomNode::_script_changed);
-
 	BIND_ENUM_CONSTANT(START_MODE_BEGIN_SEQUENCE);
 	BIND_ENUM_CONSTANT(START_MODE_CONTINUE_SEQUENCE);
 	BIND_ENUM_CONSTANT(START_MODE_RESUME_YIELD);
@@ -3144,7 +3142,7 @@ void VisualScriptCustomNode::_bind_methods() {
 }
 
 VisualScriptCustomNode::VisualScriptCustomNode() {
-	connect_compat("script_changed", this, "_script_changed");
+	connect("script_changed", callable_mp(this, &VisualScriptCustomNode::_script_changed));
 }
 
 //////////////////////////////////////////

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -520,7 +520,7 @@ void VisualScriptPropertySelector::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		connect_compat("confirmed", this, "_confirmed");
+		connect("confirmed", callable_mp(this, &VisualScriptPropertySelector::_confirmed));
 	}
 }
 
@@ -688,11 +688,6 @@ void VisualScriptPropertySelector::show_window(float p_screen_ratio) {
 
 void VisualScriptPropertySelector::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_text_changed"), &VisualScriptPropertySelector::_text_changed);
-	ClassDB::bind_method(D_METHOD("_confirmed"), &VisualScriptPropertySelector::_confirmed);
-	ClassDB::bind_method(D_METHOD("_sbox_input"), &VisualScriptPropertySelector::_sbox_input);
-	ClassDB::bind_method(D_METHOD("_item_selected"), &VisualScriptPropertySelector::_item_selected);
-
 	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::STRING, "category"), PropertyInfo(Variant::BOOL, "connecting")));
 }
 
@@ -703,16 +698,16 @@ VisualScriptPropertySelector::VisualScriptPropertySelector() {
 	//set_child_rect(vbc);
 	search_box = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", callable_mp(this, &VisualScriptPropertySelector::_text_changed));
+	search_box->connect("gui_input", callable_mp(this, &VisualScriptPropertySelector::_sbox_input));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_text(TTR("Open"));
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
-	search_options->connect_compat("cell_selected", this, "_item_selected");
+	search_options->connect("item_activated", callable_mp(this, &VisualScriptPropertySelector::_confirmed));
+	search_options->connect("cell_selected", callable_mp(this, &VisualScriptPropertySelector::_item_selected));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
 	virtuals_only = false;

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -475,10 +475,10 @@ void AnimatedSprite::_notification(int p_what) {
 void AnimatedSprite::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 	if (frames.is_valid())
-		frames->disconnect_compat("changed", this, "_res_changed");
+		frames->disconnect("changed", callable_mp(this, &AnimatedSprite::_res_changed));
 	frames = p_frames;
 	if (frames.is_valid())
-		frames->connect_compat("changed", this, "_res_changed");
+		frames->connect("changed", callable_mp(this, &AnimatedSprite::_res_changed));
 
 	if (!frames.is_valid()) {
 		frame = 0;
@@ -734,8 +734,6 @@ void AnimatedSprite::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_shininess", "shininess"), &AnimatedSprite::set_shininess);
 	ClassDB::bind_method(D_METHOD("get_shininess"), &AnimatedSprite::get_shininess);
-
-	ClassDB::bind_method(D_METHOD("_res_changed"), &AnimatedSprite::_res_changed);
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 	ADD_SIGNAL(MethodInfo("animation_finished"));

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "area_2d.h"
+
 #include "scene/scene_string_names.h"
 #include "servers/audio_server.h"
 #include "servers/physics_2d_server.h"
@@ -171,8 +172,8 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 			E->get().rc = 0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_body_enter_tree), make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_body_exit_tree), make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
 				}
@@ -198,8 +199,8 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 		if (E->get().rc == 0) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_body_enter_tree));
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_body_exit_tree));
 				if (E->get().in_tree)
 					emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
 			}
@@ -273,8 +274,8 @@ void Area2D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 			E->get().rc = 0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_area_enter_tree), make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_area_exit_tree), make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->area_entered, node);
 				}
@@ -300,8 +301,8 @@ void Area2D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 		if (E->get().rc == 0) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_area_enter_tree));
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_area_exit_tree));
 				if (E->get().in_tree)
 					emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
 			}
@@ -333,12 +334,11 @@ void Area2D::_clear_monitoring() {
 			Object *obj = ObjectDB::get_instance(E->key());
 			Node *node = Object::cast_to<Node>(obj);
 
-			if (!node) //node may have been deleted in previous frame or at other legiminate point
+			if (!node) //node may have been deleted in previous frame or at other legitimate point
 				continue;
-			//ERR_CONTINUE(!node);
 
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_body_enter_tree));
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_body_exit_tree));
 
 			if (!E->get().in_tree)
 				continue;
@@ -363,12 +363,11 @@ void Area2D::_clear_monitoring() {
 			Object *obj = ObjectDB::get_instance(E->key());
 			Node *node = Object::cast_to<Node>(obj);
 
-			if (!node) //node may have been deleted in previous frame or at other legiminate point
+			if (!node) //node may have been deleted in previous frame or at other legitimate point
 				continue;
-			//ERR_CONTINUE(!node);
 
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_area_enter_tree));
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_area_exit_tree));
 
 			if (!E->get().in_tree)
 				continue;
@@ -584,13 +583,6 @@ void Area2D::_validate_property(PropertyInfo &property) const {
 }
 
 void Area2D::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_body_enter_tree", "id"), &Area2D::_body_enter_tree);
-	ClassDB::bind_method(D_METHOD("_body_exit_tree", "id"), &Area2D::_body_exit_tree);
-
-	ClassDB::bind_method(D_METHOD("_area_enter_tree", "id"), &Area2D::_area_enter_tree);
-	ClassDB::bind_method(D_METHOD("_area_exit_tree", "id"), &Area2D::_area_exit_tree);
-
 	ClassDB::bind_method(D_METHOD("set_space_override_mode", "space_override_mode"), &Area2D::set_space_override_mode);
 	ClassDB::bind_method(D_METHOD("get_space_override_mode"), &Area2D::get_space_override_mode);
 

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -512,8 +512,6 @@ void AudioStreamPlayer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_stream_playback"), &AudioStreamPlayer2D::get_stream_playback);
 
-	ClassDB::bind_method(D_METHOD("_bus_layout_changed"), &AudioStreamPlayer2D::_bus_layout_changed);
-
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "volume_db", PROPERTY_HINT_RANGE, "-80,24"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
@@ -545,7 +543,7 @@ AudioStreamPlayer2D::AudioStreamPlayer2D() {
 	stream_paused = false;
 	stream_paused_fade_in = false;
 	stream_paused_fade_out = false;
-	AudioServer::get_singleton()->connect_compat("bus_layout_changed", this, "_bus_layout_changed");
+	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer2D::_bus_layout_changed));
 }
 
 AudioStreamPlayer2D::~AudioStreamPlayer2D() {

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -149,7 +149,7 @@ void CollisionShape2D::_notification(int p_what) {
 void CollisionShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 
 	if (shape.is_valid())
-		shape->disconnect_compat("changed", this, "_shape_changed");
+		shape->disconnect("changed", callable_mp(this, &CollisionShape2D::_shape_changed));
 	shape = p_shape;
 	update();
 	if (parent) {
@@ -160,7 +160,7 @@ void CollisionShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 	}
 
 	if (shape.is_valid())
-		shape->connect_compat("changed", this, "_shape_changed");
+		shape->connect("changed", callable_mp(this, &CollisionShape2D::_shape_changed));
 
 	update_configuration_warning();
 }
@@ -237,7 +237,6 @@ void CollisionShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_one_way_collision_enabled"), &CollisionShape2D::is_one_way_collision_enabled);
 	ClassDB::bind_method(D_METHOD("set_one_way_collision_margin", "margin"), &CollisionShape2D::set_one_way_collision_margin);
 	ClassDB::bind_method(D_METHOD("get_one_way_collision_margin"), &CollisionShape2D::get_one_way_collision_margin);
-	ClassDB::bind_method(D_METHOD("_shape_changed"), &CollisionShape2D::_shape_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "cpu_particles_2d.h"
+
 #include "core/core_string_names.h"
 #include "scene/2d/canvas_item.h"
 #include "scene/2d/particles_2d.h"
@@ -212,12 +213,12 @@ void CPUParticles2D::set_texture(const Ref<Texture2D> &p_texture) {
 		return;
 
 	if (texture.is_valid())
-		texture->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CPUParticles2D::_texture_changed));
 
 	texture = p_texture;
 
 	if (texture.is_valid())
-		texture->connect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CPUParticles2D::_texture_changed));
 
 	update();
 	_update_mesh_texture();
@@ -1340,8 +1341,6 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_gravity", "accel_vec"), &CPUParticles2D::set_gravity);
 
 	ClassDB::bind_method(D_METHOD("convert_from_particles", "particles"), &CPUParticles2D::convert_from_particles);
-
-	ClassDB::bind_method(D_METHOD("_texture_changed"), &CPUParticles2D::_texture_changed);
 
 	ADD_GROUP("Emission Shape", "emission_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_shape", PROPERTY_HINT_ENUM, "Point,Sphere,Box,Points,Directed Points"), "set_emission_shape", "get_emission_shape");

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1053,13 +1053,13 @@ void CPUParticles2D::_set_redraw(bool p_redraw) {
 	update_mutex->lock();
 #endif
 	if (redraw) {
-		VS::get_singleton()->connect_compat("frame_pre_draw", this, "_update_render_thread");
+		VS::get_singleton()->connect("frame_pre_draw", callable_mp(this, &CPUParticles2D::_update_render_thread));
 		VS::get_singleton()->canvas_item_set_update_when_visible(get_canvas_item(), true);
 
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, -1);
 	} else {
-		if (VS::get_singleton()->is_connected_compat("frame_pre_draw", this, "_update_render_thread")) {
-			VS::get_singleton()->disconnect_compat("frame_pre_draw", this, "_update_render_thread");
+		if (VS::get_singleton()->is_connected("frame_pre_draw", callable_mp(this, &CPUParticles2D::_update_render_thread))) {
+			VS::get_singleton()->disconnect("frame_pre_draw", callable_mp(this, &CPUParticles2D::_update_render_thread));
 		}
 		VS::get_singleton()->canvas_item_set_update_when_visible(get_canvas_item(), false);
 
@@ -1341,7 +1341,6 @@ void CPUParticles2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("convert_from_particles", "particles"), &CPUParticles2D::convert_from_particles);
 
-	ClassDB::bind_method(D_METHOD("_update_render_thread"), &CPUParticles2D::_update_render_thread);
 	ClassDB::bind_method(D_METHOD("_texture_changed"), &CPUParticles2D::_texture_changed);
 
 	ADD_GROUP("Emission Shape", "emission_");

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -234,7 +234,7 @@ void LightOccluder2D::set_occluder_polygon(const Ref<OccluderPolygon2D> &p_polyg
 
 #ifdef DEBUG_ENABLED
 	if (occluder_polygon.is_valid())
-		occluder_polygon->disconnect_compat("changed", this, "_poly_changed");
+		occluder_polygon->disconnect("changed", callable_mp(this, &LightOccluder2D::_poly_changed));
 #endif
 	occluder_polygon = p_polygon;
 
@@ -245,7 +245,7 @@ void LightOccluder2D::set_occluder_polygon(const Ref<OccluderPolygon2D> &p_polyg
 
 #ifdef DEBUG_ENABLED
 	if (occluder_polygon.is_valid())
-		occluder_polygon->connect_compat("changed", this, "_poly_changed");
+		occluder_polygon->connect("changed", callable_mp(this, &LightOccluder2D::_poly_changed));
 	update();
 #endif
 }
@@ -286,8 +286,6 @@ void LightOccluder2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_occluder_light_mask", "mask"), &LightOccluder2D::set_occluder_light_mask);
 	ClassDB::bind_method(D_METHOD("get_occluder_light_mask"), &LightOccluder2D::get_occluder_light_mask);
-
-	ClassDB::bind_method("_poly_changed", &LightOccluder2D::_poly_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "occluder", PROPERTY_HINT_RESOURCE_TYPE, "OccluderPolygon2D"), "set_occluder_polygon", "get_occluder_polygon");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_occluder_light_mask", "get_occluder_light_mask");

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -29,9 +29,9 @@
 /*************************************************************************/
 
 #include "line_2d.h"
-#include "line_builder.h"
 
 #include "core/core_string_names.h"
+#include "line_builder.h"
 
 // Needed so we can bind functions
 VARIANT_ENUM_CAST(Line2D::LineJointMode)
@@ -101,14 +101,14 @@ float Line2D::get_width() const {
 void Line2D::set_curve(const Ref<Curve> &p_curve) {
 	// Cleanup previous connection if any
 	if (_curve.is_valid()) {
-		_curve->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_curve_changed");
+		_curve->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_curve_changed));
 	}
 
 	_curve = p_curve;
 
 	// Connect to the curve so the line will update when it is changed
 	if (_curve.is_valid()) {
-		_curve->connect_compat(CoreStringNames::get_singleton()->changed, this, "_curve_changed");
+		_curve->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_curve_changed));
 	}
 
 	update();
@@ -171,14 +171,14 @@ void Line2D::set_gradient(const Ref<Gradient> &p_gradient) {
 
 	// Cleanup previous connection if any
 	if (_gradient.is_valid()) {
-		_gradient->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_gradient_changed");
+		_gradient->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_gradient_changed));
 	}
 
 	_gradient = p_gradient;
 
 	// Connect to the gradient so the line will update when the ColorRamp is changed
 	if (_gradient.is_valid()) {
-		_gradient->connect_compat(CoreStringNames::get_singleton()->changed, this, "_gradient_changed");
+		_gradient->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_gradient_changed));
 	}
 
 	update();
@@ -428,7 +428,4 @@ void Line2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(LINE_TEXTURE_NONE);
 	BIND_ENUM_CONSTANT(LINE_TEXTURE_TILE);
 	BIND_ENUM_CONSTANT(LINE_TEXTURE_STRETCH);
-
-	ClassDB::bind_method(D_METHOD("_gradient_changed"), &Line2D::_gradient_changed);
-	ClassDB::bind_method(D_METHOD("_curve_changed"), &Line2D::_curve_changed);
 }

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -503,14 +503,14 @@ void NavigationPolygonInstance::set_navigation_polygon(const Ref<NavigationPolyg
 	}
 
 	if (navpoly.is_valid()) {
-		navpoly->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_navpoly_changed");
+		navpoly->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NavigationPolygonInstance::_navpoly_changed));
 	}
 
 	navpoly = p_navpoly;
 	Navigation2DServer::get_singleton()->region_set_navpoly(region, p_navpoly);
 
 	if (navpoly.is_valid()) {
-		navpoly->connect_compat(CoreStringNames::get_singleton()->changed, this, "_navpoly_changed");
+		navpoly->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NavigationPolygonInstance::_navpoly_changed));
 	}
 	_navpoly_changed();
 

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -134,13 +134,13 @@ void Path2D::_curve_changed() {
 void Path2D::set_curve(const Ref<Curve2D> &p_curve) {
 
 	if (curve.is_valid()) {
-		curve->disconnect_compat("changed", this, "_curve_changed");
+		curve->disconnect("changed", callable_mp(this, &Path2D::_curve_changed));
 	}
 
 	curve = p_curve;
 
 	if (curve.is_valid()) {
-		curve->connect_compat("changed", this, "_curve_changed");
+		curve->connect("changed", callable_mp(this, &Path2D::_curve_changed));
 	}
 
 	_curve_changed();
@@ -155,7 +155,6 @@ void Path2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_curve", "curve"), &Path2D::set_curve);
 	ClassDB::bind_method(D_METHOD("get_curve"), &Path2D::get_curve);
-	ClassDB::bind_method(D_METHOD("_curve_changed"), &Path2D::_curve_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve2D"), "set_curve", "get_curve");
 }

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -192,14 +192,15 @@ real_t StaticBody2D::get_constant_angular_velocity() const {
 
 void StaticBody2D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics"))
-			physics_material_override->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody2D::_reload_physics_characteristics))) {
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody2D::_reload_physics_characteristics));
+		}
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody2D::_reload_physics_characteristics));
 	}
 	_reload_physics_characteristics();
 }
@@ -217,8 +218,6 @@ void StaticBody2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_physics_material_override", "physics_material_override"), &StaticBody2D::set_physics_material_override);
 	ClassDB::bind_method(D_METHOD("get_physics_material_override"), &StaticBody2D::get_physics_material_override);
-
-	ClassDB::bind_method(D_METHOD("_reload_physics_characteristics"), &StaticBody2D::_reload_physics_characteristics);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "constant_linear_velocity"), "set_constant_linear_velocity", "get_constant_linear_velocity");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "constant_angular_velocity"), "set_constant_angular_velocity", "get_constant_angular_velocity");
@@ -311,8 +310,8 @@ void RigidBody2D::_body_inout(int p_status, ObjectID p_instance, int p_body_shap
 			//E->get().rc=0;
 			E->get().in_scene = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &RigidBody2D::_body_enter_tree), make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &RigidBody2D::_body_exit_tree), make_binds(objid));
 				if (E->get().in_scene) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
 				}
@@ -340,8 +339,8 @@ void RigidBody2D::_body_inout(int p_status, ObjectID p_instance, int p_body_shap
 		if (E->get().shapes.empty()) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &RigidBody2D::_body_enter_tree));
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &RigidBody2D::_body_exit_tree));
 				if (in_scene)
 					emit_signal(SceneStringNames::get_singleton()->body_exited, node);
 			}
@@ -545,14 +544,15 @@ real_t RigidBody2D::get_weight() const {
 
 void RigidBody2D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics"))
-			physics_material_override->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody2D::_reload_physics_characteristics))) {
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody2D::_reload_physics_characteristics));
+		}
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody2D::_reload_physics_characteristics));
 	}
 	_reload_physics_characteristics();
 }
@@ -774,9 +774,8 @@ void RigidBody2D::set_contact_monitor(bool p_enabled) {
 			Node *node = Object::cast_to<Node>(obj);
 
 			if (node) {
-
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &RigidBody2D::_body_enter_tree));
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &RigidBody2D::_body_exit_tree));
 			}
 		}
 
@@ -845,8 +844,6 @@ void RigidBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_material_override", "physics_material_override"), &RigidBody2D::set_physics_material_override);
 	ClassDB::bind_method(D_METHOD("get_physics_material_override"), &RigidBody2D::get_physics_material_override);
 
-	ClassDB::bind_method(D_METHOD("_reload_physics_characteristics"), &RigidBody2D::_reload_physics_characteristics);
-
 	ClassDB::bind_method(D_METHOD("set_gravity_scale", "gravity_scale"), &RigidBody2D::set_gravity_scale);
 	ClassDB::bind_method(D_METHOD("get_gravity_scale"), &RigidBody2D::get_gravity_scale);
 
@@ -898,8 +895,6 @@ void RigidBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("test_motion", "motion", "infinite_inertia", "margin", "result"), &RigidBody2D::_test_motion, DEFVAL(true), DEFVAL(0.08), DEFVAL(Variant()));
 
 	ClassDB::bind_method(D_METHOD("_direct_state_changed"), &RigidBody2D::_direct_state_changed);
-	ClassDB::bind_method(D_METHOD("_body_enter_tree"), &RigidBody2D::_body_enter_tree);
-	ClassDB::bind_method(D_METHOD("_body_exit_tree"), &RigidBody2D::_body_exit_tree);
 
 	ClassDB::bind_method(D_METHOD("get_colliding_bodies"), &RigidBody2D::get_colliding_bodies);
 

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -120,11 +120,11 @@ void Polygon2D::_notification(int p_what) {
 			if (new_skeleton_id != current_skeleton_id) {
 				Object *old_skeleton = ObjectDB::get_instance(current_skeleton_id);
 				if (old_skeleton) {
-					old_skeleton->disconnect_compat("bone_setup_changed", this, "_skeleton_bone_setup_changed");
+					old_skeleton->disconnect("bone_setup_changed", callable_mp(this, &Polygon2D::_skeleton_bone_setup_changed));
 				}
 
 				if (skeleton_node) {
-					skeleton_node->connect_compat("bone_setup_changed", this, "_skeleton_bone_setup_changed");
+					skeleton_node->connect("bone_setup_changed", callable_mp(this, &Polygon2D::_skeleton_bone_setup_changed));
 				}
 
 				current_skeleton_id = new_skeleton_id;
@@ -689,8 +689,6 @@ void Polygon2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_bones", "bones"), &Polygon2D::_set_bones);
 	ClassDB::bind_method(D_METHOD("_get_bones"), &Polygon2D::_get_bones);
-
-	ClassDB::bind_method(D_METHOD("_skeleton_bone_setup_changed"), &Polygon2D::_skeleton_bone_setup_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset"), "set_offset", "get_offset");

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "sprite.h"
+
 #include "core/core_string_names.h"
 #include "core/os/os.h"
 #include "scene/main/viewport.h"
@@ -142,12 +143,12 @@ void Sprite::set_texture(const Ref<Texture2D> &p_texture) {
 		return;
 
 	if (texture.is_valid())
-		texture->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Sprite::_texture_changed));
 
 	texture = p_texture;
 
 	if (texture.is_valid())
-		texture->connect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Sprite::_texture_changed));
 
 	update();
 	emit_signal("texture_changed");
@@ -491,8 +492,6 @@ void Sprite::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_hframes"), &Sprite::get_hframes);
 
 	ClassDB::bind_method(D_METHOD("get_rect"), &Sprite::get_rect);
-
-	ClassDB::bind_method(D_METHOD("_texture_changed"), &Sprite::_texture_changed);
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 	ADD_SIGNAL(MethodInfo("texture_changed"));

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -177,7 +177,7 @@ void TileMap::_update_quadrant_transform() {
 void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 
 	if (tile_set.is_valid()) {
-		tile_set->disconnect_compat("changed", this, "_recreate_quadrants");
+		tile_set->disconnect("changed", callable_mp(this, &TileMap::_recreate_quadrants));
 		tile_set->remove_change_receptor(this);
 	}
 
@@ -185,7 +185,7 @@ void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 	tile_set = p_tileset;
 
 	if (tile_set.is_valid()) {
-		tile_set->connect_compat("changed", this, "_recreate_quadrants");
+		tile_set->connect("changed", callable_mp(this, &TileMap::_recreate_quadrants));
 		tile_set->add_change_receptor(this);
 	} else {
 		clear();
@@ -1883,7 +1883,6 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("world_to_map", "world_position"), &TileMap::world_to_map);
 
 	ClassDB::bind_method(D_METHOD("_clear_quadrants"), &TileMap::_clear_quadrants);
-	ClassDB::bind_method(D_METHOD("_recreate_quadrants"), &TileMap::_recreate_quadrants);
 	ClassDB::bind_method(D_METHOD("update_dirty_quadrants"), &TileMap::update_dirty_quadrants);
 
 	ClassDB::bind_method(D_METHOD("update_bitmask_area", "position"), &TileMap::update_bitmask_area);

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -69,12 +69,12 @@ Ref<BitMap> TouchScreenButton::get_bitmask() const {
 void TouchScreenButton::set_shape(const Ref<Shape2D> &p_shape) {
 
 	if (shape.is_valid())
-		shape->disconnect_compat("changed", this, "update");
+		shape->disconnect("changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
 
 	shape = p_shape;
 
 	if (shape.is_valid())
-		shape->connect_compat("changed", this, "update");
+		shape->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
 
 	update();
 }

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -224,7 +224,7 @@ void VisibilityEnabler2D::_find_nodes(Node *p_node) {
 
 	if (add) {
 
-		p_node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, "_node_removed", varray(p_node), CONNECT_ONESHOT);
+		p_node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &VisibilityEnabler2D::_node_removed), varray(p_node), CONNECT_ONESHOT);
 		nodes[p_node] = meta;
 		_change_node_state(p_node, false);
 	}
@@ -267,7 +267,7 @@ void VisibilityEnabler2D::_notification(int p_what) {
 
 			if (!visible)
 				_change_node_state(E->key(), true);
-			E->key()->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, "_node_removed");
+			E->key()->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &VisibilityEnabler2D::_node_removed));
 		}
 
 		nodes.clear();

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "area.h"
+
 #include "scene/scene_string_names.h"
 #include "servers/audio_server.h"
 #include "servers/physics_server.h"
@@ -170,8 +171,8 @@ void Area::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, int
 			E->get().rc = 0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area::_body_enter_tree), make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area::_body_exit_tree), make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
 				}
@@ -197,8 +198,8 @@ void Area::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, int
 		if (E->get().rc == 0) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area::_body_enter_tree));
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area::_body_exit_tree));
 				if (E->get().in_tree)
 					emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
 			}
@@ -244,8 +245,8 @@ void Area::_clear_monitoring() {
 
 			emit_signal(SceneStringNames::get_singleton()->body_exited, node);
 
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area::_body_enter_tree));
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area::_body_exit_tree));
 		}
 	}
 
@@ -274,8 +275,8 @@ void Area::_clear_monitoring() {
 
 			emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
 
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area::_area_enter_tree));
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area::_area_exit_tree));
 		}
 	}
 }
@@ -363,8 +364,8 @@ void Area::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, int
 			E->get().rc = 0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area::_area_enter_tree), make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area::_area_exit_tree), make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->area_entered, node);
 				}
@@ -390,8 +391,8 @@ void Area::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, int
 		if (E->get().rc == 0) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area::_area_enter_tree));
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area::_area_exit_tree));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
 				}
@@ -618,13 +619,6 @@ void Area::_validate_property(PropertyInfo &property) const {
 }
 
 void Area::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_body_enter_tree", "id"), &Area::_body_enter_tree);
-	ClassDB::bind_method(D_METHOD("_body_exit_tree", "id"), &Area::_body_exit_tree);
-
-	ClassDB::bind_method(D_METHOD("_area_enter_tree", "id"), &Area::_area_enter_tree);
-	ClassDB::bind_method(D_METHOD("_area_exit_tree", "id"), &Area::_area_exit_tree);
-
 	ClassDB::bind_method(D_METHOD("set_space_override_mode", "enable"), &Area::set_space_override_mode);
 	ClassDB::bind_method(D_METHOD("get_space_override_mode"), &Area::get_space_override_mode);
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -1008,8 +1008,6 @@ void AudioStreamPlayer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_stream_playback"), &AudioStreamPlayer3D::get_stream_playback);
 
-	ClassDB::bind_method(D_METHOD("_bus_layout_changed"), &AudioStreamPlayer3D::_bus_layout_changed);
-
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "attenuation_model", PROPERTY_HINT_ENUM, "Inverse,InverseSquare,Log,Disabled"), "set_attenuation_model", "get_attenuation_model");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "unit_db", PROPERTY_HINT_RANGE, "-80,80"), "set_unit_db", "get_unit_db");
@@ -1076,7 +1074,7 @@ AudioStreamPlayer3D::AudioStreamPlayer3D() {
 	stream_paused_fade_out = false;
 
 	velocity_tracker.instance();
-	AudioServer::get_singleton()->connect_compat("bus_layout_changed", this, "_bus_layout_changed");
+	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer3D::_bus_layout_changed));
 	set_disable_scale(true);
 }
 AudioStreamPlayer3D::~AudioStreamPlayer3D() {

--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -141,7 +141,6 @@ void CollisionShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("make_convex_from_brothers"), &CollisionShape::make_convex_from_brothers);
 	ClassDB::set_method_flags("CollisionShape", "make_convex_from_brothers", METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
-	ClassDB::bind_method(D_METHOD("_shape_changed"), &CollisionShape::_shape_changed);
 	ClassDB::bind_method(D_METHOD("_update_debug_shape"), &CollisionShape::_update_debug_shape);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape"), "set_shape", "get_shape");
@@ -152,12 +151,12 @@ void CollisionShape::set_shape(const Ref<Shape> &p_shape) {
 
 	if (!shape.is_null()) {
 		shape->unregister_owner(this);
-		shape->disconnect_compat("changed", this, "_shape_changed");
+		shape->disconnect("changed", callable_mp(this, &CollisionShape::_shape_changed));
 	}
 	shape = p_shape;
 	if (!shape.is_null()) {
 		shape->register_owner(this);
-		shape->connect_compat("changed", this, "_shape_changed");
+		shape->connect("changed", callable_mp(this, &CollisionShape::_shape_changed));
 	}
 	update_gizmo();
 	if (parent) {

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -1123,12 +1123,12 @@ void CPUParticles::_set_redraw(bool p_redraw) {
 	update_mutex->lock();
 #endif
 	if (redraw) {
-		VS::get_singleton()->connect_compat("frame_pre_draw", this, "_update_render_thread");
+		VS::get_singleton()->connect("frame_pre_draw", callable_mp(this, &CPUParticles::_update_render_thread));
 		VS::get_singleton()->instance_geometry_set_flag(get_instance(), VS::INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE, true);
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, -1);
 	} else {
-		if (VS::get_singleton()->is_connected_compat("frame_pre_draw", this, "_update_render_thread")) {
-			VS::get_singleton()->disconnect_compat("frame_pre_draw", this, "_update_render_thread");
+		if (VS::get_singleton()->is_connected("frame_pre_draw", callable_mp(this, &CPUParticles::_update_render_thread))) {
+			VS::get_singleton()->disconnect("frame_pre_draw", callable_mp(this, &CPUParticles::_update_render_thread));
 		}
 		VS::get_singleton()->instance_geometry_set_flag(get_instance(), VS::INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE, false);
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, 0);
@@ -1396,8 +1396,6 @@ void CPUParticles::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_gravity", "accel_vec"), &CPUParticles::set_gravity);
 
 	ClassDB::bind_method(D_METHOD("convert_from_particles", "particles"), &CPUParticles::convert_from_particles);
-
-	ClassDB::bind_method(D_METHOD("_update_render_thread"), &CPUParticles::_update_render_thread);
 
 	ADD_GROUP("Emission Shape", "emission_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_shape", PROPERTY_HINT_ENUM, "Point,Sphere,Box,Points,Directed Points"), "set_emission_shape", "get_emission_shape");

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -34,7 +34,6 @@
 #include "core/core_string_names.h"
 #include "physics_body.h"
 #include "scene/resources/material.h"
-#include "scene/scene_string_names.h"
 #include "skeleton.h"
 
 bool MeshInstance::_set(const StringName &p_name, const Variant &p_value) {
@@ -112,7 +111,7 @@ void MeshInstance::set_mesh(const Ref<Mesh> &p_mesh) {
 		return;
 
 	if (mesh.is_valid()) {
-		mesh->disconnect_compat(CoreStringNames::get_singleton()->changed, this, SceneStringNames::get_singleton()->_mesh_changed);
+		mesh->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance::_mesh_changed));
 		materials.clear();
 	}
 
@@ -129,7 +128,7 @@ void MeshInstance::set_mesh(const Ref<Mesh> &p_mesh) {
 			blend_shape_tracks["blend_shapes/" + String(mesh->get_blend_shape_name(i))] = mt;
 		}
 
-		mesh->connect_compat(CoreStringNames::get_singleton()->changed, this, SceneStringNames::get_singleton()->_mesh_changed);
+		mesh->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance::_mesh_changed));
 		materials.resize(mesh->get_surface_count());
 
 		set_base(mesh->get_rid());
@@ -403,7 +402,6 @@ void MeshInstance::_bind_methods() {
 	ClassDB::set_method_flags("MeshInstance", "create_trimesh_collision", METHOD_FLAGS_DEFAULT);
 	ClassDB::bind_method(D_METHOD("create_convex_collision"), &MeshInstance::create_convex_collision);
 	ClassDB::set_method_flags("MeshInstance", "create_convex_collision", METHOD_FLAGS_DEFAULT);
-	ClassDB::bind_method(D_METHOD("_mesh_changed"), &MeshInstance::_mesh_changed);
 
 	ClassDB::bind_method(D_METHOD("create_debug_tangents"), &MeshInstance::create_debug_tangents);
 	ClassDB::set_method_flags("MeshInstance", "create_debug_tangents", METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -59,13 +59,13 @@ void Path::_curve_changed() {
 void Path::set_curve(const Ref<Curve3D> &p_curve) {
 
 	if (curve.is_valid()) {
-		curve->disconnect_compat("changed", this, "_curve_changed");
+		curve->disconnect("changed", callable_mp(this, &Path::_curve_changed));
 	}
 
 	curve = p_curve;
 
 	if (curve.is_valid()) {
-		curve->connect_compat("changed", this, "_curve_changed");
+		curve->connect("changed", callable_mp(this, &Path::_curve_changed));
 	}
 	_curve_changed();
 }
@@ -79,7 +79,6 @@ void Path::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_curve", "curve"), &Path::set_curve);
 	ClassDB::bind_method(D_METHOD("get_curve"), &Path::get_curve);
-	ClassDB::bind_method(D_METHOD("_curve_changed"), &Path::_curve_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve3D"), "set_curve", "get_curve");
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -180,14 +180,15 @@ PhysicsBody::PhysicsBody(PhysicsServer::BodyMode p_mode) :
 
 void StaticBody::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics"))
-			physics_material_override->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody::_reload_physics_characteristics))) {
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody::_reload_physics_characteristics));
+		}
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody::_reload_physics_characteristics));
 	}
 	_reload_physics_characteristics();
 }
@@ -226,8 +227,6 @@ void StaticBody::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_physics_material_override", "physics_material_override"), &StaticBody::set_physics_material_override);
 	ClassDB::bind_method(D_METHOD("get_physics_material_override"), &StaticBody::get_physics_material_override);
-
-	ClassDB::bind_method(D_METHOD("_reload_physics_characteristics"), &StaticBody::_reload_physics_characteristics);
 
 	ClassDB::bind_method(D_METHOD("get_collision_exceptions"), &PhysicsBody::get_collision_exceptions);
 	ClassDB::bind_method(D_METHOD("add_collision_exception_with", "body"), &PhysicsBody::add_collision_exception_with);
@@ -322,8 +321,8 @@ void RigidBody::_body_inout(int p_status, ObjectID p_instance, int p_body_shape,
 			//E->get().rc=0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &RigidBody::_body_enter_tree), make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &RigidBody::_body_exit_tree), make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
 				}
@@ -349,8 +348,8 @@ void RigidBody::_body_inout(int p_status, ObjectID p_instance, int p_body_shape,
 		if (E->get().shapes.empty()) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &RigidBody::_body_enter_tree));
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &RigidBody::_body_exit_tree));
 				if (in_tree)
 					emit_signal(SceneStringNames::get_singleton()->body_exited, node);
 			}
@@ -550,14 +549,15 @@ real_t RigidBody::get_weight() const {
 
 void RigidBody::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics"))
-			physics_material_override->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody::_reload_physics_characteristics))) {
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody::_reload_physics_characteristics));
+		}
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody::_reload_physics_characteristics));
 	}
 	_reload_physics_characteristics();
 }
@@ -737,9 +737,8 @@ void RigidBody::set_contact_monitor(bool p_enabled) {
 			Node *node = Object::cast_to<Node>(obj);
 
 			if (node) {
-
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &RigidBody::_body_enter_tree));
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &RigidBody::_body_exit_tree));
 			}
 		}
 
@@ -814,8 +813,6 @@ void RigidBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_material_override", "physics_material_override"), &RigidBody::set_physics_material_override);
 	ClassDB::bind_method(D_METHOD("get_physics_material_override"), &RigidBody::get_physics_material_override);
 
-	ClassDB::bind_method(D_METHOD("_reload_physics_characteristics"), &RigidBody::_reload_physics_characteristics);
-
 	ClassDB::bind_method(D_METHOD("set_linear_velocity", "linear_velocity"), &RigidBody::set_linear_velocity);
 	ClassDB::bind_method(D_METHOD("get_linear_velocity"), &RigidBody::get_linear_velocity);
 
@@ -860,8 +857,6 @@ void RigidBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_able_to_sleep"), &RigidBody::is_able_to_sleep);
 
 	ClassDB::bind_method(D_METHOD("_direct_state_changed"), &RigidBody::_direct_state_changed);
-	ClassDB::bind_method(D_METHOD("_body_enter_tree"), &RigidBody::_body_enter_tree);
-	ClassDB::bind_method(D_METHOD("_body_exit_tree"), &RigidBody::_body_exit_tree);
 
 	ClassDB::bind_method(D_METHOD("set_axis_lock", "axis", "lock"), &RigidBody::set_axis_lock);
 	ClassDB::bind_method(D_METHOD("get_axis_lock", "axis"), &RigidBody::get_axis_lock);

--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -30,9 +30,8 @@
 
 #include "skeleton.h"
 
-#include "core/message_queue.h"
-
 #include "core/engine.h"
+#include "core/message_queue.h"
 #include "core/project_settings.h"
 #include "scene/3d/physics_body.h"
 #include "scene/resources/surface_tool.h"

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -319,8 +319,6 @@ void SoftBody::_notification(int p_what) {
 
 void SoftBody::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_draw_soft_mesh"), &SoftBody::_draw_soft_mesh);
-
 	ClassDB::bind_method(D_METHOD("set_collision_mask", "collision_mask"), &SoftBody::set_collision_mask);
 	ClassDB::bind_method(D_METHOD("get_collision_mask"), &SoftBody::get_collision_mask);
 
@@ -464,12 +462,12 @@ void SoftBody::prepare_physics_server() {
 
 		become_mesh_owner();
 		PhysicsServer::get_singleton()->soft_body_set_mesh(physics_rid, get_mesh());
-		VS::get_singleton()->connect_compat("frame_pre_draw", this, "_draw_soft_mesh");
+		VS::get_singleton()->connect("frame_pre_draw", callable_mp(this, &SoftBody::_draw_soft_mesh));
 	} else {
 
 		PhysicsServer::get_singleton()->soft_body_set_mesh(physics_rid, NULL);
-		if (VS::get_singleton()->is_connected_compat("frame_pre_draw", this, "_draw_soft_mesh")) {
-			VS::get_singleton()->disconnect_compat("frame_pre_draw", this, "_draw_soft_mesh");
+		if (VS::get_singleton()->is_connected("frame_pre_draw", callable_mp(this, &SoftBody::_draw_soft_mesh))) {
+			VS::get_singleton()->disconnect("frame_pre_draw", callable_mp(this, &SoftBody::_draw_soft_mesh));
 		}
 	}
 }

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "sprite_3d.h"
+
 #include "core/core_string_names.h"
 #include "scene/scene_string_names.h"
 
@@ -177,8 +178,6 @@ void SpriteBase3D::_im_update() {
 	_draw();
 
 	pending_update = false;
-
-	//texture->draw_rect_region(ci,dst_rect,src_rect,modulate);
 }
 
 void SpriteBase3D::_queue_update() {

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -952,10 +952,10 @@ void AnimatedSprite3D::_notification(int p_what) {
 void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 	if (frames.is_valid())
-		frames->disconnect_compat("changed", this, "_res_changed");
+		frames->disconnect("changed", callable_mp(this, &AnimatedSprite3D::_res_changed));
 	frames = p_frames;
 	if (frames.is_valid())
-		frames->connect_compat("changed", this, "_res_changed");
+		frames->connect("changed", callable_mp(this, &AnimatedSprite3D::_res_changed));
 
 	if (!frames.is_valid()) {
 		frame = 0;
@@ -1124,8 +1124,6 @@ void AnimatedSprite3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_frame", "frame"), &AnimatedSprite3D::set_frame);
 	ClassDB::bind_method(D_METHOD("get_frame"), &AnimatedSprite3D::get_frame);
-
-	ClassDB::bind_method(D_METHOD("_res_changed"), &AnimatedSprite3D::_res_changed);
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 

--- a/scene/3d/visibility_notifier.cpp
+++ b/scene/3d/visibility_notifier.cpp
@@ -170,7 +170,7 @@ void VisibilityEnabler::_find_nodes(Node *p_node) {
 
 	if (add) {
 
-		p_node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, "_node_removed", varray(p_node), CONNECT_ONESHOT);
+		p_node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &VisibilityEnabler::_node_removed), varray(p_node), CONNECT_ONESHOT);
 		nodes[p_node] = meta;
 		_change_node_state(p_node, false);
 	}
@@ -208,7 +208,7 @@ void VisibilityEnabler::_notification(int p_what) {
 
 			if (!visible)
 				_change_node_state(E->key(), true);
-			E->key()->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, "_node_removed");
+			E->key()->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &VisibilityEnabler::_node_removed));
 		}
 
 		nodes.clear();
@@ -247,7 +247,6 @@ void VisibilityEnabler::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_enabler", "enabler", "enabled"), &VisibilityEnabler::set_enabler);
 	ClassDB::bind_method(D_METHOD("is_enabler_enabled", "enabler"), &VisibilityEnabler::is_enabler_enabled);
-	ClassDB::bind_method(D_METHOD("_node_removed"), &VisibilityEnabler::_node_removed);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "pause_animations"), "set_enabler", "is_enabler_enabled", ENABLER_PAUSE_ANIMATIONS);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "freeze_bodies"), "set_enabler", "is_enabler_enabled", ENABLER_FREEZE_BODIES);

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -79,8 +79,6 @@ void AnimationNodeBlendSpace1D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_add_blend_point", "index", "node"), &AnimationNodeBlendSpace1D::_add_blend_point);
 
-	ClassDB::bind_method(D_METHOD("_tree_changed"), &AnimationNodeBlendSpace1D::_tree_changed);
-
 	for (int i = 0; i < MAX_BLEND_POINTS; i++) {
 		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "blend_point_" + itos(i) + "/node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationRootNode", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_add_blend_point", "get_blend_point_node", i);
 		ADD_PROPERTYI(PropertyInfo(Variant::REAL, "blend_point_" + itos(i) + "/pos", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_blend_point_position", "get_blend_point_position", i);
@@ -118,7 +116,7 @@ void AnimationNodeBlendSpace1D::add_blend_point(const Ref<AnimationRootNode> &p_
 	blend_points[p_at_index].node = p_node;
 	blend_points[p_at_index].position = p_position;
 
-	blend_points[p_at_index].node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	blend_points[p_at_index].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 
 	blend_points_used++;
 	emit_signal("tree_changed");
@@ -135,11 +133,11 @@ void AnimationNodeBlendSpace1D::set_blend_point_node(int p_point, const Ref<Anim
 	ERR_FAIL_COND(p_node.is_null());
 
 	if (blend_points[p_point].node.is_valid()) {
-		blend_points[p_point].node->disconnect_compat("tree_changed", this, "_tree_changed");
+		blend_points[p_point].node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed));
 	}
 
 	blend_points[p_point].node = p_node;
-	blend_points[p_point].node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	blend_points[p_point].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 
 	emit_signal("tree_changed");
 }
@@ -158,7 +156,7 @@ void AnimationNodeBlendSpace1D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
 	ERR_FAIL_COND(blend_points[p_point].node.is_null());
-	blend_points[p_point].node->disconnect_compat("tree_changed", this, "_tree_changed");
+	blend_points[p_point].node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed));
 
 	for (int i = p_point; i < blend_points_used - 1; i++) {
 		blend_points[i] = blend_points[i + 1];

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -77,7 +77,7 @@ void AnimationNodeBlendSpace2D::add_blend_point(const Ref<AnimationRootNode> &p_
 	blend_points[p_at_index].node = p_node;
 	blend_points[p_at_index].position = p_position;
 
-	blend_points[p_at_index].node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	blend_points[p_at_index].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace2D::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	blend_points_used++;
 
 	_queue_auto_triangles();
@@ -95,10 +95,10 @@ void AnimationNodeBlendSpace2D::set_blend_point_node(int p_point, const Ref<Anim
 	ERR_FAIL_COND(p_node.is_null());
 
 	if (blend_points[p_point].node.is_valid()) {
-		blend_points[p_point].node->disconnect_compat("tree_changed", this, "_tree_changed");
+		blend_points[p_point].node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace2D::_tree_changed));
 	}
 	blend_points[p_point].node = p_node;
-	blend_points[p_point].node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	blend_points[p_point].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace2D::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 
 	emit_signal("tree_changed");
 }
@@ -114,7 +114,7 @@ void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
 	ERR_FAIL_COND(blend_points[p_point].node.is_null());
-	blend_points[p_point].node->disconnect_compat("tree_changed", this, "_tree_changed");
+	blend_points[p_point].node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace2D::_tree_changed));
 
 	for (int i = 0; i < triangles.size(); i++) {
 		bool erase = false;
@@ -640,7 +640,6 @@ void AnimationNodeBlendSpace2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_blend_mode", "mode"), &AnimationNodeBlendSpace2D::set_blend_mode);
 	ClassDB::bind_method(D_METHOD("get_blend_mode"), &AnimationNodeBlendSpace2D::get_blend_mode);
 
-	ClassDB::bind_method(D_METHOD("_tree_changed"), &AnimationNodeBlendSpace2D::_tree_changed);
 	ClassDB::bind_method(D_METHOD("_update_triangles"), &AnimationNodeBlendSpace2D::_update_triangles);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_triangles", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_auto_triangles", "get_auto_triangles");

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -884,8 +884,8 @@ void AnimationNodeBlendTree::add_node(const StringName &p_name, Ref<AnimationNod
 	emit_changed();
 	emit_signal("tree_changed");
 
-	p_node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
-	p_node->connect_compat("changed", this, "_node_changed", varray(p_name), CONNECT_REFERENCE_COUNTED);
+	p_node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendTree::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
+	p_node->connect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed), varray(p_name), CONNECT_REFERENCE_COUNTED);
 }
 
 Ref<AnimationNode> AnimationNodeBlendTree::get_node(const StringName &p_name) const {
@@ -947,8 +947,8 @@ void AnimationNodeBlendTree::remove_node(const StringName &p_name) {
 
 	{
 		Ref<AnimationNode> node = nodes[p_name].node;
-		node->disconnect_compat("tree_changed", this, "_tree_changed");
-		node->disconnect_compat("changed", this, "_node_changed");
+		node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendTree::_tree_changed));
+		node->disconnect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed));
 	}
 
 	nodes.erase(p_name);
@@ -973,7 +973,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 	ERR_FAIL_COND(p_name == SceneStringNames::get_singleton()->output);
 	ERR_FAIL_COND(p_new_name == SceneStringNames::get_singleton()->output);
 
-	nodes[p_name].node->disconnect_compat("changed", this, "_node_changed");
+	nodes[p_name].node->disconnect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed));
 
 	nodes[p_new_name] = nodes[p_name];
 	nodes.erase(p_name);
@@ -988,7 +988,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 		}
 	}
 	//connection must be done with new name
-	nodes[p_new_name].node->connect_compat("changed", this, "_node_changed", varray(p_new_name), CONNECT_REFERENCE_COUNTED);
+	nodes[p_new_name].node->connect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed), varray(p_new_name), CONNECT_REFERENCE_COUNTED);
 
 	emit_signal("tree_changed");
 }
@@ -1229,9 +1229,6 @@ void AnimationNodeBlendTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_graph_offset", "offset"), &AnimationNodeBlendTree::set_graph_offset);
 	ClassDB::bind_method(D_METHOD("get_graph_offset"), &AnimationNodeBlendTree::get_graph_offset);
-
-	ClassDB::bind_method(D_METHOD("_tree_changed"), &AnimationNodeBlendTree::_tree_changed);
-	ClassDB::bind_method(D_METHOD("_node_changed", "node"), &AnimationNodeBlendTree::_node_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "graph_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_graph_offset", "get_graph_offset");
 

--- a/scene/animation/animation_cache.cpp
+++ b/scene/animation/animation_cache.cpp
@@ -56,7 +56,7 @@ void AnimationCache::_clear_cache() {
 
 	while (connected_nodes.size()) {
 
-		connected_nodes.front()->get()->disconnect_compat("tree_exiting", this, "_node_exit_tree");
+		connected_nodes.front()->get()->disconnect("tree_exiting", callable_mp(this, &AnimationCache::_node_exit_tree));
 		connected_nodes.erase(connected_nodes.front());
 	}
 	path_cache.clear();
@@ -174,7 +174,7 @@ void AnimationCache::_update_cache() {
 
 		if (!connected_nodes.has(path.node)) {
 			connected_nodes.insert(path.node);
-			path.node->connect_compat("tree_exiting", this, "_node_exit_tree", Node::make_binds(path.node), CONNECT_ONESHOT);
+			path.node->connect("tree_exiting", callable_mp(this, &AnimationCache::_node_exit_tree), Node::make_binds(path.node), CONNECT_ONESHOT);
 		}
 	}
 
@@ -313,18 +313,15 @@ void AnimationCache::set_animation(const Ref<Animation> &p_animation) {
 	_clear_cache();
 
 	if (animation.is_valid())
-		animation->disconnect_compat("changed", this, "_animation_changed");
+		animation->disconnect("changed", callable_mp(this, &AnimationCache::_animation_changed));
 
 	animation = p_animation;
 
 	if (animation.is_valid())
-		animation->connect_compat("changed", this, "_animation_changed");
+		animation->connect("changed", callable_mp(this, &AnimationCache::_animation_changed));
 }
 
 void AnimationCache::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_node_exit_tree"), &AnimationCache::_node_exit_tree);
-	ClassDB::bind_method(D_METHOD("_animation_changed"), &AnimationCache::_animation_changed);
 }
 
 void AnimationCache::set_root(Node *p_root) {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -562,7 +562,7 @@ void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<Animation
 	emit_changed();
 	emit_signal("tree_changed");
 
-	p_node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	p_node->connect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 }
 
 Ref<AnimationNode> AnimationNodeStateMachine::get_node(const StringName &p_name) const {
@@ -611,7 +611,7 @@ void AnimationNodeStateMachine::remove_node(const StringName &p_name) {
 
 		ERR_FAIL_COND(node.is_null());
 
-		node->disconnect_compat("tree_changed", this, "_tree_changed");
+		node->disconnect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed));
 	}
 
 	states.erase(p_name);
@@ -619,7 +619,7 @@ void AnimationNodeStateMachine::remove_node(const StringName &p_name) {
 
 	for (int i = 0; i < transitions.size(); i++) {
 		if (transitions[i].from == p_name || transitions[i].to == p_name) {
-			transitions.write[i].transition->disconnect_compat("advance_condition_changed", this, "_tree_changed");
+			transitions.write[i].transition->disconnect("advance_condition_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed));
 			transitions.remove(i);
 			i--;
 		}
@@ -722,7 +722,7 @@ void AnimationNodeStateMachine::add_transition(const StringName &p_from, const S
 	tr.to = p_to;
 	tr.transition = p_transition;
 
-	tr.transition->connect_compat("advance_condition_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	tr.transition->connect("advance_condition_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 
 	transitions.push_back(tr);
 }
@@ -750,7 +750,7 @@ void AnimationNodeStateMachine::remove_transition(const StringName &p_from, cons
 
 	for (int i = 0; i < transitions.size(); i++) {
 		if (transitions[i].from == p_from && transitions[i].to == p_to) {
-			transitions.write[i].transition->disconnect_compat("advance_condition_changed", this, "_tree_changed");
+			transitions.write[i].transition->disconnect("advance_condition_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed));
 			transitions.remove(i);
 			return;
 		}
@@ -764,7 +764,7 @@ void AnimationNodeStateMachine::remove_transition(const StringName &p_from, cons
 void AnimationNodeStateMachine::remove_transition_by_index(int p_transition) {
 
 	ERR_FAIL_INDEX(p_transition, transitions.size());
-	transitions.write[p_transition].transition->disconnect_compat("advance_condition_changed", this, "_tree_changed");
+	transitions.write[p_transition].transition->disconnect("advance_condition_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed));
 	transitions.remove(p_transition);
 	/*if (playing) {
 		path.clear();
@@ -975,8 +975,6 @@ void AnimationNodeStateMachine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_graph_offset", "offset"), &AnimationNodeStateMachine::set_graph_offset);
 	ClassDB::bind_method(D_METHOD("get_graph_offset"), &AnimationNodeStateMachine::get_graph_offset);
-
-	ClassDB::bind_method(D_METHOD("_tree_changed"), &AnimationNodeStateMachine::_tree_changed);
 }
 
 AnimationNodeStateMachine::AnimationNodeStateMachine() {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -263,8 +263,8 @@ void AnimationPlayer::_ensure_node_caches(AnimationData *p_anim) {
 		}
 
 		{
-			if (!child->is_connected_compat("tree_exiting", this, "_node_removed"))
-				child->connect_compat("tree_exiting", this, "_node_removed", make_binds(child), CONNECT_ONESHOT);
+			if (!child->is_connected("tree_exiting", callable_mp(this, &AnimationPlayer::_node_removed)))
+				child->connect("tree_exiting", callable_mp(this, &AnimationPlayer::_node_removed), make_binds(child), CONNECT_ONESHOT);
 		}
 
 		TrackNodeCacheKey key;
@@ -1620,7 +1620,6 @@ void AnimationPlayer::restore_animated_values(const AnimatedValuesBackup &p_back
 
 void AnimationPlayer::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_node_removed"), &AnimationPlayer::_node_removed);
 	ClassDB::bind_method(D_METHOD("_animation_changed"), &AnimationPlayer::_animation_changed);
 
 	ClassDB::bind_method(D_METHOD("add_animation", "name", "animation"), &AnimationPlayer::add_animation);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1007,12 +1007,12 @@ void AnimationPlayer::remove_animation(const StringName &p_name) {
 
 void AnimationPlayer::_ref_anim(const Ref<Animation> &p_anim) {
 
-	Ref<Animation>(p_anim)->connect_compat(SceneStringNames::get_singleton()->tracks_changed, this, "_animation_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	Ref<Animation>(p_anim)->connect(SceneStringNames::get_singleton()->tracks_changed, callable_mp(this, &AnimationPlayer::_animation_changed), varray(), CONNECT_REFERENCE_COUNTED);
 }
 
 void AnimationPlayer::_unref_anim(const Ref<Animation> &p_anim) {
 
-	Ref<Animation>(p_anim)->disconnect_compat(SceneStringNames::get_singleton()->tracks_changed, this, "_animation_changed");
+	Ref<Animation>(p_anim)->disconnect(SceneStringNames::get_singleton()->tracks_changed, callable_mp(this, &AnimationPlayer::_animation_changed));
 }
 
 void AnimationPlayer::rename_animation(const StringName &p_name, const StringName &p_new_name) {
@@ -1619,9 +1619,6 @@ void AnimationPlayer::restore_animated_values(const AnimatedValuesBackup &p_back
 #endif
 
 void AnimationPlayer::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("_animation_changed"), &AnimationPlayer::_animation_changed);
-
 	ClassDB::bind_method(D_METHOD("add_animation", "name", "animation"), &AnimationPlayer::add_animation);
 	ClassDB::bind_method(D_METHOD("remove_animation", "name"), &AnimationPlayer::remove_animation);
 	ClassDB::bind_method(D_METHOD("rename_animation", "name", "newname"), &AnimationPlayer::rename_animation);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -463,13 +463,13 @@ AnimationNode::AnimationNode() {
 void AnimationTree::set_tree_root(const Ref<AnimationNode> &p_root) {
 
 	if (root.is_valid()) {
-		root->disconnect_compat("tree_changed", this, "_tree_changed");
+		root->disconnect("tree_changed", callable_mp(this, &AnimationTree::_tree_changed));
 	}
 
 	root = p_root;
 
 	if (root.is_valid()) {
-		root->connect_compat("tree_changed", this, "_tree_changed");
+		root->connect("tree_changed", callable_mp(this, &AnimationTree::_tree_changed));
 	}
 
 	properties_dirty = true;
@@ -582,8 +582,8 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 					continue;
 				}
 
-				if (!child->is_connected_compat("tree_exited", this, "_node_removed")) {
-					child->connect_compat("tree_exited", this, "_node_removed", varray(child));
+				if (!child->is_connected("tree_exited", callable_mp(this, &AnimationTree::_node_removed))) {
+					child->connect("tree_exited", callable_mp(this, &AnimationTree::_node_removed), varray(child));
 				}
 
 				switch (track_type) {
@@ -778,12 +778,12 @@ void AnimationTree::_process_graph(float p_delta) {
 		if (last_animation_player.is_valid()) {
 			Object *old_player = ObjectDB::get_instance(last_animation_player);
 			if (old_player) {
-				old_player->disconnect_compat("caches_cleared", this, "_clear_caches");
+				old_player->disconnect("caches_cleared", callable_mp(this, &AnimationTree::_clear_caches));
 			}
 		}
 
 		if (player) {
-			player->connect_compat("caches_cleared", this, "_clear_caches");
+			player->connect("caches_cleared", callable_mp(this, &AnimationTree::_clear_caches));
 		}
 
 		last_animation_player = current_animation_player;
@@ -1300,7 +1300,7 @@ void AnimationTree::_notification(int p_what) {
 
 			Object *player = ObjectDB::get_instance(last_animation_player);
 			if (player) {
-				player->disconnect_compat("caches_cleared", this, "_clear_caches");
+				player->disconnect("caches_cleared", callable_mp(this, &AnimationTree::_clear_caches));
 			}
 		}
 	} else if (p_what == NOTIFICATION_ENTER_TREE) {
@@ -1308,7 +1308,7 @@ void AnimationTree::_notification(int p_what) {
 
 			Object *player = ObjectDB::get_instance(last_animation_player);
 			if (player) {
-				player->connect_compat("caches_cleared", this, "_clear_caches");
+				player->connect("caches_cleared", callable_mp(this, &AnimationTree::_clear_caches));
 			}
 		}
 	}
@@ -1553,15 +1553,11 @@ void AnimationTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_root_motion_transform"), &AnimationTree::get_root_motion_transform);
 
-	ClassDB::bind_method(D_METHOD("_tree_changed"), &AnimationTree::_tree_changed);
 	ClassDB::bind_method(D_METHOD("_update_properties"), &AnimationTree::_update_properties);
 
 	ClassDB::bind_method(D_METHOD("rename_parameter", "old_name", "new_name"), &AnimationTree::rename_parameter);
 
 	ClassDB::bind_method(D_METHOD("advance", "delta"), &AnimationTree::advance);
-
-	ClassDB::bind_method(D_METHOD("_node_removed"), &AnimationTree::_node_removed);
-	ClassDB::bind_method(D_METHOD("_clear_caches"), &AnimationTree::_clear_caches);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "tree_root", PROPERTY_HINT_RESOURCE_TYPE, "AnimationRootNode"), "set_tree_root", "get_tree_root");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "anim_player", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "AnimationPlayer"), "set_animation_player", "get_animation_player");

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -403,8 +403,6 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_playing", "enable"), &AudioStreamPlayer::_set_playing);
 	ClassDB::bind_method(D_METHOD("_is_active"), &AudioStreamPlayer::_is_active);
 
-	ClassDB::bind_method(D_METHOD("_bus_layout_changed"), &AudioStreamPlayer::_bus_layout_changed);
-
 	ClassDB::bind_method(D_METHOD("set_stream_paused", "pause"), &AudioStreamPlayer::set_stream_paused);
 	ClassDB::bind_method(D_METHOD("get_stream_paused"), &AudioStreamPlayer::get_stream_paused);
 
@@ -441,7 +439,7 @@ AudioStreamPlayer::AudioStreamPlayer() {
 	setstop = false;
 	use_fadeout = false;
 
-	AudioServer::get_singleton()->connect_compat("bus_layout_changed", this, "_bus_layout_changed");
+	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer::_bus_layout_changed));
 }
 
 AudioStreamPlayer::~AudioStreamPlayer() {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -615,7 +615,7 @@ void ColorPicker::_screen_pick_pressed() {
 		screen->set_as_toplevel(true);
 		screen->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 		screen->set_default_cursor_shape(CURSOR_POINTING_HAND);
-		screen->connect_compat("gui_input", this, "_screen_input");
+		screen->connect("gui_input", callable_mp(this, &ColorPicker::_screen_input));
 		// It immediately toggles off in the first press otherwise.
 		screen->call_deferred("connect", "hide", Callable(btn_pick, "set_pressed"), varray(false));
 	}
@@ -678,9 +678,7 @@ void ColorPicker::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_pick_color", "color"), &ColorPicker::set_pick_color);
 	ClassDB::bind_method(D_METHOD("get_pick_color"), &ColorPicker::get_pick_color);
-	ClassDB::bind_method(D_METHOD("set_hsv_mode", "mode"), &ColorPicker::set_hsv_mode);
 	ClassDB::bind_method(D_METHOD("is_hsv_mode"), &ColorPicker::is_hsv_mode);
-	ClassDB::bind_method(D_METHOD("set_raw_mode", "mode"), &ColorPicker::set_raw_mode);
 	ClassDB::bind_method(D_METHOD("is_raw_mode"), &ColorPicker::is_raw_mode);
 	ClassDB::bind_method(D_METHOD("set_deferred_mode", "mode"), &ColorPicker::set_deferred_mode);
 	ClassDB::bind_method(D_METHOD("is_deferred_mode"), &ColorPicker::is_deferred_mode);
@@ -693,21 +691,6 @@ void ColorPicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_preset", "color"), &ColorPicker::add_preset);
 	ClassDB::bind_method(D_METHOD("erase_preset", "color"), &ColorPicker::erase_preset);
 	ClassDB::bind_method(D_METHOD("get_presets"), &ColorPicker::get_presets);
-	ClassDB::bind_method(D_METHOD("_value_changed"), &ColorPicker::_value_changed);
-	ClassDB::bind_method(D_METHOD("_html_entered"), &ColorPicker::_html_entered);
-	ClassDB::bind_method(D_METHOD("_text_type_toggled"), &ColorPicker::_text_type_toggled);
-	ClassDB::bind_method(D_METHOD("_add_preset_pressed"), &ColorPicker::_add_preset_pressed);
-	ClassDB::bind_method(D_METHOD("_screen_pick_pressed"), &ColorPicker::_screen_pick_pressed);
-	ClassDB::bind_method(D_METHOD("_sample_draw"), &ColorPicker::_sample_draw);
-	ClassDB::bind_method(D_METHOD("_update_presets"), &ColorPicker::_update_presets);
-	ClassDB::bind_method(D_METHOD("_hsv_draw"), &ColorPicker::_hsv_draw);
-	ClassDB::bind_method(D_METHOD("_uv_input"), &ColorPicker::_uv_input);
-	ClassDB::bind_method(D_METHOD("_w_input"), &ColorPicker::_w_input);
-	ClassDB::bind_method(D_METHOD("_preset_input"), &ColorPicker::_preset_input);
-	ClassDB::bind_method(D_METHOD("_screen_input"), &ColorPicker::_screen_input);
-	ClassDB::bind_method(D_METHOD("_focus_enter"), &ColorPicker::_focus_enter);
-	ClassDB::bind_method(D_METHOD("_focus_exit"), &ColorPicker::_focus_exit);
-	ClassDB::bind_method(D_METHOD("_html_focus_exit"), &ColorPicker::_html_focus_exit);
 
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_pick_color", "get_pick_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "edit_alpha"), "set_edit_alpha", "is_editing_alpha");
@@ -742,20 +725,20 @@ ColorPicker::ColorPicker() :
 
 	uv_edit = memnew(Control);
 	hb_edit->add_child(uv_edit);
-	uv_edit->connect_compat("gui_input", this, "_uv_input");
+	uv_edit->connect("gui_input", callable_mp(this, &ColorPicker::_uv_input));
 	uv_edit->set_mouse_filter(MOUSE_FILTER_PASS);
 	uv_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	uv_edit->set_v_size_flags(SIZE_EXPAND_FILL);
 	uv_edit->set_custom_minimum_size(Size2(get_constant("sv_width"), get_constant("sv_height")));
-	uv_edit->connect_compat("draw", this, "_hsv_draw", make_binds(0, uv_edit));
+	uv_edit->connect("draw", callable_mp(this, &ColorPicker::_hsv_draw), make_binds(0, uv_edit));
 
 	w_edit = memnew(Control);
 	hb_edit->add_child(w_edit);
 	w_edit->set_custom_minimum_size(Size2(get_constant("h_width"), 0));
 	w_edit->set_h_size_flags(SIZE_FILL);
 	w_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	w_edit->connect_compat("gui_input", this, "_w_input");
-	w_edit->connect_compat("draw", this, "_hsv_draw", make_binds(1, w_edit));
+	w_edit->connect("gui_input", callable_mp(this, &ColorPicker::_w_input));
+	w_edit->connect("draw", callable_mp(this, &ColorPicker::_hsv_draw), make_binds(1, w_edit));
 
 	HBoxContainer *hb_smpl = memnew(HBoxContainer);
 	add_child(hb_smpl);
@@ -763,13 +746,13 @@ ColorPicker::ColorPicker() :
 	sample = memnew(TextureRect);
 	hb_smpl->add_child(sample);
 	sample->set_h_size_flags(SIZE_EXPAND_FILL);
-	sample->connect_compat("draw", this, "_sample_draw");
+	sample->connect("draw", callable_mp(this, &ColorPicker::_sample_draw));
 
 	btn_pick = memnew(ToolButton);
 	hb_smpl->add_child(btn_pick);
 	btn_pick->set_toggle_mode(true);
 	btn_pick->set_tooltip(TTR("Pick a color from the editor window."));
-	btn_pick->connect_compat("pressed", this, "_screen_pick_pressed");
+	btn_pick->connect("pressed", callable_mp(this, &ColorPicker::_screen_pick_pressed));
 
 	VBoxContainer *vbl = memnew(VBoxContainer);
 	add_child(vbl);
@@ -797,14 +780,14 @@ ColorPicker::ColorPicker() :
 		values[i] = memnew(SpinBox);
 		scroll[i]->share(values[i]);
 		hbc->add_child(values[i]);
-		values[i]->get_line_edit()->connect_compat("focus_entered", this, "_focus_enter");
-		values[i]->get_line_edit()->connect_compat("focus_exited", this, "_focus_exit");
+		values[i]->get_line_edit()->connect("focus_entered", callable_mp(this, &ColorPicker::_focus_enter));
+		values[i]->get_line_edit()->connect("focus_exited", callable_mp(this, &ColorPicker::_focus_exit));
 
 		scroll[i]->set_min(0);
 		scroll[i]->set_page(0);
 		scroll[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 
-		scroll[i]->connect_compat("value_changed", this, "_value_changed");
+		scroll[i]->connect("value_changed", callable_mp(this, &ColorPicker::_value_changed));
 
 		vbr->add_child(hbc);
 	}
@@ -816,12 +799,12 @@ ColorPicker::ColorPicker() :
 	btn_hsv = memnew(CheckButton);
 	hhb->add_child(btn_hsv);
 	btn_hsv->set_text(TTR("HSV"));
-	btn_hsv->connect_compat("toggled", this, "set_hsv_mode");
+	btn_hsv->connect("toggled", callable_mp(this, &ColorPicker::set_hsv_mode));
 
 	btn_raw = memnew(CheckButton);
 	hhb->add_child(btn_raw);
 	btn_raw->set_text(TTR("Raw"));
-	btn_raw->connect_compat("toggled", this, "set_raw_mode");
+	btn_raw->connect("toggled", callable_mp(this, &ColorPicker::set_raw_mode));
 
 	text_type = memnew(Button);
 	hhb->add_child(text_type);
@@ -832,7 +815,7 @@ ColorPicker::ColorPicker() :
 #ifdef TOOLS_ENABLED
 		text_type->set_custom_minimum_size(Size2(28 * EDSCALE, 0)); // Adjust for the width of the "Script" icon.
 #endif
-		text_type->connect_compat("pressed", this, "_text_type_toggled");
+		text_type->connect("pressed", callable_mp(this, &ColorPicker::_text_type_toggled));
 	} else {
 
 		text_type->set_flat(true);
@@ -842,9 +825,9 @@ ColorPicker::ColorPicker() :
 	c_text = memnew(LineEdit);
 	hhb->add_child(c_text);
 	c_text->set_h_size_flags(SIZE_EXPAND_FILL);
-	c_text->connect_compat("text_entered", this, "_html_entered");
-	c_text->connect_compat("focus_entered", this, "_focus_enter");
-	c_text->connect_compat("focus_exited", this, "_html_focus_exit");
+	c_text->connect("text_entered", callable_mp(this, &ColorPicker::_html_entered));
+	c_text->connect("focus_entered", callable_mp(this, &ColorPicker::_focus_enter));
+	c_text->connect("focus_exited", callable_mp(this, &ColorPicker::_html_focus_exit));
 
 	_update_controls();
 	updating = false;
@@ -860,8 +843,8 @@ ColorPicker::ColorPicker() :
 
 	preset = memnew(TextureRect);
 	preset_container->add_child(preset);
-	preset->connect_compat("gui_input", this, "_preset_input");
-	preset->connect_compat("draw", this, "_update_presets");
+	preset->connect("gui_input", callable_mp(this, &ColorPicker::_preset_input));
+	preset->connect("draw", callable_mp(this, &ColorPicker::_update_presets));
 
 	preset_container2 = memnew(HBoxContainer);
 	preset_container2->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -869,7 +852,7 @@ ColorPicker::ColorPicker() :
 	bt_add_preset = memnew(Button);
 	preset_container2->add_child(bt_add_preset);
 	bt_add_preset->set_tooltip(TTR("Add current color as a preset."));
-	bt_add_preset->connect_compat("pressed", this, "_add_preset_pressed");
+	bt_add_preset->connect("pressed", callable_mp(this, &ColorPicker::_add_preset_pressed));
 }
 
 /////////////////
@@ -969,8 +952,8 @@ void ColorPickerButton::_update_picker() {
 		picker = memnew(ColorPicker);
 		popup->add_child(picker);
 		add_child(popup);
-		picker->connect_compat("color_changed", this, "_color_changed");
-		popup->connect_compat("modal_closed", this, "_modal_closed");
+		picker->connect("color_changed", callable_mp(this, &ColorPickerButton::_color_changed));
+		popup->connect("modal_closed", callable_mp(this, &ColorPickerButton::_modal_closed));
 		popup->connect_compat("about_to_show", this, "set_pressed", varray(true));
 		popup->connect_compat("popup_hide", this, "set_pressed", varray(false));
 		picker->set_pick_color(color);
@@ -987,8 +970,6 @@ void ColorPickerButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_popup"), &ColorPickerButton::get_popup);
 	ClassDB::bind_method(D_METHOD("set_edit_alpha", "show"), &ColorPickerButton::set_edit_alpha);
 	ClassDB::bind_method(D_METHOD("is_editing_alpha"), &ColorPickerButton::is_editing_alpha);
-	ClassDB::bind_method(D_METHOD("_color_changed"), &ColorPickerButton::_color_changed);
-	ClassDB::bind_method(D_METHOD("_modal_closed"), &ColorPickerButton::_modal_closed);
 
 	ADD_SIGNAL(MethodInfo("color_changed", PropertyInfo(Variant::COLOR, "color")));
 	ADD_SIGNAL(MethodInfo("popup_closed"));

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -954,8 +954,8 @@ void ColorPickerButton::_update_picker() {
 		add_child(popup);
 		picker->connect("color_changed", callable_mp(this, &ColorPickerButton::_color_changed));
 		popup->connect("modal_closed", callable_mp(this, &ColorPickerButton::_modal_closed));
-		popup->connect_compat("about_to_show", this, "set_pressed", varray(true));
-		popup->connect_compat("popup_hide", this, "set_pressed", varray(false));
+		popup->connect("about_to_show", callable_mp((BaseButton *)this, &BaseButton::set_pressed), varray(true));
+		popup->connect("popup_hide", callable_mp((BaseButton *)this, &BaseButton::set_pressed), varray(false));
 		picker->set_pick_color(color);
 		picker->set_edit_alpha(edit_alpha);
 		emit_signal("picker_created");

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -48,9 +48,9 @@ void Container::add_child_notify(Node *p_child) {
 	if (!control)
 		return;
 
-	control->connect_compat("size_flags_changed", this, "queue_sort");
-	control->connect_compat("minimum_size_changed", this, "_child_minsize_changed");
-	control->connect_compat("visibility_changed", this, "_child_minsize_changed");
+	control->connect("size_flags_changed", callable_mp(this, &Container::queue_sort));
+	control->connect("minimum_size_changed", callable_mp(this, &Container::_child_minsize_changed));
+	control->connect("visibility_changed", callable_mp(this, &Container::_child_minsize_changed));
 
 	minimum_size_changed();
 	queue_sort();
@@ -75,9 +75,9 @@ void Container::remove_child_notify(Node *p_child) {
 	if (!control)
 		return;
 
-	control->disconnect_compat("size_flags_changed", this, "queue_sort");
-	control->disconnect_compat("minimum_size_changed", this, "_child_minsize_changed");
-	control->disconnect_compat("visibility_changed", this, "_child_minsize_changed");
+	control->disconnect("size_flags_changed", callable_mp(this, &Container::queue_sort));
+	control->disconnect("minimum_size_changed", callable_mp(this, &Container::_child_minsize_changed));
+	control->disconnect("visibility_changed", callable_mp(this, &Container::_child_minsize_changed));
 
 	minimum_size_changed();
 	queue_sort();
@@ -185,9 +185,7 @@ String Container::get_configuration_warning() const {
 void Container::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_sort_children"), &Container::_sort_children);
-	ClassDB::bind_method(D_METHOD("_child_minsize_changed"), &Container::_child_minsize_changed);
 
-	ClassDB::bind_method(D_METHOD("queue_sort"), &Container::queue_sort);
 	ClassDB::bind_method(D_METHOD("fit_child_in_rect", "child", "rect"), &Container::fit_child_in_rect);
 
 	BIND_CONSTANT(NOTIFICATION_SORT_CHILDREN);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -221,28 +221,28 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 		if (name.begins_with("custom_icons/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.icon_override.has(dname)) {
-				data.icon_override[dname]->disconnect_compat("changed", this, "_override_changed");
+				data.icon_override[dname]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 			}
 			data.icon_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
 		} else if (name.begins_with("custom_shaders/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.shader_override.has(dname)) {
-				data.shader_override[dname]->disconnect_compat("changed", this, "_override_changed");
+				data.shader_override[dname]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 			}
 			data.shader_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
 		} else if (name.begins_with("custom_styles/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.style_override.has(dname)) {
-				data.style_override[dname]->disconnect_compat("changed", this, "_override_changed");
+				data.style_override[dname]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 			}
 			data.style_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
 		} else if (name.begins_with("custom_fonts/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.font_override.has(dname)) {
-				data.font_override[dname]->disconnect_compat("changed", this, "_override_changed");
+				data.font_override[dname]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 			}
 			data.font_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
@@ -542,10 +542,10 @@ void Control::_notification(int p_notification) {
 
 				if (data.parent_canvas_item) {
 
-					data.parent_canvas_item->connect_compat("item_rect_changed", this, "_size_changed");
+					data.parent_canvas_item->connect("item_rect_changed", callable_mp(this, &Control::_size_changed));
 				} else {
 					//connect viewport
-					get_viewport()->connect_compat("size_changed", this, "_size_changed");
+					get_viewport()->connect("size_changed", callable_mp(this, &Control::_size_changed));
 				}
 			}
 
@@ -561,11 +561,11 @@ void Control::_notification(int p_notification) {
 
 			if (data.parent_canvas_item) {
 
-				data.parent_canvas_item->disconnect_compat("item_rect_changed", this, "_size_changed");
+				data.parent_canvas_item->disconnect("item_rect_changed", callable_mp(this, &Control::_size_changed));
 				data.parent_canvas_item = NULL;
 			} else if (!is_set_as_toplevel()) {
 				//disconnect viewport
-				get_viewport()->disconnect_compat("size_changed", this, "_size_changed");
+				get_viewport()->disconnect("size_changed", callable_mp(this, &Control::_size_changed));
 			}
 
 			if (data.MI) {
@@ -1883,7 +1883,7 @@ Rect2 Control::get_anchorable_rect() const {
 void Control::add_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon) {
 
 	if (data.icon_override.has(p_name)) {
-		data.icon_override[p_name]->disconnect_compat("changed", this, "_override_changed");
+		data.icon_override[p_name]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 	}
 
 	// clear if "null" is passed instead of a icon
@@ -1892,7 +1892,7 @@ void Control::add_icon_override(const StringName &p_name, const Ref<Texture2D> &
 	} else {
 		data.icon_override[p_name] = p_icon;
 		if (data.icon_override[p_name].is_valid()) {
-			data.icon_override[p_name]->connect_compat("changed", this, "_override_changed", Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
+			data.icon_override[p_name]->connect("changed", callable_mp(this, &Control::_override_changed), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 	notification(NOTIFICATION_THEME_CHANGED);
@@ -1901,7 +1901,7 @@ void Control::add_icon_override(const StringName &p_name, const Ref<Texture2D> &
 void Control::add_shader_override(const StringName &p_name, const Ref<Shader> &p_shader) {
 
 	if (data.shader_override.has(p_name)) {
-		data.shader_override[p_name]->disconnect_compat("changed", this, "_override_changed");
+		data.shader_override[p_name]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 	}
 
 	// clear if "null" is passed instead of a shader
@@ -1910,7 +1910,7 @@ void Control::add_shader_override(const StringName &p_name, const Ref<Shader> &p
 	} else {
 		data.shader_override[p_name] = p_shader;
 		if (data.shader_override[p_name].is_valid()) {
-			data.shader_override[p_name]->connect_compat("changed", this, "_override_changed", Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
+			data.shader_override[p_name]->connect("changed", callable_mp(this, &Control::_override_changed), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 	notification(NOTIFICATION_THEME_CHANGED);
@@ -1918,7 +1918,7 @@ void Control::add_shader_override(const StringName &p_name, const Ref<Shader> &p
 void Control::add_style_override(const StringName &p_name, const Ref<StyleBox> &p_style) {
 
 	if (data.style_override.has(p_name)) {
-		data.style_override[p_name]->disconnect_compat("changed", this, "_override_changed");
+		data.style_override[p_name]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 	}
 
 	// clear if "null" is passed instead of a style
@@ -1927,7 +1927,7 @@ void Control::add_style_override(const StringName &p_name, const Ref<StyleBox> &
 	} else {
 		data.style_override[p_name] = p_style;
 		if (data.style_override[p_name].is_valid()) {
-			data.style_override[p_name]->connect_compat("changed", this, "_override_changed", Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
+			data.style_override[p_name]->connect("changed", callable_mp(this, &Control::_override_changed), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 	notification(NOTIFICATION_THEME_CHANGED);
@@ -1936,7 +1936,7 @@ void Control::add_style_override(const StringName &p_name, const Ref<StyleBox> &
 void Control::add_font_override(const StringName &p_name, const Ref<Font> &p_font) {
 
 	if (data.font_override.has(p_name)) {
-		data.font_override[p_name]->disconnect_compat("changed", this, "_override_changed");
+		data.font_override[p_name]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 	}
 
 	// clear if "null" is passed instead of a font
@@ -1945,7 +1945,7 @@ void Control::add_font_override(const StringName &p_name, const Ref<Font> &p_fon
 	} else {
 		data.font_override[p_name] = p_font;
 		if (data.font_override[p_name].is_valid()) {
-			data.font_override[p_name]->connect_compat("changed", this, "_override_changed", Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
+			data.font_override[p_name]->connect("changed", callable_mp(this, &Control::_override_changed), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 	notification(NOTIFICATION_THEME_CHANGED);
@@ -2262,7 +2262,7 @@ void Control::set_theme(const Ref<Theme> &p_theme) {
 		return;
 
 	if (data.theme.is_valid()) {
-		data.theme->disconnect_compat("changed", this, "_theme_changed");
+		data.theme->disconnect("changed", callable_mp(this, &Control::_theme_changed));
 	}
 
 	data.theme = p_theme;
@@ -2282,7 +2282,7 @@ void Control::set_theme(const Ref<Theme> &p_theme) {
 	}
 
 	if (data.theme.is_valid()) {
-		data.theme->connect_compat("changed", this, "_theme_changed", varray(), CONNECT_DEFERRED);
+		data.theme->connect("changed", callable_mp(this, &Control::_theme_changed), varray(), CONNECT_DEFERRED);
 	}
 }
 
@@ -2813,7 +2813,6 @@ Control::GrowDirection Control::get_v_grow_direction() const {
 void Control::_bind_methods() {
 
 	//ClassDB::bind_method(D_METHOD("_window_resize_event"),&Control::_window_resize_event);
-	ClassDB::bind_method(D_METHOD("_size_changed"), &Control::_size_changed);
 	ClassDB::bind_method(D_METHOD("_update_minimum_size"), &Control::_update_minimum_size);
 
 	ClassDB::bind_method(D_METHOD("accept_event"), &Control::accept_event);
@@ -2941,10 +2940,6 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("warp_mouse", "to_position"), &Control::warp_mouse);
 
 	ClassDB::bind_method(D_METHOD("minimum_size_changed"), &Control::minimum_size_changed);
-
-	ClassDB::bind_method(D_METHOD("_theme_changed"), &Control::_theme_changed);
-
-	ClassDB::bind_method(D_METHOD("_override_changed"), &Control::_override_changed);
 
 	BIND_VMETHOD(MethodInfo("_gui_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	BIND_VMETHOD(MethodInfo(Variant::VECTOR2, "_get_minimum_size"));

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -336,6 +336,8 @@ void WindowDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_resizable"), &WindowDialog::get_resizable);
 	ClassDB::bind_method(D_METHOD("get_close_button"), &WindowDialog::get_close_button);
 
+	ClassDB::bind_method(D_METHOD("_closed"), &WindowDialog::_closed); // Still used by some connect_compat.
+
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "window_title", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT_INTL), "set_title", "get_title");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resizable", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT_INTL), "set_resizable", "get_resizable");
 }
@@ -559,6 +561,9 @@ void AcceptDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_text"), &AcceptDialog::get_text);
 	ClassDB::bind_method(D_METHOD("set_autowrap", "autowrap"), &AcceptDialog::set_autowrap);
 	ClassDB::bind_method(D_METHOD("has_autowrap"), &AcceptDialog::has_autowrap);
+
+	ClassDB::bind_method(D_METHOD("_ok"), &AcceptDialog::_ok_pressed); // Still used by some connect_compat.
+	ClassDB::bind_method(D_METHOD("_builtin_text_entered"), &AcceptDialog::_builtin_text_entered); // Still used by some connect_compat.
 
 	ADD_SIGNAL(MethodInfo("confirmed"));
 	ADD_SIGNAL(MethodInfo("custom_action", PropertyInfo(Variant::STRING_NAME, "action")));

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -334,7 +334,6 @@ void WindowDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_title"), &WindowDialog::get_title);
 	ClassDB::bind_method(D_METHOD("set_resizable", "resizable"), &WindowDialog::set_resizable);
 	ClassDB::bind_method(D_METHOD("get_resizable"), &WindowDialog::get_resizable);
-	ClassDB::bind_method(D_METHOD("_closed"), &WindowDialog::_closed);
 	ClassDB::bind_method(D_METHOD("get_close_button"), &WindowDialog::get_close_button);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "window_title", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT_INTL), "set_title", "get_title");
@@ -347,7 +346,7 @@ WindowDialog::WindowDialog() {
 	resizable = false;
 	close_button = memnew(TextureButton);
 	add_child(close_button);
-	close_button->connect_compat("pressed", this, "_closed");
+	close_button->connect("pressed", callable_mp(this, &WindowDialog::_closed));
 
 #ifdef TOOLS_ENABLED
 	was_editor_dimmed = false;
@@ -446,7 +445,7 @@ void AcceptDialog::register_text_enter(Node *p_line_edit) {
 	ERR_FAIL_NULL(p_line_edit);
 	LineEdit *line_edit = Object::cast_to<LineEdit>(p_line_edit);
 	if (line_edit)
-		line_edit->connect_compat("text_entered", this, "_builtin_text_entered");
+		line_edit->connect("text_entered", callable_mp(this, &AcceptDialog::_builtin_text_entered));
 }
 
 void AcceptDialog::_update_child_rects() {
@@ -531,7 +530,7 @@ Button *AcceptDialog::add_button(const String &p_text, bool p_right, const Strin
 	}
 
 	if (p_action != "") {
-		button->connect_compat("pressed", this, "_custom_action", varray(p_action));
+		button->connect("pressed", callable_mp(this, &AcceptDialog::_custom_action), varray(p_action));
 	}
 
 	return button;
@@ -549,16 +548,13 @@ Button *AcceptDialog::add_cancel(const String &p_cancel) {
 
 void AcceptDialog::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_ok"), &AcceptDialog::_ok_pressed);
 	ClassDB::bind_method(D_METHOD("get_ok"), &AcceptDialog::get_ok);
 	ClassDB::bind_method(D_METHOD("get_label"), &AcceptDialog::get_label);
 	ClassDB::bind_method(D_METHOD("set_hide_on_ok", "enabled"), &AcceptDialog::set_hide_on_ok);
 	ClassDB::bind_method(D_METHOD("get_hide_on_ok"), &AcceptDialog::get_hide_on_ok);
 	ClassDB::bind_method(D_METHOD("add_button", "text", "right", "action"), &AcceptDialog::add_button, DEFVAL(false), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("add_cancel", "name"), &AcceptDialog::add_cancel);
-	ClassDB::bind_method(D_METHOD("_builtin_text_entered"), &AcceptDialog::_builtin_text_entered);
 	ClassDB::bind_method(D_METHOD("register_text_enter", "line_edit"), &AcceptDialog::register_text_enter);
-	ClassDB::bind_method(D_METHOD("_custom_action"), &AcceptDialog::_custom_action);
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &AcceptDialog::set_text);
 	ClassDB::bind_method(D_METHOD("get_text"), &AcceptDialog::get_text);
 	ClassDB::bind_method(D_METHOD("set_autowrap", "autowrap"), &AcceptDialog::set_autowrap);
@@ -600,7 +596,7 @@ AcceptDialog::AcceptDialog() {
 	hbc->add_child(ok);
 	hbc->add_spacer();
 
-	ok->connect_compat("pressed", this, "_ok");
+	ok->connect("pressed", callable_mp(this, &AcceptDialog::_ok_pressed));
 	set_as_toplevel(true);
 
 	hide_on_ok = true;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -805,15 +805,7 @@ void FileDialog::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_unhandled_input"), &FileDialog::_unhandled_input);
 
-	ClassDB::bind_method(D_METHOD("_tree_multi_selected"), &FileDialog::_tree_multi_selected);
-	ClassDB::bind_method(D_METHOD("_tree_selected"), &FileDialog::_tree_selected);
-	ClassDB::bind_method(D_METHOD("_tree_item_activated"), &FileDialog::_tree_item_activated);
-	ClassDB::bind_method(D_METHOD("_dir_entered"), &FileDialog::_dir_entered);
-	ClassDB::bind_method(D_METHOD("_file_entered"), &FileDialog::_file_entered);
-	ClassDB::bind_method(D_METHOD("_action_pressed"), &FileDialog::_action_pressed);
 	ClassDB::bind_method(D_METHOD("_cancel_pressed"), &FileDialog::_cancel_pressed);
-	ClassDB::bind_method(D_METHOD("_filter_selected"), &FileDialog::_filter_selected);
-	ClassDB::bind_method(D_METHOD("_save_confirm_pressed"), &FileDialog::_save_confirm_pressed);
 
 	ClassDB::bind_method(D_METHOD("clear_filters"), &FileDialog::clear_filters);
 	ClassDB::bind_method(D_METHOD("add_filter", "filter"), &FileDialog::add_filter);
@@ -833,16 +825,9 @@ void FileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_line_edit"), &FileDialog::get_line_edit);
 	ClassDB::bind_method(D_METHOD("set_access", "access"), &FileDialog::set_access);
 	ClassDB::bind_method(D_METHOD("get_access"), &FileDialog::get_access);
-	ClassDB::bind_method(D_METHOD("set_show_hidden_files", "show"), &FileDialog::set_show_hidden_files);
 	ClassDB::bind_method(D_METHOD("is_showing_hidden_files"), &FileDialog::is_showing_hidden_files);
-	ClassDB::bind_method(D_METHOD("_select_drive"), &FileDialog::_select_drive);
-	ClassDB::bind_method(D_METHOD("_make_dir"), &FileDialog::_make_dir);
-	ClassDB::bind_method(D_METHOD("_make_dir_confirm"), &FileDialog::_make_dir_confirm);
 	ClassDB::bind_method(D_METHOD("_update_file_name"), &FileDialog::update_file_name);
-	ClassDB::bind_method(D_METHOD("_update_file_list"), &FileDialog::update_file_list);
 	ClassDB::bind_method(D_METHOD("_update_dir"), &FileDialog::update_dir);
-	ClassDB::bind_method(D_METHOD("_go_up"), &FileDialog::_go_up);
-	ClassDB::bind_method(D_METHOD("deselect_items"), &FileDialog::deselect_items);
 
 	ClassDB::bind_method(D_METHOD("invalidate"), &FileDialog::invalidate);
 
@@ -900,11 +885,11 @@ FileDialog::FileDialog() {
 	dir_up = memnew(ToolButton);
 	dir_up->set_tooltip(RTR("Go to parent folder."));
 	hbc->add_child(dir_up);
-	dir_up->connect_compat("pressed", this, "_go_up");
+	dir_up->connect("pressed", callable_mp(this, &FileDialog::_go_up));
 
 	drives = memnew(OptionButton);
 	hbc->add_child(drives);
-	drives->connect_compat("item_selected", this, "_select_drive");
+	drives->connect("item_selected", callable_mp(this, &FileDialog::_select_drive));
 
 	hbc->add_child(memnew(Label(RTR("Path:"))));
 	dir = memnew(LineEdit);
@@ -913,19 +898,19 @@ FileDialog::FileDialog() {
 
 	refresh = memnew(ToolButton);
 	refresh->set_tooltip(RTR("Refresh files."));
-	refresh->connect_compat("pressed", this, "_update_file_list");
+	refresh->connect("pressed", callable_mp(this, &FileDialog::update_file_list));
 	hbc->add_child(refresh);
 
 	show_hidden = memnew(ToolButton);
 	show_hidden->set_toggle_mode(true);
 	show_hidden->set_pressed(is_showing_hidden_files());
 	show_hidden->set_tooltip(RTR("Toggle the visibility of hidden files."));
-	show_hidden->connect_compat("toggled", this, "set_show_hidden_files");
+	show_hidden->connect("toggled", callable_mp(this, &FileDialog::set_show_hidden_files));
 	hbc->add_child(show_hidden);
 
 	makedir = memnew(Button);
 	makedir->set_text(RTR("Create Folder"));
-	makedir->connect_compat("pressed", this, "_make_dir");
+	makedir->connect("pressed", callable_mp(this, &FileDialog::_make_dir));
 	hbc->add_child(makedir);
 	vbc->add_child(hbc);
 
@@ -950,20 +935,20 @@ FileDialog::FileDialog() {
 	access = ACCESS_RESOURCES;
 	_update_drives();
 
-	connect_compat("confirmed", this, "_action_pressed");
-	tree->connect_compat("multi_selected", this, "_tree_multi_selected", varray(), CONNECT_DEFERRED);
-	tree->connect_compat("cell_selected", this, "_tree_selected", varray(), CONNECT_DEFERRED);
-	tree->connect_compat("item_activated", this, "_tree_item_activated", varray());
-	tree->connect_compat("nothing_selected", this, "deselect_items");
-	dir->connect_compat("text_entered", this, "_dir_entered");
-	file->connect_compat("text_entered", this, "_file_entered");
-	filter->connect_compat("item_selected", this, "_filter_selected");
+	connect("confirmed", callable_mp(this, &FileDialog::_action_pressed));
+	tree->connect("multi_selected", callable_mp(this, &FileDialog::_tree_multi_selected), varray(), CONNECT_DEFERRED);
+	tree->connect("cell_selected", callable_mp(this, &FileDialog::_tree_selected), varray(), CONNECT_DEFERRED);
+	tree->connect("item_activated", callable_mp(this, &FileDialog::_tree_item_activated), varray());
+	tree->connect("nothing_selected", callable_mp(this, &FileDialog::deselect_items));
+	dir->connect("text_entered", callable_mp(this, &FileDialog::_dir_entered));
+	file->connect("text_entered", callable_mp(this, &FileDialog::_file_entered));
+	filter->connect("item_selected", callable_mp(this, &FileDialog::_filter_selected));
 
 	confirm_save = memnew(ConfirmationDialog);
 	confirm_save->set_as_toplevel(true);
 	add_child(confirm_save);
 
-	confirm_save->connect_compat("confirmed", this, "_save_confirm_pressed");
+	confirm_save->connect("confirmed", callable_mp(this, &FileDialog::_save_confirm_pressed));
 
 	makedialog = memnew(ConfirmationDialog);
 	makedialog->set_title(RTR("Create Folder"));
@@ -974,7 +959,7 @@ FileDialog::FileDialog() {
 	makevb->add_margin_child(RTR("Name:"), makedirname);
 	add_child(makedialog);
 	makedialog->register_text_enter(makedirname);
-	makedialog->connect_compat("confirmed", this, "_make_dir_confirm");
+	makedialog->connect("confirmed", callable_mp(this, &FileDialog::_make_dir_confirm));
 	mkdirerr = memnew(AcceptDialog);
 	mkdirerr->set_text(RTR("Could not create folder."));
 	add_child(mkdirerr);
@@ -1003,8 +988,6 @@ FileDialog::~FileDialog() {
 
 void LineEditFileChooser::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_browse"), &LineEditFileChooser::_browse);
-	ClassDB::bind_method(D_METHOD("_chosen"), &LineEditFileChooser::_chosen);
 	ClassDB::bind_method(D_METHOD("get_button"), &LineEditFileChooser::get_button);
 	ClassDB::bind_method(D_METHOD("get_line_edit"), &LineEditFileChooser::get_line_edit);
 	ClassDB::bind_method(D_METHOD("get_file_dialog"), &LineEditFileChooser::get_file_dialog);
@@ -1029,10 +1012,10 @@ LineEditFileChooser::LineEditFileChooser() {
 	button = memnew(Button);
 	button->set_text(" .. ");
 	add_child(button);
-	button->connect_compat("pressed", this, "_browse");
+	button->connect("pressed", callable_mp(this, &LineEditFileChooser::_browse));
 	dialog = memnew(FileDialog);
 	add_child(dialog);
-	dialog->connect_compat("file_selected", this, "_chosen");
-	dialog->connect_compat("dir_selected", this, "_chosen");
-	dialog->connect_compat("files_selected", this, "_chosen");
+	dialog->connect("file_selected", callable_mp(this, &LineEditFileChooser::_chosen));
+	dialog->connect("dir_selected", callable_mp(this, &LineEditFileChooser::_chosen));
+	dialog->connect("files_selected", callable_mp(this, &LineEditFileChooser::_chosen));
 }

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -302,8 +302,8 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 void GradientEdit::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (!picker->is_connected_compat("color_changed", this, "_color_changed")) {
-			picker->connect_compat("color_changed", this, "_color_changed");
+		if (!picker->is_connected("color_changed", callable_mp(this, &GradientEdit::_color_changed))) {
+			picker->connect("color_changed", callable_mp(this, &GradientEdit::_color_changed));
 		}
 	}
 	if (p_what == NOTIFICATION_DRAW) {
@@ -490,6 +490,5 @@ Vector<Gradient::Point> &GradientEdit::get_points() {
 
 void GradientEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_gui_input"), &GradientEdit::_gui_input);
-	ClassDB::bind_method(D_METHOD("_color_changed"), &GradientEdit::_color_changed);
 	ADD_SIGNAL(MethodInfo("ramp_changed"));
 }

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -259,7 +259,7 @@ void GraphEdit::add_child_notify(Node *p_child) {
 		gn->set_scale(Vector2(zoom, zoom));
 		gn->connect("offset_changed", callable_mp(this, &GraphEdit::_graph_node_moved), varray(gn));
 		gn->connect("raise_request", callable_mp(this, &GraphEdit::_graph_node_raised), varray(gn));
-		gn->connect_compat("item_rect_changed", connections_layer, "update");
+		gn->connect("item_rect_changed", callable_mp((CanvasItem *)connections_layer, &CanvasItem::update));
 		_graph_node_moved(gn);
 		gn->set_mouse_filter(MOUSE_FILTER_PASS);
 	}

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -257,8 +257,8 @@ void GraphEdit::add_child_notify(Node *p_child) {
 	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
 		gn->set_scale(Vector2(zoom, zoom));
-		gn->connect_compat("offset_changed", this, "_graph_node_moved", varray(gn));
-		gn->connect_compat("raise_request", this, "_graph_node_raised", varray(gn));
+		gn->connect("offset_changed", callable_mp(this, &GraphEdit::_graph_node_moved), varray(gn));
+		gn->connect("raise_request", callable_mp(this, &GraphEdit::_graph_node_raised), varray(gn));
 		gn->connect_compat("item_rect_changed", connections_layer, "update");
 		_graph_node_moved(gn);
 		gn->set_mouse_filter(MOUSE_FILTER_PASS);
@@ -273,8 +273,8 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 	}
 	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
-		gn->disconnect_compat("offset_changed", this, "_graph_node_moved");
-		gn->disconnect_compat("raise_request", this, "_graph_node_raised");
+		gn->disconnect("offset_changed", callable_mp(this, &GraphEdit::_graph_node_moved));
+		gn->disconnect("raise_request", callable_mp(this, &GraphEdit::_graph_node_raised));
 	}
 }
 
@@ -1291,21 +1291,8 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_right_disconnects", "enable"), &GraphEdit::set_right_disconnects);
 	ClassDB::bind_method(D_METHOD("is_right_disconnects_enabled"), &GraphEdit::is_right_disconnects_enabled);
 
-	ClassDB::bind_method(D_METHOD("_graph_node_moved"), &GraphEdit::_graph_node_moved);
-	ClassDB::bind_method(D_METHOD("_graph_node_raised"), &GraphEdit::_graph_node_raised);
-
-	ClassDB::bind_method(D_METHOD("_top_layer_input"), &GraphEdit::_top_layer_input);
-	ClassDB::bind_method(D_METHOD("_top_layer_draw"), &GraphEdit::_top_layer_draw);
-	ClassDB::bind_method(D_METHOD("_scroll_moved"), &GraphEdit::_scroll_moved);
-	ClassDB::bind_method(D_METHOD("_zoom_minus"), &GraphEdit::_zoom_minus);
-	ClassDB::bind_method(D_METHOD("_zoom_reset"), &GraphEdit::_zoom_reset);
-	ClassDB::bind_method(D_METHOD("_zoom_plus"), &GraphEdit::_zoom_plus);
-	ClassDB::bind_method(D_METHOD("_snap_toggled"), &GraphEdit::_snap_toggled);
-	ClassDB::bind_method(D_METHOD("_snap_value_changed"), &GraphEdit::_snap_value_changed);
-
 	ClassDB::bind_method(D_METHOD("_gui_input"), &GraphEdit::_gui_input);
 	ClassDB::bind_method(D_METHOD("_update_scroll_offset"), &GraphEdit::_update_scroll_offset);
-	ClassDB::bind_method(D_METHOD("_connections_layer_draw"), &GraphEdit::_connections_layer_draw);
 
 	ClassDB::bind_method(D_METHOD("get_zoom_hbox"), &GraphEdit::get_zoom_hbox);
 
@@ -1341,12 +1328,12 @@ GraphEdit::GraphEdit() {
 	add_child(top_layer);
 	top_layer->set_mouse_filter(MOUSE_FILTER_PASS);
 	top_layer->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	top_layer->connect_compat("draw", this, "_top_layer_draw");
-	top_layer->connect_compat("gui_input", this, "_top_layer_input");
+	top_layer->connect("draw", callable_mp(this, &GraphEdit::_top_layer_draw));
+	top_layer->connect("gui_input", callable_mp(this, &GraphEdit::_top_layer_input));
 
 	connections_layer = memnew(Control);
 	add_child(connections_layer);
-	connections_layer->connect_compat("draw", this, "_connections_layer_draw");
+	connections_layer->connect("draw", callable_mp(this, &GraphEdit::_connections_layer_draw));
 	connections_layer->set_name("CLAYER");
 	connections_layer->set_disable_visibility_clip(true); // so it can draw freely and be offset
 	connections_layer->set_mouse_filter(MOUSE_FILTER_IGNORE);
@@ -1373,8 +1360,8 @@ GraphEdit::GraphEdit() {
 	v_scroll->set_min(-10000);
 	v_scroll->set_max(10000);
 
-	h_scroll->connect_compat("value_changed", this, "_scroll_moved");
-	v_scroll->connect_compat("value_changed", this, "_scroll_moved");
+	h_scroll->connect("value_changed", callable_mp(this, &GraphEdit::_scroll_moved));
+	v_scroll->connect("value_changed", callable_mp(this, &GraphEdit::_scroll_moved));
 
 	zoom = 1;
 
@@ -1385,25 +1372,25 @@ GraphEdit::GraphEdit() {
 	zoom_minus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_minus);
 	zoom_minus->set_tooltip(RTR("Zoom Out"));
-	zoom_minus->connect_compat("pressed", this, "_zoom_minus");
+	zoom_minus->connect("pressed", callable_mp(this, &GraphEdit::_zoom_minus));
 	zoom_minus->set_focus_mode(FOCUS_NONE);
 
 	zoom_reset = memnew(ToolButton);
 	zoom_hb->add_child(zoom_reset);
 	zoom_reset->set_tooltip(RTR("Zoom Reset"));
-	zoom_reset->connect_compat("pressed", this, "_zoom_reset");
+	zoom_reset->connect("pressed", callable_mp(this, &GraphEdit::_zoom_reset));
 	zoom_reset->set_focus_mode(FOCUS_NONE);
 
 	zoom_plus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_plus);
 	zoom_plus->set_tooltip(RTR("Zoom In"));
-	zoom_plus->connect_compat("pressed", this, "_zoom_plus");
+	zoom_plus->connect("pressed", callable_mp(this, &GraphEdit::_zoom_plus));
 	zoom_plus->set_focus_mode(FOCUS_NONE);
 
 	snap_button = memnew(ToolButton);
 	snap_button->set_toggle_mode(true);
 	snap_button->set_tooltip(RTR("Enable snap and show grid."));
-	snap_button->connect_compat("pressed", this, "_snap_toggled");
+	snap_button->connect("pressed", callable_mp(this, &GraphEdit::_snap_toggled));
 	snap_button->set_pressed(true);
 	snap_button->set_focus_mode(FOCUS_NONE);
 	zoom_hb->add_child(snap_button);
@@ -1413,7 +1400,7 @@ GraphEdit::GraphEdit() {
 	snap_amount->set_max(100);
 	snap_amount->set_step(1);
 	snap_amount->set_value(20);
-	snap_amount->connect_compat("value_changed", this, "_snap_value_changed");
+	snap_amount->connect("value_changed", callable_mp(this, &GraphEdit::_snap_value_changed));
 	zoom_hb->add_child(snap_amount);
 
 	setting_scroll_ofs = false;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1542,7 +1542,6 @@ void ItemList::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_v_scroll"), &ItemList::get_v_scroll);
 
-	ClassDB::bind_method(D_METHOD("_scroll_changed"), &ItemList::_scroll_changed);
 	ClassDB::bind_method(D_METHOD("_gui_input"), &ItemList::_gui_input);
 
 	ClassDB::bind_method(D_METHOD("_set_items"), &ItemList::_set_items);
@@ -1599,7 +1598,7 @@ ItemList::ItemList() {
 	add_child(scroll_bar);
 
 	shape_changed = true;
-	scroll_bar->connect_compat("value_changed", this, "_scroll_changed");
+	scroll_bar->connect("value_changed", callable_mp(this, &ItemList::_scroll_changed));
 
 	set_focus_mode(FOCUS_ALL);
 	current_columns = 1;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -648,8 +648,8 @@ void LineEdit::_notification(int p_what) {
 				cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
 				cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
 
-				if (!EditorSettings::get_singleton()->is_connected_compat("settings_changed", this, "_editor_settings_changed")) {
-					EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_editor_settings_changed");
+				if (!EditorSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed))) {
+					EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed));
 				}
 			}
 		} break;
@@ -1752,9 +1752,6 @@ void LineEdit::_generate_context_menu() {
 void LineEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_text_changed"), &LineEdit::_text_changed);
-	ClassDB::bind_method(D_METHOD("_toggle_draw_caret"), &LineEdit::_toggle_draw_caret);
-
-	ClassDB::bind_method("_editor_settings_changed", &LineEdit::_editor_settings_changed);
 
 	ClassDB::bind_method(D_METHOD("set_align", "align"), &LineEdit::set_align);
 	ClassDB::bind_method(D_METHOD("get_align"), &LineEdit::get_align);
@@ -1787,7 +1784,6 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_secret"), &LineEdit::is_secret);
 	ClassDB::bind_method(D_METHOD("set_secret_character", "character"), &LineEdit::set_secret_character);
 	ClassDB::bind_method(D_METHOD("get_secret_character"), &LineEdit::get_secret_character);
-	ClassDB::bind_method(D_METHOD("menu_option", "option"), &LineEdit::menu_option);
 	ClassDB::bind_method(D_METHOD("get_menu"), &LineEdit::get_menu);
 	ClassDB::bind_method(D_METHOD("set_context_menu_enabled", "enable"), &LineEdit::set_context_menu_enabled);
 	ClassDB::bind_method(D_METHOD("is_context_menu_enabled"), &LineEdit::is_context_menu_enabled);
@@ -1870,7 +1866,7 @@ LineEdit::LineEdit() {
 	caret_blink_timer = memnew(Timer);
 	add_child(caret_blink_timer);
 	caret_blink_timer->set_wait_time(0.65);
-	caret_blink_timer->connect_compat("timeout", this, "_toggle_draw_caret");
+	caret_blink_timer->connect("timeout", callable_mp(this, &LineEdit::_toggle_draw_caret));
 	cursor_set_blink_enabled(false);
 
 	context_menu_enabled = true;
@@ -1878,7 +1874,7 @@ LineEdit::LineEdit() {
 	add_child(menu);
 	editable = false; // Initialise to opposite first, so we get past the early-out in set_editable.
 	set_editable(true);
-	menu->connect_compat("id_pressed", this, "menu_option");
+	menu->connect("id_pressed", callable_mp(this, &LineEdit::menu_option));
 	expand_to_text_length = false;
 }
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "menu_button.h"
+
 #include "core/os/keyboard.h"
 #include "scene/main/viewport.h"
 
@@ -137,8 +138,8 @@ MenuButton::MenuButton() {
 	popup->hide();
 	add_child(popup);
 	popup->set_pass_on_modal_close_click(false);
-	popup->connect_compat("about_to_show", this, "set_pressed", varray(true)); // For when switching from another MenuButton.
-	popup->connect_compat("popup_hide", this, "set_pressed", varray(false));
+	popup->connect("about_to_show", callable_mp((BaseButton *)this, &BaseButton::set_pressed), varray(true)); // For when switching from another MenuButton.
+	popup->connect("popup_hide", callable_mp((BaseButton *)this, &BaseButton::set_pressed), varray(false));
 }
 
 MenuButton::~MenuButton() {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "option_button.h"
+
 #include "core/print_string.h"
 
 Size2 OptionButton::get_minimum_size() const {
@@ -362,7 +363,7 @@ OptionButton::OptionButton() {
 	popup->set_allow_search(true);
 	popup->connect("index_pressed", callable_mp(this, &OptionButton::_selected));
 	popup->connect("id_focused", callable_mp(this, &OptionButton::_focused));
-	popup->connect_compat("popup_hide", this, "set_pressed", varray(false));
+	popup->connect("popup_hide", callable_mp((BaseButton *)this, &BaseButton::set_pressed), varray(false));
 }
 
 OptionButton::~OptionButton() {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -309,9 +309,6 @@ void OptionButton::get_translatable_strings(List<String> *p_strings) const {
 
 void OptionButton::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_selected"), &OptionButton::_selected);
-	ClassDB::bind_method(D_METHOD("_focused"), &OptionButton::_focused);
-
 	ClassDB::bind_method(D_METHOD("add_item", "label", "id"), &OptionButton::add_item, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("add_icon_item", "texture", "label", "id"), &OptionButton::add_icon_item, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("set_item_text", "idx", "text"), &OptionButton::set_item_text);
@@ -363,8 +360,8 @@ OptionButton::OptionButton() {
 	popup->set_pass_on_modal_close_click(false);
 	popup->set_notify_transform(true);
 	popup->set_allow_search(true);
-	popup->connect_compat("index_pressed", this, "_selected");
-	popup->connect_compat("id_focused", this, "_focused");
+	popup->connect("index_pressed", callable_mp(this, &OptionButton::_selected));
+	popup->connect("id_focused", callable_mp(this, &OptionButton::_focused));
 	popup->connect_compat("popup_hide", this, "set_pressed", varray(false));
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1471,8 +1471,6 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_allow_search", "allow"), &PopupMenu::set_allow_search);
 	ClassDB::bind_method(D_METHOD("get_allow_search"), &PopupMenu::get_allow_search);
 
-	ClassDB::bind_method(D_METHOD("_submenu_timeout"), &PopupMenu::_submenu_timeout);
-
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "items", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_items", "_get_items");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_item_selection"), "set_hide_on_item_selection", "is_hide_on_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_checkable_item_selection"), "set_hide_on_checkable_item_selection", "is_hide_on_checkable_item_selection");
@@ -1514,7 +1512,7 @@ PopupMenu::PopupMenu() {
 	submenu_timer = memnew(Timer);
 	submenu_timer->set_wait_time(0.3);
 	submenu_timer->set_one_shot(true);
-	submenu_timer->connect_compat("timeout", this, "_submenu_timeout");
+	submenu_timer->connect("timeout", callable_mp(this, &PopupMenu::_submenu_timeout));
 	add_child(submenu_timer);
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "popup_menu.h"
+
 #include "core/os/input.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
@@ -1233,7 +1234,7 @@ void PopupMenu::_ref_shortcut(Ref<ShortCut> p_sc) {
 
 	if (!shortcut_refcount.has(p_sc)) {
 		shortcut_refcount[p_sc] = 1;
-		p_sc->connect_compat("changed", this, "update");
+		p_sc->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
 	} else {
 		shortcut_refcount[p_sc] += 1;
 	}
@@ -1244,7 +1245,7 @@ void PopupMenu::_unref_shortcut(Ref<ShortCut> p_sc) {
 	ERR_FAIL_COND(!shortcut_refcount.has(p_sc));
 	shortcut_refcount[p_sc]--;
 	if (shortcut_refcount[p_sc] == 0) {
-		p_sc->disconnect_compat("changed", this, "update");
+		p_sc->disconnect("changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
 		shortcut_refcount.erase(p_sc);
 	}
 }

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2699,7 +2699,6 @@ int RichTextLabel::get_content_height() {
 void RichTextLabel::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &RichTextLabel::_gui_input);
-	ClassDB::bind_method(D_METHOD("_scroll_changed"), &RichTextLabel::_scroll_changed);
 	ClassDB::bind_method(D_METHOD("get_text"), &RichTextLabel::get_text);
 	ClassDB::bind_method(D_METHOD("add_text", "text"), &RichTextLabel::add_text);
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &RichTextLabel::set_text);
@@ -2963,7 +2962,7 @@ RichTextLabel::RichTextLabel() {
 	vscroll->set_anchor_and_margin(MARGIN_TOP, ANCHOR_BEGIN, 0);
 	vscroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, 0);
 	vscroll->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, 0);
-	vscroll->connect_compat("value_changed", this, "_scroll_changed");
+	vscroll->connect("value_changed", callable_mp(this, &RichTextLabel::_scroll_changed));
 	vscroll->set_step(1);
 	vscroll->hide();
 	current_idx = 1;

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -296,15 +296,15 @@ void ScrollBar::_notification(int p_what) {
 		}
 
 		if (drag_node) {
-			drag_node->connect_compat("gui_input", this, "_drag_node_input");
-			drag_node->connect_compat("tree_exiting", this, "_drag_node_exit", varray(), CONNECT_ONESHOT);
+			drag_node->connect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
+			drag_node->connect("tree_exiting", callable_mp(this, &ScrollBar::_drag_node_exit), varray(), CONNECT_ONESHOT);
 		}
 	}
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
 		if (drag_node) {
-			drag_node->disconnect_compat("gui_input", this, "_drag_node_input");
-			drag_node->disconnect_compat("tree_exiting", this, "_drag_node_exit");
+			drag_node->disconnect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
+			drag_node->disconnect("tree_exiting", callable_mp(this, &ScrollBar::_drag_node_exit));
 		}
 
 		drag_node = NULL;
@@ -539,7 +539,7 @@ float ScrollBar::get_custom_step() const {
 void ScrollBar::_drag_node_exit() {
 
 	if (drag_node) {
-		drag_node->disconnect_compat("gui_input", this, "_drag_node_input");
+		drag_node->disconnect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
 	}
 	drag_node = NULL;
 }
@@ -611,8 +611,8 @@ void ScrollBar::set_drag_node(const NodePath &p_path) {
 	if (is_inside_tree()) {
 
 		if (drag_node) {
-			drag_node->disconnect_compat("gui_input", this, "_drag_node_input");
-			drag_node->disconnect_compat("tree_exiting", this, "_drag_node_exit");
+			drag_node->disconnect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
+			drag_node->disconnect("tree_exiting", callable_mp(this, &ScrollBar::_drag_node_exit));
 		}
 	}
 
@@ -627,8 +627,8 @@ void ScrollBar::set_drag_node(const NodePath &p_path) {
 		}
 
 		if (drag_node) {
-			drag_node->connect_compat("gui_input", this, "_drag_node_input");
-			drag_node->connect_compat("tree_exiting", this, "_drag_node_exit", varray(), CONNECT_ONESHOT);
+			drag_node->connect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
+			drag_node->connect("tree_exiting", callable_mp(this, &ScrollBar::_drag_node_exit), varray(), CONNECT_ONESHOT);
 		}
 	}
 }
@@ -651,8 +651,6 @@ void ScrollBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_gui_input"), &ScrollBar::_gui_input);
 	ClassDB::bind_method(D_METHOD("set_custom_step", "step"), &ScrollBar::set_custom_step);
 	ClassDB::bind_method(D_METHOD("get_custom_step"), &ScrollBar::get_custom_step);
-	ClassDB::bind_method(D_METHOD("_drag_node_input"), &ScrollBar::_drag_node_input);
-	ClassDB::bind_method(D_METHOD("_drag_node_exit"), &ScrollBar::_drag_node_exit);
 
 	ADD_SIGNAL(MethodInfo("scrolling"));
 

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -267,7 +267,7 @@ void ScrollContainer::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_READY) {
 
-		get_viewport()->connect_compat("gui_focus_changed", this, "_ensure_focused_visible");
+		get_viewport()->connect("gui_focus_changed", callable_mp(this, &ScrollContainer::_ensure_focused_visible));
 	}
 
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
@@ -570,14 +570,12 @@ VScrollBar *ScrollContainer::get_v_scrollbar() {
 
 void ScrollContainer::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_scroll_moved"), &ScrollContainer::_scroll_moved);
 	ClassDB::bind_method(D_METHOD("_gui_input"), &ScrollContainer::_gui_input);
 	ClassDB::bind_method(D_METHOD("set_enable_h_scroll", "enable"), &ScrollContainer::set_enable_h_scroll);
 	ClassDB::bind_method(D_METHOD("is_h_scroll_enabled"), &ScrollContainer::is_h_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("set_enable_v_scroll", "enable"), &ScrollContainer::set_enable_v_scroll);
 	ClassDB::bind_method(D_METHOD("is_v_scroll_enabled"), &ScrollContainer::is_v_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("_update_scrollbar_position"), &ScrollContainer::_update_scrollbar_position);
-	ClassDB::bind_method(D_METHOD("_ensure_focused_visible"), &ScrollContainer::_ensure_focused_visible);
 	ClassDB::bind_method(D_METHOD("set_h_scroll", "value"), &ScrollContainer::set_h_scroll);
 	ClassDB::bind_method(D_METHOD("get_h_scroll"), &ScrollContainer::get_h_scroll);
 	ClassDB::bind_method(D_METHOD("set_v_scroll", "value"), &ScrollContainer::set_v_scroll);
@@ -610,12 +608,12 @@ ScrollContainer::ScrollContainer() {
 	h_scroll = memnew(HScrollBar);
 	h_scroll->set_name("_h_scroll");
 	add_child(h_scroll);
-	h_scroll->connect_compat("value_changed", this, "_scroll_moved");
+	h_scroll->connect("value_changed", callable_mp(this, &ScrollContainer::_scroll_moved));
 
 	v_scroll = memnew(VScrollBar);
 	v_scroll->set_name("_v_scroll");
 	add_child(v_scroll);
-	v_scroll->connect_compat("value_changed", this, "_scroll_moved");
+	v_scroll->connect("value_changed", callable_mp(this, &ScrollContainer::_scroll_moved));
 
 	drag_speed = Vector2();
 	drag_touching = false;

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -267,7 +267,6 @@ void SpinBox::_bind_methods() {
 
 	//ClassDB::bind_method(D_METHOD("_value_changed"),&SpinBox::_value_changed);
 	ClassDB::bind_method(D_METHOD("_gui_input"), &SpinBox::_gui_input);
-	ClassDB::bind_method(D_METHOD("_text_entered"), &SpinBox::_text_entered);
 	ClassDB::bind_method(D_METHOD("set_align", "align"), &SpinBox::set_align);
 	ClassDB::bind_method(D_METHOD("get_align"), &SpinBox::get_align);
 	ClassDB::bind_method(D_METHOD("set_suffix", "suffix"), &SpinBox::set_suffix);
@@ -277,10 +276,7 @@ void SpinBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_editable", "editable"), &SpinBox::set_editable);
 	ClassDB::bind_method(D_METHOD("is_editable"), &SpinBox::is_editable);
 	ClassDB::bind_method(D_METHOD("apply"), &SpinBox::apply);
-	ClassDB::bind_method(D_METHOD("_line_edit_focus_exit"), &SpinBox::_line_edit_focus_exit);
 	ClassDB::bind_method(D_METHOD("get_line_edit"), &SpinBox::get_line_edit);
-	ClassDB::bind_method(D_METHOD("_line_edit_input"), &SpinBox::_line_edit_input);
-	ClassDB::bind_method(D_METHOD("_range_click_timeout"), &SpinBox::_range_click_timeout);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "align", PROPERTY_HINT_ENUM, "Left,Center,Right,Fill"), "set_align", "get_align");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
@@ -297,12 +293,12 @@ SpinBox::SpinBox() {
 	line_edit->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	line_edit->set_mouse_filter(MOUSE_FILTER_PASS);
 	//connect("value_changed",this,"_value_changed");
-	line_edit->connect_compat("text_entered", this, "_text_entered", Vector<Variant>(), CONNECT_DEFERRED);
-	line_edit->connect_compat("focus_exited", this, "_line_edit_focus_exit", Vector<Variant>(), CONNECT_DEFERRED);
-	line_edit->connect_compat("gui_input", this, "_line_edit_input");
+	line_edit->connect("text_entered", callable_mp(this, &SpinBox::_text_entered), Vector<Variant>(), CONNECT_DEFERRED);
+	line_edit->connect("focus_exited", callable_mp(this, &SpinBox::_line_edit_focus_exit), Vector<Variant>(), CONNECT_DEFERRED);
+	line_edit->connect("gui_input", callable_mp(this, &SpinBox::_line_edit_input));
 	drag.enabled = false;
 
 	range_click_timer = memnew(Timer);
-	range_click_timer->connect_compat("timeout", this, "_range_click_timeout");
+	range_click_timer->connect("timeout", callable_mp(this, &SpinBox::_range_click_timeout));
 	add_child(range_click_timer);
 }

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -538,7 +538,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 
 	update();
 	p_child->connect("renamed", callable_mp(this, &TabContainer::_child_renamed_callback));
-	if (first)
+	if (first && is_inside_tree())
 		emit_signal("tab_changed", current);
 }
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -537,7 +537,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 	c->set_margin(Margin(MARGIN_BOTTOM), c->get_margin(Margin(MARGIN_BOTTOM)) - sb->get_margin(Margin(MARGIN_BOTTOM)));
 
 	update();
-	p_child->connect_compat("renamed", this, "_child_renamed_callback");
+	p_child->connect("renamed", callable_mp(this, &TabContainer::_child_renamed_callback));
 	if (first)
 		emit_signal("tab_changed", current);
 }
@@ -620,7 +620,7 @@ void TabContainer::remove_child_notify(Node *p_child) {
 
 	call_deferred("_update_current_tab");
 
-	p_child->disconnect_compat("renamed", this, "_child_renamed_callback");
+	p_child->disconnect("renamed", callable_mp(this, &TabContainer::_child_renamed_callback));
 
 	update();
 }
@@ -1011,9 +1011,7 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_hidden_tabs_for_min_size", "enabled"), &TabContainer::set_use_hidden_tabs_for_min_size);
 	ClassDB::bind_method(D_METHOD("get_use_hidden_tabs_for_min_size"), &TabContainer::get_use_hidden_tabs_for_min_size);
 
-	ClassDB::bind_method(D_METHOD("_child_renamed_callback"), &TabContainer::_child_renamed_callback);
 	ClassDB::bind_method(D_METHOD("_on_theme_changed"), &TabContainer::_on_theme_changed);
-	ClassDB::bind_method(D_METHOD("_on_mouse_exited"), &TabContainer::_on_mouse_exited);
 	ClassDB::bind_method(D_METHOD("_update_current_tab"), &TabContainer::_update_current_tab);
 
 	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab")));
@@ -1048,5 +1046,5 @@ TabContainer::TabContainer() {
 	tabs_rearrange_group = -1;
 	use_hidden_tabs_for_min_size = false;
 
-	connect_compat("mouse_exited", this, "_on_mouse_exited");
+	connect("mouse_exited", callable_mp(this, &TabContainer::_on_mouse_exited));
 }

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -956,7 +956,6 @@ void Tabs::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &Tabs::_gui_input);
 	ClassDB::bind_method(D_METHOD("_update_hover"), &Tabs::_update_hover);
-	ClassDB::bind_method(D_METHOD("_on_mouse_exited"), &Tabs::_on_mouse_exited);
 	ClassDB::bind_method(D_METHOD("get_tab_count"), &Tabs::get_tab_count);
 	ClassDB::bind_method(D_METHOD("set_current_tab", "tab_idx"), &Tabs::set_current_tab);
 	ClassDB::bind_method(D_METHOD("get_current_tab"), &Tabs::get_current_tab);
@@ -1034,5 +1033,5 @@ Tabs::Tabs() {
 	drag_to_rearrange_enabled = false;
 	tabs_rearrange_group = -1;
 
-	connect_compat("mouse_exited", this, "_on_mouse_exited");
+	connect("mouse_exited", callable_mp(this, &Tabs::_on_mouse_exited));
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7031,13 +7031,8 @@ PopupMenu *TextEdit::get_menu() const {
 void TextEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &TextEdit::_gui_input);
-	ClassDB::bind_method(D_METHOD("_scroll_moved"), &TextEdit::_scroll_moved);
 	ClassDB::bind_method(D_METHOD("_cursor_changed_emit"), &TextEdit::_cursor_changed_emit);
 	ClassDB::bind_method(D_METHOD("_text_changed_emit"), &TextEdit::_text_changed_emit);
-	ClassDB::bind_method(D_METHOD("_push_current_op"), &TextEdit::_push_current_op);
-	ClassDB::bind_method(D_METHOD("_click_selection_held"), &TextEdit::_click_selection_held);
-	ClassDB::bind_method(D_METHOD("_toggle_draw_caret"), &TextEdit::_toggle_draw_caret);
-	ClassDB::bind_method(D_METHOD("_v_scroll_input"), &TextEdit::_v_scroll_input);
 	ClassDB::bind_method(D_METHOD("_update_wrap_at"), &TextEdit::_update_wrap_at);
 
 	BIND_ENUM_CONSTANT(SEARCH_MATCH_CASE);
@@ -7157,7 +7152,6 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_keyword_color", "keyword"), &TextEdit::get_keyword_color);
 	ClassDB::bind_method(D_METHOD("add_color_region", "begin_key", "end_key", "color", "line_only"), &TextEdit::add_color_region, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("clear_colors"), &TextEdit::clear_colors);
-	ClassDB::bind_method(D_METHOD("menu_option", "option"), &TextEdit::menu_option);
 	ClassDB::bind_method(D_METHOD("get_menu"), &TextEdit::get_menu);
 
 	ClassDB::bind_method(D_METHOD("get_breakpoints"), &TextEdit::get_breakpoints_array);
@@ -7259,10 +7253,10 @@ TextEdit::TextEdit() {
 	updating_scrolls = false;
 	selection.active = false;
 
-	h_scroll->connect_compat("value_changed", this, "_scroll_moved");
-	v_scroll->connect_compat("value_changed", this, "_scroll_moved");
+	h_scroll->connect("value_changed", callable_mp(this, &TextEdit::_scroll_moved));
+	v_scroll->connect("value_changed", callable_mp(this, &TextEdit::_scroll_moved));
 
-	v_scroll->connect_compat("scrolling", this, "_v_scroll_input");
+	v_scroll->connect("scrolling", callable_mp(this, &TextEdit::_v_scroll_input));
 
 	cursor_changed_dirty = false;
 	text_changed_dirty = false;
@@ -7279,7 +7273,7 @@ TextEdit::TextEdit() {
 	caret_blink_timer = memnew(Timer);
 	add_child(caret_blink_timer);
 	caret_blink_timer->set_wait_time(0.65);
-	caret_blink_timer->connect_compat("timeout", this, "_toggle_draw_caret");
+	caret_blink_timer->connect("timeout", callable_mp(this, &TextEdit::_toggle_draw_caret));
 	cursor_set_blink_enabled(false);
 	right_click_moves_caret = true;
 
@@ -7287,12 +7281,12 @@ TextEdit::TextEdit() {
 	add_child(idle_detect);
 	idle_detect->set_one_shot(true);
 	idle_detect->set_wait_time(GLOBAL_GET("gui/timers/text_edit_idle_detect_sec"));
-	idle_detect->connect_compat("timeout", this, "_push_current_op");
+	idle_detect->connect("timeout", callable_mp(this, &TextEdit::_push_current_op));
 
 	click_select_held = memnew(Timer);
 	add_child(click_select_held);
 	click_select_held->set_wait_time(0.05);
-	click_select_held->connect_compat("timeout", this, "_click_selection_held");
+	click_select_held->connect("timeout", callable_mp(this, &TextEdit::_click_selection_held));
 
 	current_op.type = TextOperation::TYPE_NONE;
 	undo_enabled = true;
@@ -7350,7 +7344,7 @@ TextEdit::TextEdit() {
 	add_child(menu);
 	readonly = true; // Initialise to opposite first, so we get past the early-out in set_readonly.
 	set_readonly(false);
-	menu->connect_compat("id_pressed", this, "menu_option");
+	menu->connect("id_pressed", callable_mp(this, &TextEdit::menu_option));
 	first_draw = true;
 
 	executing_line = -1;

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -127,7 +127,6 @@ void TextureRect::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_flipped_v"), &TextureRect::is_flipped_v);
 	ClassDB::bind_method(D_METHOD("set_stretch_mode", "stretch_mode"), &TextureRect::set_stretch_mode);
 	ClassDB::bind_method(D_METHOD("get_stretch_mode"), &TextureRect::get_stretch_mode);
-	ClassDB::bind_method(D_METHOD("_texture_changed"), &TextureRect::_texture_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand"), "set_expand", "has_expand");
@@ -160,13 +159,13 @@ void TextureRect::set_texture(const Ref<Texture2D> &p_tex) {
 	}
 
 	if (texture.is_valid()) {
-		texture->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TextureRect::_texture_changed));
 	}
 
 	texture = p_tex;
 
 	if (texture.is_valid()) {
-		texture->connect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TextureRect::_texture_changed));
 	}
 
 	update();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3914,13 +3914,7 @@ bool Tree::get_allow_reselect() const {
 
 void Tree::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_range_click_timeout"), &Tree::_range_click_timeout);
 	ClassDB::bind_method(D_METHOD("_gui_input"), &Tree::_gui_input);
-	ClassDB::bind_method(D_METHOD("_popup_select"), &Tree::popup_select);
-	ClassDB::bind_method(D_METHOD("_text_editor_enter"), &Tree::text_editor_enter);
-	ClassDB::bind_method(D_METHOD("_text_editor_modal_close"), &Tree::_text_editor_modal_close);
-	ClassDB::bind_method(D_METHOD("_value_editor_changed"), &Tree::value_editor_changed);
-	ClassDB::bind_method(D_METHOD("_scroll_moved"), &Tree::_scroll_moved);
 
 	ClassDB::bind_method(D_METHOD("clear"), &Tree::clear);
 	ClassDB::bind_method(D_METHOD("create_item", "parent", "idx"), &Tree::_create_item, DEFVAL(Variant()), DEFVAL(-1));
@@ -4043,15 +4037,15 @@ Tree::Tree() {
 	add_child(v_scroll);
 
 	range_click_timer = memnew(Timer);
-	range_click_timer->connect_compat("timeout", this, "_range_click_timeout");
+	range_click_timer->connect("timeout", callable_mp(this, &Tree::_range_click_timeout));
 	add_child(range_click_timer);
 
-	h_scroll->connect_compat("value_changed", this, "_scroll_moved");
-	v_scroll->connect_compat("value_changed", this, "_scroll_moved");
-	text_editor->connect_compat("text_entered", this, "_text_editor_enter");
-	text_editor->connect_compat("modal_closed", this, "_text_editor_modal_close");
-	popup_menu->connect_compat("id_pressed", this, "_popup_select");
-	value_editor->connect_compat("value_changed", this, "_value_editor_changed");
+	h_scroll->connect("value_changed", callable_mp(this, &Tree::_scroll_moved));
+	v_scroll->connect("value_changed", callable_mp(this, &Tree::_scroll_moved));
+	text_editor->connect("text_entered", callable_mp(this, &Tree::text_editor_enter));
+	text_editor->connect("modal_closed", callable_mp(this, &Tree::_text_editor_modal_close));
+	popup_menu->connect("id_pressed", callable_mp(this, &Tree::popup_select));
+	value_editor->connect("value_changed", callable_mp(this, &Tree::value_editor_changed));
 
 	value_editor->set_as_toplevel(true);
 	text_editor->set_as_toplevel(true);

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -539,8 +539,6 @@ void HTTPRequest::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_download_chunk_size"), &HTTPRequest::set_download_chunk_size);
 	ClassDB::bind_method(D_METHOD("get_download_chunk_size"), &HTTPRequest::get_download_chunk_size);
 
-	ClassDB::bind_method(D_METHOD("_timeout"), &HTTPRequest::_timeout);
-
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "download_file", PROPERTY_HINT_FILE), "set_download_file", "get_download_file");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "download_chunk_size", PROPERTY_HINT_RANGE, "256,16777216"), "set_download_chunk_size", "get_download_chunk_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_threads"), "set_use_threads", "is_using_threads");
@@ -589,7 +587,7 @@ HTTPRequest::HTTPRequest() {
 
 	timer = memnew(Timer);
 	timer->set_one_shot(true);
-	timer->connect_compat("timeout", this, "_timeout");
+	timer->connect("timeout", callable_mp(this, &HTTPRequest::_timeout));
 	add_child(timer);
 	timeout = 0;
 }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -30,8 +30,6 @@
 
 #include "node.h"
 
-#include <stdint.h>
-
 #include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
 #include "core/message_queue.h"
@@ -45,6 +43,8 @@
 #ifdef TOOLS_ENABLED
 #include "editor/editor_settings.h"
 #endif
+
+#include <stdint.h>
 
 VARIANT_ENUM_CAST(Node::PauseMode);
 
@@ -2346,15 +2346,18 @@ void Node::_duplicate_signals(const Node *p_original, Node *p_copy) const {
 
 			Node *copytarget = target;
 
-			// Atempt to find a path to the duplicate target, if it seems it's not part
+			// Attempt to find a path to the duplicate target, if it seems it's not part
 			// of the duplicated and not yet parented hierarchy then at least try to connect
 			// to the same target as the original
 
 			if (p_copy->has_node(ptarget))
 				copytarget = p_copy->get_node(ptarget);
 
-			if (copy && copytarget && !copy->is_connected_compat(E->get().signal.get_name(), copytarget, E->get().callable.get_method())) {
-				copy->connect_compat(E->get().signal.get_name(), copytarget, E->get().callable.get_method(), E->get().binds, E->get().flags);
+			if (copy && copytarget) {
+				const Callable copy_callable = Callable(copytarget, E->get().callable.get_method());
+				if (!copy->is_connected(E->get().signal.get_name(), copy_callable)) {
+					copy->connect(E->get().signal.get_name(), copy_callable, E->get().binds, E->get().flags);
+				}
 			}
 		}
 	}
@@ -2509,10 +2512,10 @@ void Node::_replace_connections_target(Node *p_new_target) {
 		Connection &c = E->get();
 
 		if (c.flags & CONNECT_PERSIST) {
-			c.signal.get_object()->disconnect_compat(c.signal.get_name(), this, c.callable.get_method());
+			c.signal.get_object()->disconnect(c.signal.get_name(), Callable(this, c.callable.get_method()));
 			bool valid = p_new_target->has_method(c.callable.get_method()) || Ref<Script>(p_new_target->get_script()).is_null() || Ref<Script>(p_new_target->get_script())->has_method(c.callable.get_method());
 			ERR_CONTINUE_MSG(!valid, "Attempt to connect signal '" + c.signal.get_object()->get_class() + "." + c.signal.get_name() + "' to nonexistent method '" + c.callable.get_object()->get_class() + "." + c.callable.get_method() + "'.");
-			c.signal.get_object()->connect_compat(c.signal.get_name(), p_new_target, c.callable.get_method(), c.binds, c.flags);
+			c.signal.get_object()->connect(c.signal.get_name(), Callable(p_new_target, c.callable.get_method()), c.binds, c.flags);
 		}
 	}
 }

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -88,7 +88,7 @@ void SceneTreeTimer::release_connections() {
 
 	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
 		Connection const &connection = E->get();
-		disconnect_compat(connection.signal.get_name(), connection.callable.get_object(), connection.callable.get_method());
+		disconnect(connection.signal.get_name(), connection.callable);
 	}
 }
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1393,21 +1393,21 @@ void SceneTree::set_multiplayer(Ref<MultiplayerAPI> p_multiplayer) {
 	ERR_FAIL_COND(!p_multiplayer.is_valid());
 
 	if (multiplayer.is_valid()) {
-		multiplayer->disconnect_compat("network_peer_connected", this, "_network_peer_connected");
-		multiplayer->disconnect_compat("network_peer_disconnected", this, "_network_peer_disconnected");
-		multiplayer->disconnect_compat("connected_to_server", this, "_connected_to_server");
-		multiplayer->disconnect_compat("connection_failed", this, "_connection_failed");
-		multiplayer->disconnect_compat("server_disconnected", this, "_server_disconnected");
+		multiplayer->disconnect("network_peer_connected", callable_mp(this, &SceneTree::_network_peer_connected));
+		multiplayer->disconnect("network_peer_disconnected", callable_mp(this, &SceneTree::_network_peer_disconnected));
+		multiplayer->disconnect("connected_to_server", callable_mp(this, &SceneTree::_connected_to_server));
+		multiplayer->disconnect("connection_failed", callable_mp(this, &SceneTree::_connection_failed));
+		multiplayer->disconnect("server_disconnected", callable_mp(this, &SceneTree::_server_disconnected));
 	}
 
 	multiplayer = p_multiplayer;
 	multiplayer->set_root_node(root);
 
-	multiplayer->connect_compat("network_peer_connected", this, "_network_peer_connected");
-	multiplayer->connect_compat("network_peer_disconnected", this, "_network_peer_disconnected");
-	multiplayer->connect_compat("connected_to_server", this, "_connected_to_server");
-	multiplayer->connect_compat("connection_failed", this, "_connection_failed");
-	multiplayer->connect_compat("server_disconnected", this, "_server_disconnected");
+	multiplayer->connect("network_peer_connected", callable_mp(this, &SceneTree::_network_peer_connected));
+	multiplayer->connect("network_peer_disconnected", callable_mp(this, &SceneTree::_network_peer_disconnected));
+	multiplayer->connect("connected_to_server", callable_mp(this, &SceneTree::_connected_to_server));
+	multiplayer->connect("connection_failed", callable_mp(this, &SceneTree::_connection_failed));
+	multiplayer->connect("server_disconnected", callable_mp(this, &SceneTree::_server_disconnected));
 }
 
 void SceneTree::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_network_peer) {
@@ -1528,11 +1528,6 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rpc_sender_id"), &SceneTree::get_rpc_sender_id);
 	ClassDB::bind_method(D_METHOD("set_refuse_new_network_connections", "refuse"), &SceneTree::set_refuse_new_network_connections);
 	ClassDB::bind_method(D_METHOD("is_refusing_new_network_connections"), &SceneTree::is_refusing_new_network_connections);
-	ClassDB::bind_method(D_METHOD("_network_peer_connected"), &SceneTree::_network_peer_connected);
-	ClassDB::bind_method(D_METHOD("_network_peer_disconnected"), &SceneTree::_network_peer_disconnected);
-	ClassDB::bind_method(D_METHOD("_connected_to_server"), &SceneTree::_connected_to_server);
-	ClassDB::bind_method(D_METHOD("_connection_failed"), &SceneTree::_connection_failed);
-	ClassDB::bind_method(D_METHOD("_server_disconnected"), &SceneTree::_server_disconnected);
 
 	ClassDB::bind_method(D_METHOD("set_use_font_oversampling", "enable"), &SceneTree::set_use_font_oversampling);
 	ClassDB::bind_method(D_METHOD("is_using_font_oversampling"), &SceneTree::is_using_font_oversampling);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1124,7 +1124,7 @@ void Viewport::set_world(const Ref<World> &p_world) {
 		_propagate_exit_world(this);
 
 	if (own_world.is_valid() && world.is_valid()) {
-		world->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_own_world_changed");
+		world->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_changed));
 	}
 
 	world = p_world;
@@ -1132,7 +1132,7 @@ void Viewport::set_world(const Ref<World> &p_world) {
 	if (own_world.is_valid()) {
 		if (world.is_valid()) {
 			own_world = world->duplicate();
-			world->connect_compat(CoreStringNames::get_singleton()->changed, this, "_own_world_changed");
+			world->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_changed));
 		} else {
 			own_world = Ref<World>(memnew(World));
 		}
@@ -2473,7 +2473,7 @@ List<Control *>::Element *Viewport::_gui_add_root_control(Control *p_control) {
 
 List<Control *>::Element *Viewport::_gui_add_subwindow_control(Control *p_control) {
 
-	p_control->connect_compat("visibility_changed", this, "_subwindow_visibility_changed");
+	p_control->connect("visibility_changed", callable_mp(this, &Viewport::_subwindow_visibility_changed));
 
 	if (p_control->is_visible_in_tree()) {
 		gui.subwindow_order_dirty = true;
@@ -2568,7 +2568,7 @@ void Viewport::_gui_remove_subwindow_control(List<Control *>::Element *SI) {
 
 	Control *control = SI->get();
 
-	control->disconnect_compat("visibility_changed", this, "_subwindow_visibility_changed");
+	control->disconnect("visibility_changed", callable_mp(this, &Viewport::_subwindow_visibility_changed));
 
 	List<Control *>::Element *E = gui.subwindows.find(control);
 	if (E)
@@ -2850,12 +2850,12 @@ void Viewport::set_use_own_world(bool p_world) {
 	if (!p_world) {
 		own_world = Ref<World>();
 		if (world.is_valid()) {
-			world->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_own_world_changed");
+			world->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_changed));
 		}
 	} else {
 		if (world.is_valid()) {
 			own_world = world->duplicate();
-			world->connect_compat(CoreStringNames::get_singleton()->changed, this, "_own_world_changed");
+			world->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_changed));
 		} else {
 			own_world = Ref<World>(memnew(World));
 		}
@@ -3193,10 +3193,6 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_default_canvas_item_texture_repeat", "mode"), &Viewport::set_default_canvas_item_texture_repeat);
 	ClassDB::bind_method(D_METHOD("get_default_canvas_item_texture_repeat"), &Viewport::get_default_canvas_item_texture_repeat);
-
-	ClassDB::bind_method(D_METHOD("_subwindow_visibility_changed"), &Viewport::_subwindow_visibility_changed);
-
-	ClassDB::bind_method(D_METHOD("_own_world_changed"), &Viewport::_own_world_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "arvr"), "set_use_arvr", "use_arvr");
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -197,7 +197,7 @@ void ShaderMaterial::set_shader(const Ref<Shader> &p_shader) {
 	// This can be a slow operation, and `_change_notify()` (which is called by `_shader_changed()`)
 	// does nothing in non-editor builds anyway. See GH-34741 for details.
 	if (shader.is_valid() && Engine::get_singleton()->is_editor_hint()) {
-		shader->disconnect_compat("changed", this, "_shader_changed");
+		shader->disconnect("changed", callable_mp(this, &ShaderMaterial::_shader_changed));
 	}
 
 	shader = p_shader;
@@ -207,7 +207,7 @@ void ShaderMaterial::set_shader(const Ref<Shader> &p_shader) {
 		rid = shader->get_rid();
 
 		if (Engine::get_singleton()->is_editor_hint()) {
-			shader->connect_compat("changed", this, "_shader_changed");
+			shader->connect("changed", callable_mp(this, &ShaderMaterial::_shader_changed));
 		}
 	}
 
@@ -241,7 +241,6 @@ void ShaderMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_shader"), &ShaderMaterial::get_shader);
 	ClassDB::bind_method(D_METHOD("set_shader_param", "param", "value"), &ShaderMaterial::set_shader_param);
 	ClassDB::bind_method(D_METHOD("get_shader_param", "param"), &ShaderMaterial::get_shader_param);
-	ClassDB::bind_method(D_METHOD("_shader_changed"), &ShaderMaterial::_shader_changed);
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &ShaderMaterial::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &ShaderMaterial::property_get_revert);
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -331,7 +331,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 				binds.write[j] = props[c.binds[j]];
 		}
 
-		cfrom->connect_compat(snames[c.signal], cto, snames[c.method], binds, CONNECT_PERSIST | c.flags);
+		cfrom->connect(snames[c.signal], Callable(cto, snames[c.method]), binds, CONNECT_PERSIST | c.flags);
 	}
 
 	//Node *s = ret_nodes[0];

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1409,11 +1409,11 @@ void CurveTexture::ensure_default_setup(float p_min, float p_max) {
 void CurveTexture::set_curve(Ref<Curve> p_curve) {
 	if (_curve != p_curve) {
 		if (_curve.is_valid()) {
-			_curve->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_update");
+			_curve->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveTexture::_update));
 		}
 		_curve = p_curve;
 		if (_curve.is_valid()) {
-			_curve->connect_compat(CoreStringNames::get_singleton()->changed, this, "_update");
+			_curve->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveTexture::_update));
 		}
 		_update();
 	}
@@ -1514,11 +1514,11 @@ void GradientTexture::set_gradient(Ref<Gradient> p_gradient) {
 	if (p_gradient == gradient)
 		return;
 	if (gradient.is_valid()) {
-		gradient->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_update");
+		gradient->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &GradientTexture::_update));
 	}
 	gradient = p_gradient;
 	if (gradient.is_valid()) {
-		gradient->connect_compat(CoreStringNames::get_singleton()->changed, this, "_update");
+		gradient->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &GradientTexture::_update));
 	}
 	_update();
 	emit_changed();

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1843,8 +1843,6 @@ void AnimatedTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_frame_delay", "frame", "delay"), &AnimatedTexture::set_frame_delay);
 	ClassDB::bind_method(D_METHOD("get_frame_delay", "frame"), &AnimatedTexture::get_frame_delay);
 
-	ClassDB::bind_method(D_METHOD("_update_proxy"), &AnimatedTexture::_update_proxy);
-
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frames", PROPERTY_HINT_RANGE, "1," + itos(MAX_FRAMES), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_frames", "get_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "fps", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_fps", "get_fps");
 
@@ -1867,7 +1865,7 @@ AnimatedTexture::AnimatedTexture() {
 	fps = 4;
 	prev_ticks = 0;
 	current_frame = 0;
-	VisualServer::get_singleton()->connect_compat("frame_pre_draw", this, "_update_proxy");
+	VisualServer::get_singleton()->connect("frame_pre_draw", callable_mp(this, &AnimatedTexture::_update_proxy));
 
 #ifndef NO_THREADS
 	rw_lock = RWLock::create();

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -302,13 +302,13 @@ void Theme::set_default_theme_font(const Ref<Font> &p_default_font) {
 		return;
 
 	if (default_theme_font.is_valid()) {
-		default_theme_font->disconnect_compat("changed", this, "_emit_theme_changed");
+		default_theme_font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	default_theme_font = p_default_font;
 
 	if (default_theme_font.is_valid()) {
-		default_theme_font->connect_compat("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		default_theme_font->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_change_notify();
@@ -366,13 +366,13 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_type, const R
 	bool new_value = !icon_map.has(p_type) || !icon_map[p_type].has(p_name);
 
 	if (icon_map[p_type].has(p_name) && icon_map[p_type][p_name].is_valid()) {
-		icon_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		icon_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	icon_map[p_type][p_name] = p_icon;
 
 	if (p_icon.is_valid()) {
-		icon_map[p_type][p_name]->connect_compat("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		icon_map[p_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value) {
@@ -401,7 +401,7 @@ void Theme::clear_icon(const StringName &p_name, const StringName &p_type) {
 	ERR_FAIL_COND(!icon_map[p_type].has(p_name));
 
 	if (icon_map[p_type][p_name].is_valid()) {
-		icon_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		icon_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	icon_map[p_type].erase(p_name);
@@ -479,13 +479,13 @@ void Theme::set_stylebox(const StringName &p_name, const StringName &p_type, con
 	bool new_value = !style_map.has(p_type) || !style_map[p_type].has(p_name);
 
 	if (style_map[p_type].has(p_name) && style_map[p_type][p_name].is_valid()) {
-		style_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		style_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	style_map[p_type][p_name] = p_style;
 
 	if (p_style.is_valid()) {
-		style_map[p_type][p_name]->connect_compat("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		style_map[p_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value)
@@ -514,7 +514,7 @@ void Theme::clear_stylebox(const StringName &p_name, const StringName &p_type) {
 	ERR_FAIL_COND(!style_map[p_type].has(p_name));
 
 	if (style_map[p_type][p_name].is_valid()) {
-		style_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		style_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	style_map[p_type].erase(p_name);
@@ -554,13 +554,13 @@ void Theme::set_font(const StringName &p_name, const StringName &p_type, const R
 	bool new_value = !font_map.has(p_type) || !font_map[p_type].has(p_name);
 
 	if (font_map[p_type][p_name].is_valid()) {
-		font_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		font_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	font_map[p_type][p_name] = p_font;
 
 	if (p_font.is_valid()) {
-		font_map[p_type][p_name]->connect_compat("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		font_map[p_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value) {
@@ -589,7 +589,7 @@ void Theme::clear_font(const StringName &p_name, const StringName &p_type) {
 	ERR_FAIL_COND(!font_map[p_type].has(p_name));
 
 	if (font_map[p_type][p_name].is_valid()) {
-		font_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		font_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	font_map[p_type].erase(p_name);
@@ -722,7 +722,7 @@ void Theme::clear() {
 			while ((L = icon_map[*K].next(L))) {
 				Ref<Texture2D> icon = icon_map[*K][*L];
 				if (icon.is_valid()) {
-					icon->disconnect_compat("changed", this, "_emit_theme_changed");
+					icon->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 				}
 			}
 		}
@@ -735,7 +735,7 @@ void Theme::clear() {
 			while ((L = style_map[*K].next(L))) {
 				Ref<StyleBox> style = style_map[*K][*L];
 				if (style.is_valid()) {
-					style->disconnect_compat("changed", this, "_emit_theme_changed");
+					style->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 				}
 			}
 		}
@@ -748,7 +748,7 @@ void Theme::clear() {
 			while ((L = font_map[*K].next(L))) {
 				Ref<Font> font = font_map[*K][*L];
 				if (font.is_valid()) {
-					font->disconnect_compat("changed", this, "_emit_theme_changed");
+					font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 				}
 			}
 		}
@@ -905,8 +905,6 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_default_font"), &Theme::get_default_theme_font);
 
 	ClassDB::bind_method(D_METHOD("get_type_list", "type"), &Theme::_get_type_list);
-
-	ClassDB::bind_method(D_METHOD("_emit_theme_changed"), &Theme::_emit_theme_changed);
 
 	ClassDB::bind_method("copy_default_theme", &Theme::copy_default_theme);
 	ClassDB::bind_method(D_METHOD("copy_theme", "other"), &Theme::copy_theme);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -304,10 +304,10 @@ void VisualShader::add_node(Type p_type, const Ref<VisualShaderNode> &p_node, co
 	if (input.is_valid()) {
 		input->shader_mode = shader_mode;
 		input->shader_type = p_type;
-		input->connect_compat("input_type_changed", this, "_input_type_changed", varray(p_type, p_id));
+		input->connect("input_type_changed", callable_mp(this, &VisualShader::_input_type_changed), varray(p_type, p_id));
 	}
 
-	n.node->connect_compat("changed", this, "_queue_update");
+	n.node->connect("changed", callable_mp(this, &VisualShader::_queue_update));
 
 	Ref<VisualShaderNodeCustom> custom = n.node;
 	if (custom.is_valid()) {
@@ -374,10 +374,10 @@ void VisualShader::remove_node(Type p_type, int p_id) {
 
 	Ref<VisualShaderNodeInput> input = g->nodes[p_id].node;
 	if (input.is_valid()) {
-		input->disconnect_compat("input_type_changed", this, "_input_type_changed");
+		input->disconnect("input_type_changed", callable_mp(this, &VisualShader::_input_type_changed));
 	}
 
-	g->nodes[p_id].node->disconnect_compat("changed", this, "_queue_update");
+	g->nodes[p_id].node->disconnect("changed", callable_mp(this, &VisualShader::_queue_update));
 
 	g->nodes.erase(p_id);
 
@@ -1414,10 +1414,7 @@ void VisualShader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_graph_offset", "offset"), &VisualShader::set_graph_offset);
 	ClassDB::bind_method(D_METHOD("get_graph_offset"), &VisualShader::get_graph_offset);
 
-	ClassDB::bind_method(D_METHOD("_queue_update"), &VisualShader::_queue_update);
 	ClassDB::bind_method(D_METHOD("_update_shader"), &VisualShader::_update_shader);
-
-	ClassDB::bind_method(D_METHOD("_input_type_changed"), &VisualShader::_input_type_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "graph_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_graph_offset", "get_graph_offset");
 

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -119,12 +119,6 @@ SceneStringNames::SceneStringNames() {
 	camera_entered = StaticCString::create("camera_entered");
 	camera_exited = StaticCString::create("camera_exited");
 
-	_body_enter_tree = StaticCString::create("_body_enter_tree");
-	_body_exit_tree = StaticCString::create("_body_exit_tree");
-
-	_area_enter_tree = StaticCString::create("_area_enter_tree");
-	_area_exit_tree = StaticCString::create("_area_exit_tree");
-
 	_input = StaticCString::create("_input");
 	_input_event = StaticCString::create("_input_event");
 
@@ -167,8 +161,8 @@ SceneStringNames::SceneStringNames() {
 	drop_data = StaticCString::create("drop_data");
 	can_drop_data = StaticCString::create("can_drop_data");
 
-	_im_update = StaticCString::create("_im_update");
-	_queue_update = StaticCString::create("_queue_update");
+	_im_update = StaticCString::create("_im_update"); // Sprite3D
+	_queue_update = StaticCString::create("_queue_update"); // Sprite3D
 
 	baked_light_changed = StaticCString::create("baked_light_changed");
 	_baked_light_changed = StaticCString::create("_baked_light_changed");
@@ -199,8 +193,6 @@ SceneStringNames::SceneStringNames() {
 
 		mesh_materials[i] = "material/" + itos(i);
 	}
-
-	_mesh_changed = StaticCString::create("_mesh_changed");
 
 	parameters_base_path = "parameters/";
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -33,6 +33,7 @@
 
 #include "core/node_path.h"
 #include "core/string_name.h"
+
 class SceneStringNames {
 
 	friend void register_scene_types();
@@ -147,12 +148,6 @@ public:
 	StringName camera_entered;
 	StringName camera_exited;
 
-	StringName _body_enter_tree;
-	StringName _body_exit_tree;
-
-	StringName _area_enter_tree;
-	StringName _area_exit_tree;
-
 	StringName changed;
 	StringName _shader_changed;
 
@@ -211,7 +206,6 @@ public:
 		MAX_MATERIALS = 32
 	};
 	StringName mesh_materials[MAX_MATERIALS];
-	StringName _mesh_changed;
 };
 
 #endif // SCENE_STRING_NAMES_H


### PR DESCRIPTION
I repaired some connections most noticeable are

- Right-click PopMenu from SceneTreeDock has no effect when you press an action
- When we add an action on **Project Settings > Input Map**, this print an error saying "_settings_changed" are not a register method.

**Known bug:**

When you create an Animation on the AnimationPlayer, the emit signal "idle_frame" is printing 'CALL_ERROR_TOO_FEW_ARGUMENTS' (with DEBUG_METHODS_ENABLED)

This is because his slot has 6 arguments (1 from p_method + 5 from VARIANT_ARG_LIST). 
```
void call_deferred(const StringName &p_method, VARIANT_ARG_LIST);
```

And our connect has only one bind variable (from AnimationPlayerEditor::_start_onion_skinning())
```
get_tree()->connect("idle_frame", callable_mp((Object *)this, &Object::call_deferred), varray("_prepare_onion_layers_1"));
```

The easy solution is creating a list of 6 Variant with varray (or make_binds) with null data. But I don't think so.

I spend 90% of my time reading code haha. I'll be faster.